### PR TITLE
Fix typos in Numerical Optimization chapter

### DIFF
--- a/22-Optimization.Rmd
+++ b/22-Optimization.Rmd
@@ -508,8 +508,8 @@ A *descent direction* in $\theta$ is a vector $\rho \in
 \mathbb{R}^p$ such that $$\nabla H(\theta)^T \rho < 0.$$
 :::
 
-When $\theta$ is not a stationary point,  
-$$\nabla H(\theta)^T -\nabla H(\theta)$ = - \| \nabla H(\theta)^T \|_2 < 0$$
+When $\theta$ is not a stationary point,
+$$\nabla H(\theta)^T(-\nabla H(\theta)) = - \| \nabla H(\theta)^T \|^2 < 0$$
 and $-\nabla H(\theta)^T$ is a descent direction in $\theta$ according to 
 the definition.
 

--- a/22-Optimization.Rmd
+++ b/22-Optimization.Rmd
@@ -122,7 +122,7 @@ Indeed, theory rarely provides us with sharp quantitative results on
 the rate of convergence and we will need computational techniques to monitor and measure convergence of algorithms in practice. Otherwise we cannot compare 
 the efficiency of different algorithms. 
 
-### Gradient descent 
+### Gradient descent {#grad-descent-convergence}
 
 We will assume in this section that $\Theta = \mathbb{R}^p$. This will 
 simplify the analysis a bit, but with minor modifications it can 
@@ -529,7 +529,7 @@ would give the maximal possible descent in the direction $\rho_n$,
 and as we have argued, if $\rho_n$ is a descent direction, a minimizer $\gamma > 0$
 guarantees descent of $H$. However, unless the minimization can be 
 done analytically it is often computationally too expensive. 
-Less will also do, and as shown in Example \@ref(exm:grad-descent),
+Less will also do, and as shown in Section \@ref(grad-descent-convergence),
 if the Hessian has uniformly bounded numerical radius it is possible to 
 fix one (sufficiently small) step length that will guarantee descent. 
 

--- a/22-Optimization.Rmd
+++ b/22-Optimization.Rmd
@@ -503,10 +503,10 @@ away from $\theta$ in the direction of $-\nabla H(\theta)$.
 However, other directions than the negative gradient can also be suitable
 descent directions.
 
-::: {.definition} A *descent direction* in $\theta$ 
-is a vector $\rho \in \mathbb{R}^p$ such that 
-$$\nabla H(\theta)^T \rho < 0.$$
-::: 
+::: {.definition}
+A *descent direction* in $\theta$ is a vector $\rho \in
+\mathbb{R}^p$ such that $$\nabla H(\theta)^T \rho < 0.$$
+:::
 
 When $\theta$ is not a stationary point,  
 $$\nabla H(\theta)^T -\nabla H(\theta)$ = - \| \nabla H(\theta)^T \|_2 < 0$$


### PR DESCRIPTION
These commits fix some typos, formatting, and reference errors in chapter 7. I have not knitted the book, so you should check that it looks okay.