### PR TITLE
Fix typo in multinomial log-likelihood formula

### DIFF
--- a/21-Examples.Rmd
+++ b/21-Examples.Rmd
@@ -409,9 +409,9 @@ $$p_C^2, 2p_Cp_I, 2p_Cp_T, p_I^2,  2p_Ip_T, p_T^2.$$
 If we could observe the genotypes, the complete multinomial log-likelihood would be 
 
 \begin{align*}
- & 2n_{CC} \log(p_C) + n_{CI} \log (2 p_C p_I) + n_{CT} \log(2 p_C p_I) \\
+ & 2n_{CC} \log(p_C) + n_{CI} \log (2 p_C p_I) + n_{CT} \log(2 p_C p_T) \\
 & \ \ + 2 n_{II} \log(p_I) + n_{IT} \log(2p_I p_T) + 2 n_{TT} \log(p_T) \\
-& = 2n_{CC} \log(p_C) + n_{CI} \log (2 p_C p_I) + n_{CT} \log(2 p_C p_I) \\
+& = 2n_{CC} \log(p_C) + n_{CI} \log (2 p_C p_I) + n_{CT} \log(2 p_C p_T) \\
 & \ \ + 2 n_{II} \log(p_I) + n_{IT} \log(2p_I (1 - p_C - p_I)) + 2 n_{TT} \log(1 - p_C - p_I). 
 \end{align*}
 


### PR DESCRIPTION
n_{CT} \log(2 p_C p_I) should instead be n_{CT} \log(2 p_C p_T); p_I -> p_T