### PR TITLE
fix: fix cross-reference to figure

### DIFF
--- a/05-Density.Rmd
+++ b/05-Density.Rmd
@@ -181,7 +181,7 @@ The rectangular kernel makes a sharp cut at $x \pm h$; either a data point count
 does not. Other (smoother) kernels more gradually downweight points further 
 away from $x$.
 
-Figure \@ref{fig:psiDens} illustrates how the choice of bandwidth and kernel
+Figure \@ref(fig:psiDens) illustrates how the choice of bandwidth and kernel
 affects the resulting kernel density estimate. The choice of kernel has
 relatively minor effects in practice, and we will in this chapter mostly use the
 Gaussian kernel, but see Exercise \@ref(exr:epanechnikov) for an alternative. The


### PR DESCRIPTION
The syntax for the cross-reference is incorrect.