### PR TITLE
Fix get(simplify = TRUE) for traced column vectors

### DIFF
--- a/CSwR_package/R/tracer.R
+++ b/CSwR_package/R/tracer.R
@@ -101,6 +101,8 @@ tracer <- function(
   get <- function(simplify = FALSE) {
     if (simplify) {
       col_names <- unique(unlist(lapply(values_save, names)))
+      values_save <- lapply(values_save,
+                            function(entry) lapply(entry, col_to_row))
       values_save <- lapply(
         col_names,
         function(x) {
@@ -140,7 +142,15 @@ tracer <- function(
   structure(list(tracer = tracer, get = get, clear = clear), class = "tracer")
 }
 
-
+# If x is a matrix object which encodes a column vector, then the transpose of x
+# is returned. Otherwise, x is returned.
+col_to_row <- function(x) {
+    if (inherits(x, "matrix") && nrow(x) > 1 && ncol(x) == 1) {
+        t(x)
+    } else {
+        x
+    }
+}
 
 #' Subsetting tracer objects
 #'


### PR DESCRIPTION
If the traced object is a a matrix with one column, then `get` with `simplify = TRUE`
(and hence also the `summary` method for tracer objects) returns the cryptic error message

> Error in (function (..., deparse.level = 1)  : 
>   number of rows of matrices must match (see arg 2)

For instance, the result of a computation `A %*% b` is a matrix object with one column.
The error may confuse users since it is unclear that they have to manually
call `as.vector(A %*% b)` or `t(A %*% b)` in their own code before tracing the
object to fix the error. The included patch fixes this error directly in the
`get` function, such that the user can trace column vectors without manually
converting them to row vectors.

I have patched the `get` function to first transpose all traced matrix objects
with 1 column (see the `col_to_row` function). It only changes traced objects
which inherits from the "matrix" class, has exactly 1 column and strictly more
than 1 row, so it hopefully fixes the problem without introducing any problems.

# Reproducible example

```{r}
library(CSwR)

## Column vector
column_tracer <- tracer("col_vec")
for (i in 1:5) {
    col_vec <- matrix(i * (1:10), ncol = 1)
    column_tracer$tracer()
}
## get with simplify = TRUE gives cryptic error
column_tracer$get(simplify = TRUE)
## Hence, summary gives the same error
summary(column_tracer)

## Row vectors don't give problems
row_tracer <- tracer("row_vec")
for (i in 1:5) {
    row_vec <- matrix(i * (1:10), nrow = 1)
    row_tracer$tracer()
}
## Both get and summary work as intended
row_tracer$get(simplify = TRUE)
summary(row_tracer)
```
