### PR TITLE
fix(renv): update source for CSwR in lockfile

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -26,14 +26,21 @@
     "CSwR": {
       "Package": "CSwR",
       "Version": "0.1.2",
-      "Source": "unknown",
+      "Source": "GitHub",
+      "RemoteType": "github",
+      "RemoteHost": "api.github.com",
+      "RemoteRepo": "CSwR",
+      "RemoteUsername": "nielsrhansen",
+      "RemoteRef": "HEAD",
+      "RemoteSha": "5ec6f7c1774bcbe67eb78323fec41e115b436705",
+      "RemoteSubdir": "CSwR_package",
       "Requirements": [
         "R",
         "bench",
         "ggplot2",
         "rlang"
       ],
-      "Hash": "919622a551a9b9bace0964cc47e8fde3"
+      "Hash": "c4619ea236187d86105493ff1fefbb2f"
     },
     "DBI": {
       "Package": "DBI",


### PR DESCRIPTION
I had trouble restoring the renv environment because the source for CSwR is unknown. This pins it to the github repo. 