### PR TITLE
fix(deps): upgrade R dependency to fix warning

### DIFF
--- a/CSwR_package/DESCRIPTION
+++ b/CSwR_package/DESCRIPTION
@@ -5,7 +5,7 @@ Version: 0.1.2
 Authors@R: person("Niels Richard", "Hansen", email = "Niels.R.Hansen@math.ku.dk",
                   role = c("aut", "cre"))
 Depends:
-    R (>= 3.1)
+    R (>= 3.5.0)
 Imports:
     bench,
     ggplot2,


### PR DESCRIPTION
I was getting this warning when installing the CSwR package:

```
* checking for empty or unneeded directories
  NB: this package now depends on R (>= 3.5.0)
  WARNING: Added dependency on R >= 3.5.0 because serialize
  serialize/load version 3 cannot be read in older versions
  File(s) containing such objects:
    ‘CSwR/data/angle.RData’ ‘CSwR/data/greenland.RData’
    ‘CSwR/data/news.RData’ ‘CSwR/data/nuuk.RData’
    ‘CSwR/data/vegetables.RData’
```

This PR bumps the version requirement accordingly.