### PR TITLE
Rewrite the optimization part

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ devenv.local.yaml
 
 # pre-commit
 .pre-commit-config.yaml
+CSwR.tex

--- a/05-Density.Rmd
+++ b/05-Density.Rmd
@@ -446,7 +446,7 @@ time. In this section we focus on benchmarking runtime and memory usage.
 
 Base R provides a simple way of measuring runtime via the function `system.time()`.
 Throughout this book we will use the tools from the bench package to benchmark 
-code, see also Appendix \@ref(performance). It includes the `bench_time()` 
+code, see also Appendix \@ref(measuring-performance). It includes the `bench_time()`
 function as an alternative to `system.time()` for measuring 
 the time it takes to evaluate a single expression. 
 
@@ -480,7 +480,7 @@ From this simple benchmark, `kern_dens_loop()` is clearly substantially slower
 than the three other implementations. For more systematic benchmarking of 
 runtime we use the `mark()` function from the bench package, which evaluates 
 expressions repeatedly to give a more complete picture of the distribution 
-of runtime and memory usage, see also Appendix \@ref(performance).
+of runtime and memory usage, see also Appendix \@ref(measuring-performance).
 
 ```{r kern-bench, echo=2, dependson=c( "kern-dens", "kern-dens-vec", "kern-dens-apply", "kern-dens-outer")}
 set.seed(2345)

--- a/13-Rejection.Rmd
+++ b/13-Rejection.Rmd
@@ -428,7 +428,7 @@ bench::system_time(von_mises_loop(100000, kappa = 5))
 Though the implementation can easily simulate 100,000 variables in less than one
 second, it might still be possible to improve it. To investigate what most of
 the runtime is spent on we use the line profiling tool as implemented in the
-profvis package, see also Section \@ref(profiling).
+profvis package, see also Section \@ref(tracing).
 
 ```{r, echo=4}
 #| label: profvis-vMsim
@@ -509,7 +509,7 @@ proposals and otherwise 20% more than estimated. The implementation contains a
 few additional bells and whistles. First, the ellipses argument, `...`, is used,
 which captures all arguments to a function and in this case passes them on via
 the call `rng(M, ...)`. Second, for the sake of subsequent usages in Section
-\@ref(von-mises-distribution). we include the callback argument `cb`, see also
+\@ref(vM). we include the callback argument `cb`, see also
 Section \@ref(tracing).
 
 ```{r, dependson="vM-rejection-vec-random"}

--- a/21-Examples.Rmd
+++ b/21-Examples.Rmd
@@ -1,422 +1,1670 @@
 ---
 output: html_document
-editor_options: 
+editor_options:
   chunk_output_type: console
 ---
 
-# Likelihood and optimization
+# Optimization and statistical estimation
 
-This chapter introduces likelihood functions for parametrized statistical models
-and treats in some detail a collection of examples. For all parametric models, a
-central computational challenge is to fit the models to data via (penalized)
-likelihood maximization. Details about actual optimization algorithms and
-implementations are the topics of Chapters \@ref(numopt), \@ref(em) and
-\@ref(stochopt). The focus of this chapter is on the structure of the
-statistical models themselves to provide the necessary background for the later
-chapters.
+Many of the computational problems addressed in this book can be framed as an
+*optimization problem*: given a function $H$, find the parameter $\theta$ that
+minimizes (or maximizes) it. The function might be the negative log-likelihood
+of a parametric statistical model, the residual sum of squares of a regression
+fit, the empirical risk of a classifier, or something more exotic. The parameter
+might be a single number or a vector with thousands of entries. The structure of
+the function, whether it is smooth, whether it is convex, and whether the input
+is constrained, determines both how hard the problem is and which algorithm we
+should reach for.
 
-Statistical models come in many varieties. Mathematically, a statistical model
-is defined as a parametrized family of probability distributions. To say
-anything of interest, though, we need more structure on the model, such as
-structure on the parameter space, properties of the parametrized distributions,
-and properties of the mapping from the parameter space to the distributions. 
-Any specific model will have a lot of structure but often also an overwhelming
-amount of irrelevant details that will be more distracting than clarifying. The
-intention with this chapter, and the examples treated, is to illustrate
-how some quite different statistical models share important structures, 
-while we avoid getting lost in abstractions.
+This chapter develops the fundamentals of optimization. We introduce a *standard
+form* that makes it easier to classify and reason about optimization problems;
+define convexity and optimality conditions; develop the smoothness vocabulary we
+need to talk about algorithm convergence; and end with constraints. We use
+statistical estimation, primarily maximum likelihood, as running examples.
+Chapter\ \@ref(numopt) introduces the algorithms that solve the problems we set
+up here. Chapter\ \@ref(em) covers the EM algorithm for likelihood maximization
+with incomplete data, and Chapter\ \@ref(stochopt) covers stochastic
+optimization for the settings where the number of observations is too large to
+process them all at once.
 
-In the first section we introduce the key idea of a parametrized 
-statistical model and give some simple examples. We give the definition
-of the (log-)likelihood function and touch on the phenomenon that 
-computationally important properties of the log-likelihood function 
-may depend on the chosen parametrization. In the subsequent sections 
-we cover multinomial models, regression models, mixture models and random 
-effects models as four main examples.
+## What is an optimization problem? {#opt-problem}
 
-## Parametrized models and the likelihood
-
-In all our examples we will consider a parameter space $\Theta \subseteq \mathbb{R}^p$
-and a parametrized family of probability distributions on a common sample space 
-denoted $\mathcal{Y}$. The 
-distribution corresponding to $\theta \in \Theta$ is assumed to have a 
-density $f_{\theta}$ (w.r.t. a $\theta$-independent reference measure).
-
-In many applications, the sample space is a product space
+An optimization problem in *standard form* is
 
 \[
-  \mathcal{Y} = \mathcal{Y}_1 \times \ldots \times \mathcal{Y}_N
+\begin{aligned}
+& \operatorname*{minimize}_{\theta \in \mathbb{R}^p} && H(\theta) \\
+& \text{subject to} && g_i(\theta) \leq 0, \quad i = 1, \ldots, r, \\
+& && h_j(\theta) = 0, \quad j = 1, \ldots, s.
+\end{aligned}
 \]
 
-corresponding to observations $y_1 \in \mathcal{Y}_1, \ldots, y_N \in \mathcal{Y}_N$.
-We will in this case be  interested in modeling the observations 
-as independent but not necessarily identically distributed. Thus the joint 
-density is a product 
+The function $H : \mathbb{R}^p \to \mathbb{R}$ is the *objective function*.
+$g_i$ and $h_j$ define the $r$ inequality and $s$ equality constraints,
+respectively. We say that a point $\theta \in \mathbb{R}^p$ is *feasible* if it
+satisfies all of the constraints, and the set of feasible points is the
+*feasible set* $C$. The *optimal value* of the problem is
 
 \[
-  f_{\theta}(y_1, \ldots, y_N) = \prod_{i=1}^N f_{i,\theta}(y_i). \
+H^\star = \inf \{ H(\theta) : \theta \in C \},
 \]
 
-Note that the density, $f_{i,\theta}$, is a density for a probability 
-distribution on $\mathcal{Y}_i$, and that all these densities are parametrized 
-by the same parameter $\theta \in \Theta$, but due to the $i$-index they 
-may differ. If all the densities are equal, data is modeled as 
-independent *and* identically distributed (i.i.d.).
+and any feasible point that achieves this value is an *optimal point* or
+*minimizer*, which we denote by \index{argmin}
 
-The likelihood function is, for fixed data $y = (y_1, \ldots, y_N)$, the function 
-\index{likelihood function}
+\[
+\theta^\star \in \argmin_{\theta \in C} H(\theta),
+\]
+
+with the understanding that $\argmin$ is in general a *set*---there may be no
+minimizer, exactly one, or infinitely many, even when the optimal value
+$H^\star$ is uniquely defined. We write $\theta^\star$ for the abstract
+minimizer and reserve $\hat{\theta}$ for *estimators*, in keeping with
+statistical convention. The two refer to the same object whenever the
+optimization problem is parameter estimation, and we use whichever fits the
+context at hand.
+
+Maximization fits into the same framework, since maximizing $H$ is equivalent to
+minimizing $-H$, but we will typically prefer to phrase everything in terms of
+minimization to keep notation consistent with the optimization literature. When
+$r = s = 0$ the problem is *unconstrained*, which is the setting for most of
+this chapter as well as the algorithms of Chapter\ \@ref(numopt). We return to
+constraints in Section\ \@ref(constraints).
+
+Throughout the text, we will keep two running threads. The first is *maximum
+likelihood estimation*\ (MLE): given a parametric statistical model with density
+$f_\theta$ and observations $y_1, \ldots, y_N$, find the parameter
+$\hat{\theta}$ that makes the data most probable. We will see in the next
+section that this is the optimization problem
+
+\[
+\operatorname*{minimize}_{\theta \in \Theta} \left(-\ell(\theta) = -\sum_{i=1}^{N} \log f_\theta(y_i) \right).
+\]
+
+The second is *ordinary least squares*\ (OLS): given a response vector
+$\mathbf{y} \in \mathbb{R}^N$ and a model matrix
+$\mathbf{X} \in \mathbb{R}^{N \times p}$, find the coefficient vector $\beta$
+that minimizes the residual sum of squares,
+
+\[
+\operatorname*{minimize}_{\beta \in \mathbb{R}^p} \frac{1}{2}\; \|\mathbf{y} - \mathbf{X} \beta\|_2^2.
+\]
+
+OLS turns out to be a maximum-likelihood problem in disguise. It is the MLE for
+$\beta$ when $\mathbf{y}$ is Gaussian with mean $\mathbf{X} \beta$. But it is
+useful to hold the two examples apart: OLS features a simple quadratic objective
+whose landscape we can visualize and whose properties (convex, smooth, and
+unconstrained when $p < N$ and $\mathbf{X}$ has full column rank) make it easy
+and forgiving to work with. Maximum likelihood is the umbrella framework that
+encompasses a large group of statistical estimation problems, and the properties
+of the negative log-likelihood can vary widely across models and
+parametrizations. The Poisson and von Mises examples of the next section
+illustrate this variety.
+
+## Statistical estimation as optimization {#mle-as-opt}
+
+We consider a parametrized family of probability distributions on a sample space
+$\mathcal{Y}$, with the distribution corresponding to
+$\theta \in \Theta \subseteq \mathbb{R}^p$ having density $f_\theta$ with
+respect to a $\theta$-independent reference measure. In most applications the
+sample space is a product space
+
+\[
+\mathcal{Y} = \mathcal{Y}_1 \times \ldots \times \mathcal{Y}_N
+\]
+
+corresponding to observations $y_1, \ldots, y_N$ that we model as independent.
+The joint density then factors into
+
+\[
+f_\theta(y_1, \ldots, y_N) = \prod_{i=1}^N f_{i,\theta}(y_i),
+\]
+
+although the individual densities $f_{i,\theta}$ may differ, for instance when
+each observation has its own predictor in a regression model. When all of the
+marginals are equal the observations are independent and identically
+distributed.
+
+The *likelihood function* for fixed data $y = (y_1, \ldots, y_N)$ is the joint
+density formulated as a function of the parameter, \index{likelihood function}
 
 \[
 \mathcal{L}(\theta) = \prod_{i=1}^N f_{i,\theta}(y_i),
 \]
 
-as a function of the parameter $\theta$. The log-likelihood function is 
-\index{log-likelihood function}
+and the *log-likelihood* is its logarithm, \index{log-likelihood function}
 
 \[
-\ell(\theta) = \log (\mathcal{L}(\theta)) = \sum_{i=1}^N \log(f_{i,\theta}(y_i)),
+\ell(\theta) = \log \mathcal{L}(\theta) = \sum_{i=1}^N \log f_{i,\theta}(y_i).
 \]
 
-and the negative log-likelihood function is $-\ell$. In practice, we will 
-minimize the negative log-likelihood function over 
-the parameter space to find the model within the parametrized 
-family of distributions that best fits the data. The resulting parameter 
-estimate is known as the maximum-likelihood estimate. \index{maximum-likelihood!estimate}
-
-
-::: {.example .boxed #poisson-exponential}
-Poisson distributions with sample space $\mathcal{Y} = \mathbb{N}_0 = \{0, 1, 2, \ldots \}$ 
-are used to model non-negative integer counts. The Poisson distributions
-are parametrized by the mean parameter $\mu > 0$, and the density is given 
-by the point probabilities 
+The *maximum-likelihood estimate* is any $\hat{\theta}$ that maximizes
+$\mathcal{L}$ over $\Theta$. Equivalently, $\hat{\theta}$ minimizes the
+*negative log-likelihood* $-\ell$: \index{maximum-likelihood!estimate}
 
 \[
-f_{\mu}(y)= e^{-\mu} \frac{\mu^y}{y!}.
+\hat{\theta} \in \argmin_{\theta \in \Theta} \, -\ell(\theta).
 \]
 
-The parameter space is thus $\Theta = (0, \infty)$. 
+The jump from $\mathcal{L}$ to $-\ell$ is a matter of convenience that does not
+change the optimum, but it has three practical benefits. First, the logarithm
+turns the product into a sum, which avoids the floating-point overflow and
+underflow that would plague the product for large $N$. Second, the sum form
+differentiates more cleanly than the product, since the derivative of a sum is
+the sum of derivatives. Third, many densities of interest have a $\log f_\theta$
+that is simpler than $f_\theta$ itself; the Poisson and Gaussian densities are
+canonical examples, and we will encounter additional such. The choice to
+*minimize* $-\ell$ rather than maximize $\ell$ aligns maximum-likelihood
+estimation with the standard form of Section\ \@ref(opt-problem), and with the
+optimization literature more broadly.
 
-With i.i.d. observations $y_1, \ldots, y_N$ the negative log-likelihood is 
-given by 
+For most of this chapter and the next, we will use negative log-likelihoods as
+running examples of optimization. The two cases that follow illustrate the range
+of difficulty an MLE problem can present. The first has a closed-form solution
+and serves as a sanity check that we can recover a familiar estimator. The
+second has no closed-form solution and motivates the algorithms we will
+introduce in Chapter \@ref(numopt).
+
+::: {.example .boxed #poisson-mle}
+The Poisson distributions are used to model non-negative integer counts and have
+sample space $\mathcal{Y} = \mathbb{N}_0 = \{0, 1, 2, \ldots\}$. They are
+parametrized by the mean parameter $\mu > 0$, with density (with respect to
+counting measure)
 
 \[
-- \ell(\mu) = \sum_{i=1}^N \left( \mu - y_i \log(\mu) + \log(y!) \right) = 
-  N \mu - \log(\mu) \sum_{i=1}^N y_i + N \log(y!).
+f_\mu(y) = e^{-\mu} \frac{\mu^y}{y!}.
 \]
 
-For this model we can find an analytic expression for the maximum-likelihood 
-estimate. By differentiating twice we see that 
-
-\begin{align*}
-- \ell'(\mu) & =  N - \frac{1}{\mu} \sum_{i=1}^N y_i \\
-- \ell''(\mu) & = \frac{1}{\mu^2} \sum_{i=1}^N y_i \geq 0
-\end{align*}
-
-Since the second derivative is non-negative, the negative log-likelihood is 
-convex, and a solution to $- \ell'(\mu) = 0$ will be a global minimizer. We 
-see that if $\sum_{i=1}^N y_i > 0$, the unique solution to this equation is 
+The parameter space is $\Theta = (0, \infty)$. With i.i.d. observations
+$y_1, \ldots, y_N$ the negative log-likelihood is
 
 \[
- \hat{\mu} =\frac{1}{N} \sum_{i=1}^N y_i,
+-\ell(\mu) = \sum_{i=1}^N \left( \mu - y_i \log \mu + \log(y_i!) \right) =
+  N \mu - \log(\mu) \sum_{i=1}^N y_i + \sum_{i=1}^N \log(y_i!).
 \]
 
-and this is thus the maximum-likelihood estimate. 
+The final term does not depend on $\mu$ and therefore plays no role in the
+minimization. Differentiating with respect to $\mu$ and setting the result to
+zero gives
 
-If $\sum_{i=1}^N y_i = 0$ (which is equivalent to $y_1 = y_2 = \ldots = y_N = 0$)
-there is no minimizer in the open parameter space $(0, \infty)$. We could argue 
-that by extending the parameter space to include $0$, then $\hat{\mu} = 0$ 
-is the maximum-likelihood estimate when $\sum_{i=1}^N y_i = 0$. Working 
-with the closed parameter space $[0, \infty)$ may appear natural in this case.
-When we turn to numerical optimization algorithms we will, however, focus on the 
-case where the parameter space is open, and where a maximum-likelihood estimate
-is thus an interior point. 
+\[
+N - \frac{1}{\mu} \sum_{i=1}^N y_i = 0,
+\]
 
-Note that the (negative) log-likelihood depends on data only though the 
-data transformation $\sum_{i=1}^N y_i$. We call this sum a 
-*sufficient statistic* \index{sufficient statistic}
-since it is sufficient for the computation of the log-likelihood 
-and the maximum-likelihood estimate.
+so when $\sum_i y_i > 0$, the unique stationary point is
+
+\[
+\hat{\mu} = \frac{1}{N} \sum_{i=1}^N y_i.
+\]
+
+That the stationary point is the *global* minimizer of $-\ell$, rather than,
+say, a local maximum or a saddle point, requires an argument we defer until
+Section\ \@ref(opt-conditions). The missing ingredient is *convexity* of $-\ell$
+(Section\ \@ref(convexity)).
+
+If $\sum_i y_i = 0$, or equivalently $y_1 = \cdots = y_N = 0$, no minimizer
+exists in the open parameter space $(0, \infty)$ and the negative log-likelihood
+descends toward its infimum as $\mu \downarrow 0$. We could extend the parameter
+space to $[0, \infty)$ and set $\hat{\mu} = 0$, but the numerical optimization
+algorithms of Chapter \@ref(numopt) work best when the parameter space is open
+and the maximum-likelihood estimate is in the interior. We return to the
+distinction between open and closed parameter spaces in
+Section\ \@ref(constraints).
 :::
 
-The Poisson model with i.i.d. data is so simple that we can minimize the 
-negative log-likelihood analytically. This is not possible for many other 
-statistical models as the following example will illustrate. 
+The Poisson MLE is convenient: a single parameter, an elementary density, and a
+closed-form solution. Most parametric models of practical interest have neither
+a closed-form MLE nor a one-dimensional parameter space, and require numerical
+optimization as a result. Example\ \@ref(exm:von-Mises-mle), is one of the
+simplest, yet still non-trivial, instances of this.
 
-::: {.example .boxed #von-Mises-exponential} 
-Recall the von Mises distributions on the sample space $\mathcal{Y} = (-\pi, \pi],$
-which were introduced in Section \@ref(vM). They were introduced as a parametrized 
-family of probability distributions with density \index{von Mises distribution!statistical model}
-
-\[
-  f_{\theta}(y) = \frac{1}{\varphi(\theta)} e^{\theta_1 \cos(y) + \theta_2 \sin(y)}
-\]
-
-for $\theta = (\theta_1, \theta_2) \in \mathbb{R}^2$. That is, $\Theta = \mathbb{R}^2$.
-The function
+::: {.example .boxed #von-Mises-mle}
+The *von Mises distributions* are a family of probability distributions on
+the circle, with sample space $\mathcal{Y} = (-\pi, \pi]$. They were
+introduced in Section\ \@ref(vM) and used there for simulation; here we treat
+them as a parametric statistical model. The density is
+\index{von Mises distribution!statistical model}
 
 \[
-  \varphi(\theta) = \int_{-\pi}^{\pi} e^{\theta_1 \cos(u) + \theta_2 \sin(u)} \mathrm{d}u < \infty
+f_\theta(y) = \frac{1}{\varphi(\theta)} e^{\theta_1 \cos(y) + \theta_2 \sin(y)}
 \]
 
-for $\theta \in \Theta$ can be expressed in terms of a modified Bessel function, but 
-it cannot be expressed in terms of elementary functions.
-
-An alternative parametrization was also introduced in Section \@ref(vM)
-in terms of polar coordinates given by the reparametrization map
+for $\theta = (\theta_1, \theta_2) \in \mathbb{R}^2 = \Theta$. The normalizing
+constant
 
 \[
-  (\kappa, \mu) \mapsto \theta = \kappa \left(\begin{array}{c} \cos(\mu) \\ \sin(\mu) \end{array}\right)
+\varphi(\theta) = \int_{-\pi}^{\pi} e^{\theta_1 \cos(u) + \theta_2 \sin(u)} \, \mathrm{d}u
 \]
 
-that maps $[0,\infty) \times (-\pi, \pi]$ onto $\Theta$. 
-This alternative $(\kappa, \mu)$-parametrization has several problems.
-First, the $\mu$ parameter is not identifiable if $\kappa = 0$, which is 
-reflected by the fact that the reparametrization is not a one-to-one map. 
-Second, the parameter space is not open, which can be quite a nuisance
-for, e.g., maxmimum-likelihood estimation. We could circumvent these problems by restricting 
-attention to $(\kappa, \mu) \in (0,\infty) \times (-\pi, \pi)$, but 
-we would then miss some of the distributions parametrized by $\theta$---
-notably the uniform distribution corresponding to $\theta = 0$. 
+is finite for every $\theta \in \Theta$ and can be expressed in terms of a
+modified Bessel function, but not in terms of elementary functions.
 
-With observations $y_1, \ldots, y_N$ the negative log-likelihood in the 
-$\theta$-parametrization becomes 
+With observations $y_1, \ldots, y_N$ the negative log-likelihood becomes
 
 \[
- - \ell(\theta) = N \log \varphi(\theta) - \theta_1 \sum_{i=1}^N \cos(y_i) -  
-   \theta_2 \sum_{i=1}^N \sin(y_i).
+-\ell(\theta) = N \log \varphi(\theta) -
+  \theta_1 \sum_{i=1}^N \cos(y_i) -
+  \theta_2 \sum_{i=1}^N \sin(y_i).
 \]
 
-This function can be shown to be convex. Moreover, with this parametrization
-the log-likelihood only depends on data through the two statistics 
-$\sum_{i=1}^N \cos(y_i)$ and $\sum_{i=1}^N \sin(y_i)$, which are 
-thus sufficient statistics. 
-When minimizing the negative log-likelihood numerically, the sufficient statistics
-can be computed once upfront instead of repeatedly every time the 
-negative log-likelihood is evaluated.
+Unlike the Poisson case, setting the gradient to zero does not lead to a
+closed-form expression for the minimizer. The gradient depends on $\theta$
+through the partial derivatives of $\log \varphi$, which themselves involve
+Bessel functions, and the resulting system has no simple solution. The MLE
+*must* be computed numerically.
 
-Using the $(\kappa, \mu)$-parametrization the negative log-likelihood is
-
-\[
- - \ell(\kappa, \mu) = N \log \varphi(\kappa (\cos(\mu), \sin(\mu))^T) - 
-   \kappa \sum_{i=1}^N \cos(y_i - \mu),
-\]
-
-see also Section \@ref(vM). This function is not necessarily convex, and 
-without essentially reexpressing it in terms of the $\theta$-parametrization
-it does not reveal any sufficient statistics. 
-
-Irrespectively of the chosen parametrization, we will not be able to find an
-analytic formula for the maximum-likelihood estimate. We have to rely on
-numerical optimization procedures. When doing so, it can be beneficial to use an
-appropriate parametrization, e.g., one where the negative log-likelihood is
-convex and where computations of it and its gradient can be implemented
-efficiently.
+In Chapter\ \@ref(numopt), we introduce the algorithms we need to tackle this
+problem, and it turns out that this negative log-likelihood is well-behaved
+enough that even straightforward methods converge quickly. The function $-\ell$
+is *convex* (Section \@ref(convexity)) and its gradient is *Lipschitz
+continuous* (Section \@ref(smoothness)), which is exactly the structure
+algorithms depend upon. Both properties hold in the $\theta$-parametrization
+above. Section\ \@ref(parametrization) shows that a different but natural
+parametrization in terms of a mean direction and a concentration parameter loses
+convexity, and that the choice of parametrization is therefore as much an
+optimization question as it is a statistical one.
 :::
 
-The example above with the von Mises distributions illustrates how the 
-log-likelihood is specified in terms of the densities and data 
-as a function of the parameters. The example also shows that the 
-precise form of the log-likelihood depends on the specific parametrization. 
-The parametrization determines, for instance, whether the negative 
-log-likelihood is convex, and it can also reveal or hide whether there
-exist sufficient statistics. 
+We will return to these examples throughout the rest of the chapter. The Poisson
+example shows that maximum likelihood, treated as an optimization problem,
+sometimes has a clean analytic solution, whereas the von Mises example shows
+that it sometimes does not, which is why we sometimes need numerical algorithms.
+The intervening sections develop the concepts that let us reason about these
+cases: convexity, optimality conditions, smoothness, parametrization, and
+constraints.
 
-::: {.example .boxed #gaussian-exponential}
-The family of Gaussian distributions on $\mathbb{R}$ is most often parametrized 
-by the mean $\mu \in \mathbb{R}$ and variance $\sigma^2 > 0$. The density for 
-the $\mathcal{N}(\mu, \sigma^2)$-distribution is 
+## Convexity {#convexity}
 
-\begin{align*}
-f_{\mu, \sigma^2}(y) & = \frac{1}{\sqrt{2\pi\sigma^2}}\exp\left(-\frac{(y - \mu)^2}{2\sigma^2}\right) \\
-& =   \frac{1}{\sqrt{\pi}} \exp\left(\frac{\mu}{\sigma^2} y - \frac{1}{2\sigma^2} y^2 - \frac{\mu^2}{2\sigma^2} - 
-                                     \frac{1}{2}\log (2\sigma^2) \right),
-\end{align*}
+The property that typically determines whether an optimization problem is easy
+or hard is convexity. For a convex problem, every local minimum is global and
+the first-order condition $\nabla H(\theta^\star) = 0$ is both necessary and
+sufficient for optimality on the interior of the feasible set. This turns the
+search for a minimizer into a search for a stationary point. For a non-convex
+problem, none of that applies: a method may converge to a stationary point that
+is a saddle point, a local but not global minimum, or even a local maximum.
 
-and the parameter space is $\mathbb{R} \times (0, \infty)$. 
-
-Up to the factor $1/{\sqrt{\pi}}$, the negative log-likelihood 
-with $N$ observations is 
-
-\[ 
- - \ell(\mu, \sigma) =  \frac{\mu}{\sigma^2} \sum_{i=1}^N y_i - \frac{1}{2\sigma^2} 
- \sum_{i=1}^N y^2_i - N \frac{\mu^2}{2\sigma^2} - 
-                                     N \frac{1}{2}\log (2\sigma^2).
-\]
-
-We see that $\sum_{i=1}^N y_i$ and $\sum_{i=1}^N y_i^2$ constitute sufficient 
-statistics. It is possible to show that the unique maximum-likelihood estimate 
-(when at least two of the observations differ) equals 
-
-\begin{align*}
-\hat{\mu} & = \frac{1}{N} \sum_{i=1}^N y_i \\
-\hat{\sigma}^2 & = \frac{1}{N} \sum_{i=1}^N (y_i - \hat{\mu})^2. \\
-\end{align*}
-
-It is fairly straightforward to show that $(\hat{\mu}, \hat{\sigma}^2) \in 
-\mathbb{R} \times (0, \infty)$ is the unique stationary point, but 
-the negative log-likelihood is not convex in the $(\mu, \sigma^2)$-parametrization, 
-which makes it a bit tricky to show that the solution above is, indeed, 
-the global minimizer. 
-
-One possibility is to use the reparametrization 
-
-\[ 
-  \theta_1 = \frac{\mu}{\sigma^2} \quad \text{and} \quad \theta_2 = \frac{1}{2 \sigma^2},
-\]
-
-which gives 
-
-\[ 
- - \ell(\theta_1, \theta_2) =  \theta_1 \sum_{i=1}^N y_i - \theta_2 
- \sum_{i=1}^N y^2_i - N \frac{\theta_1^2}{4\theta_2} + 
-                                     N \frac{1}{2}\log (\theta_2).
-\]
-
-This function is convex in $\theta = (\theta_1, \theta_2)^T \in \mathbb{R} \times (0,\infty)$. If we 
-choose to minimize  $- \ell$ in this parametrization, we can return to the mean and variance 
-parameters via  
+A set $C \subseteq \mathbb{R}^p$ is *convex* if for any two points
+$\theta_1, \theta_2 \in C$ and any $\lambda \in [0, 1]$ the line segment between
+them stays inside $C$, that is, \index{convex set}
 
 \[
-  \mu = \frac{\theta_1}{2\theta_2} \quad \text{and} \quad  \sigma^2 = \frac{1}{2\theta_2}.
+\lambda \theta_1 + (1 - \lambda) \theta_2 \in C.
+\]
+
+Affine subspaces, half-spaces, balls, and the probability simplex
+$\Delta_K = \{p \in \mathbb{R}^K \mid p_i \geq 0, \sum_i p_i = 1\}$ are convex,
+and intersections of convex sets are convex. Figure\ \@ref(fig:convex-sets)
+shows four examples in $\mathbb{R}^2$.
+
+```{r}
+#| label: convex-sets
+#| echo: false
+#| fig-cap: "Examples of convex sets in $\\mathbb{R}^2$. From left to right: a
+#|   half-space, a ball, a polytope (intersection of finitely many half-spaces),
+#|   and the probability simplex $\\Delta_3$. In each case the segment between
+#|   any two points of the set stays inside the set."
+#| fig-width: 8
+#| fig-height: 2.2
+#| out-width: "100%"
+#| fig-align: "center"
+#| warning: false
+
+library(patchwork)
+
+fill_col <- "steelblue"
+fill_alpha <- 0.3
+
+panel_theme <- theme_void() +
+  theme(plot.title = element_text(hjust = 0.5, size = 11))
+
+box <- coord_equal(xlim = c(-1.2, 1.2), ylim = c(-1.2, 1.2))
+
+chord <- function(x1, y1, x2, y2) {
+  list(
+    geom_segment(
+      aes(x = x1, xend = x2, y = y1, yend = y2),
+      linetype = "dashed"
+    ),
+    geom_point(
+      data = data.frame(x = c(x1, x2), y = c(y1, y2)),
+      aes(x, y),
+      size = 1.2
+    )
+  )
+}
+
+# Half-space {(x, y) : x + y <= 1}, clipped to the viewport
+p_halfspace <- ggplot() +
+  geom_polygon(
+    data = data.frame(
+      x = c(-1.2, 1.2, 1.2, -0.2, -1.2),
+      y = c(-1.2, -1.2, -0.2, 1.2, 1.2)
+    ),
+    aes(x, y),
+    fill = fill_col,
+    alpha = fill_alpha
+  ) +
+  geom_segment(
+    aes(x = 1.2, xend = -0.2, y = -0.2, yend = 1.2)
+  ) +
+  chord(-0.8, -0.6, 0.5, -0.8) +
+  box +
+  labs(title = "Half-space") +
+  panel_theme
+
+# Ball: unit disk
+t <- seq(0, 2 * pi, length.out = 200)
+p_ball <- ggplot() +
+  geom_polygon(
+    data = data.frame(x = cos(t), y = sin(t)),
+    aes(x, y),
+    fill = fill_col,
+    alpha = fill_alpha,
+    color = "black"
+  ) +
+  chord(-0.6, 0.4, 0.5, -0.5) +
+  box +
+  labs(title = "Ball") +
+  panel_theme
+
+# Polytope: an irregular convex hexagon
+p_polytope <- ggplot() +
+  geom_polygon(
+    data = data.frame(
+      x = c(1.1, 0.6, -0.4, -1.1, -0.6, 0.7),
+      y = c(0.2, 1.0, 1.0, 0.1, -0.9, -0.7)
+    ),
+    aes(x, y),
+    fill = fill_col,
+    alpha = fill_alpha,
+    color = "black"
+  ) +
+  chord(-0.5, 0.5, 0.4, -0.2) +
+  box +
+  labs(title = "Polytope") +
+  panel_theme
+
+# Probability simplex Delta_3: equilateral triangle, centered and scaled
+# to fill the same viewport as the other panels
+p_simplex <- ggplot() +
+  geom_polygon(
+    data = data.frame(
+      x = c(-0.9, 0.9, 0),
+      y = c(-0.52, -0.52, 1.04)
+    ),
+    aes(x, y),
+    fill = fill_col,
+    alpha = fill_alpha,
+    color = "black"
+  ) +
+  chord(-0.4, -0.25, 0.3, 0.4) +
+  box +
+  labs(title = "Simplex") +
+  panel_theme
+
+p_halfspace + p_ball + p_polytope + p_simplex + plot_layout(nrow = 1)
+```
+
+A function $H : C \to \mathbb{R}$ defined on a convex domain $C$ is *convex* if
+\index{convex function}
+
+\[
+H(\lambda \theta_1 + (1 - \lambda) \theta_2) \leq
+  \lambda H(\theta_1) + (1 - \lambda) H(\theta_2)
+\]
+
+for all $\theta_1, \theta_2 \in C$ and $\lambda \in [0, 1]$. Geometrically, the
+chord between any two points on the graph of $H$ lies above the graph; see
+Figure\ \@ref(fig:convex-jensen) for an example and a non-example. The
+inequality is known as *Jensen's inequality*. \index{Jensen's inequality} When
+the inequality is strict for $\theta_1 \neq \theta_2$ and $\lambda \in (0, 1)$,
+the function is *strictly convex*^[Do not confuse *strictly* with *strongly*
+convex, which are two related but separate concepts.], and any minimizer is then
+unique. A function $H$ is *concave* if $-H$ is convex; affine functions are both
+convex and concave, and they are the only functions with that property.
+
+```{r}
+#| label: convex-jensen
+#| echo: false
+#| fig-cap: "Jensen's inequality. For a convex function (left) the chord
+#|   (dashed) between any two points on the graph lies above the graph; for
+#|   a non-convex function (right) the chord may cross below the graph,
+#|   violating the inequality."
+#| fig-width: 7
+#| fig-height: 2.5
+#| out-width: "100%"
+#| fig-align: "center"
+#| warning: false
+
+library(patchwork)
+
+jensen_panel <- function(H, thetas, theta1, theta2, title) {
+  ggplot(data.frame(theta = thetas, y = H(thetas)), aes(theta, y)) +
+    geom_line() +
+    geom_segment(
+      aes(x = theta1, xend = theta2, y = H(theta1), yend = H(theta2)),
+      linetype = "dashed",
+      color = "steelblue"
+    ) +
+    geom_point(
+      data = data.frame(
+        theta = c(theta1, theta2),
+        y = c(H(theta1), H(theta2))
+      )
+    ) +
+    annotate(
+      "text",
+      x = theta1 - 0.12,
+      y = H(theta1),
+      label = "theta[1]",
+      parse = TRUE
+    ) +
+    annotate(
+      "text",
+      x = theta2 + 0.12,
+      y = H(theta2),
+      label = "theta[2]",
+      parse = TRUE
+    ) +
+    theme_void() +
+    labs(x = NULL, y = NULL, title = title) +
+    theme(plot.title = element_text(hjust = 0.5, size = 11))
+}
+
+H_conv <- function(theta) theta^2
+H_nonconv <- function(theta) (theta^2 - 1)^2
+
+p_conv <- jensen_panel(
+  H_conv,
+  seq(-1.2, 1.5, length.out = 200),
+  -0.5,
+  1,
+  "Convex"
+)
+
+p_nonconv <- jensen_panel(
+  H_nonconv,
+  seq(-1.5, 1.5, length.out = 200),
+  -1.2,
+  1.2,
+  "Non-convex"
+)
+
+p_conv + p_nonconv
+```
+
+If $H$ is differentiable, convexity has an equivalent first-order
+characterization: $H$ is convex if and only if
+
+\[
+H(\theta_1) \geq H(\theta_2) + \nabla H(\theta_2)^\top (\theta_1 - \theta_2)
+\]
+
+for all $\theta_1, \theta_2 \in C$. The right-hand side is the first-order
+Taylor approximation of $H$ at $\theta_2$, so the condition says that the
+tangent hyperplane at any point lies entirely below the graph; see
+Figure\ \@ref(fig:convex-tangent). This characterization is the foundation of
+most of the optimality and convergence arguments to come---it provides a global
+lower bound on $H$ in terms of purely local first-order information.
+
+```{r}
+#| label: convex-tangent
+#| echo: false
+#| fig-cap: "First-order characterization of convexity. The tangent hyperplane (dashed) at any point lies below the graph of a convex function."
+#| fig-width: 4.5
+#| fig-height: 2.5
+#| out-width: "70%"
+#| fig-align: "center"
+#| warning: false
+
+H <- function(theta) theta^2
+Hp <- function(theta) 2 * theta
+
+theta2 <- 0.3
+thetas <- seq(-1.3, 1.5, length.out = 200)
+
+ggplot(data.frame(theta = thetas, y = H(thetas)), aes(theta, y)) +
+  geom_line() +
+  geom_abline(
+    slope = Hp(theta2),
+    intercept = H(theta2) - Hp(theta2) * theta2,
+    linetype = "dashed",
+    color = "steelblue"
+  ) +
+  geom_point(data = data.frame(theta = theta2, y = H(theta2))) +
+  annotate(
+    "text",
+    x = theta2 + 0.08,
+    y = H(theta2) - 0.25,
+    label = "theta[2]",
+    parse = TRUE
+  ) +
+  theme_void() +
+  coord_cartesian(ylim = c(-0.8, 2.4)) +
+  labs(x = NULL, y = expression(H(theta)))
+```
+
+If $H$ is twice differentiable, there is a still simpler test: $H$ is convex if
+and only if the Hessian is positive semidefinite at every point,
+
+\[
+\nabla^2 H(\theta) \succeq 0 \quad \text{for all } \theta \in C.
+\]
+
+In a single variable this reduces to $H''(\theta) \geq 0$. When the Hessian is
+positive definite throughout $C$, the function is strictly convex. If in
+addition the smallest eigenvalue of $\nabla^2 H(\theta)$ is bounded away from
+zero by some $m > 0$, then $H$ is *strongly convex*
+(Section\ \@ref(smoothness)).
+
+These concepts will pave the way for a proposition that we prove in
+Section\ \@ref(opt-conditions): if $H$ is convex and $C$ is convex, then *every*
+local minimum of $H$ on $C$ is a global minimum, and *any* stationary point in
+the interior of $C$ minimizes $H$. The practical consequence is that any
+stationary point we find is guaranteed, via convexity, to be a global minimizer,
+without us having to search elsewhere or rule out competing minima.
+
+Verifying convexity directly from the chord inequality is rarely the most
+convenient strategy. Several operations preserve convexity and let us assemble
+complicated convex functions from simple ones. Non-negative linear combinations
+of convex functions are convex; the composition of a convex function with an
+affine map is convex; and the pointwise supremum of any family of convex
+functions is convex. We will make use of the first two rules repeatedly in the
+examples that follow.
+
+A subtlety worth raising now is that convexity is a property of the
+*parameterization* of a statistical model. The same distribution can produce a
+convex negative log-likelihood under one parametrization and a non-convex one
+under another, so the choice of parametrization is a question with both
+statistical and computational consequences. In Section\ \@ref(parametrization),
+we return to this point as we tackle the von Mises distribution.
+
+::: {.example .boxed #poisson-mle-convex}
+Returning to the Poisson maximum-likelihood problem of
+Example\ \@ref(exm:poisson-mle), the negative log-likelihood on
+$\Theta = (0, \infty)$ is
+
+\[
+-\ell(\mu) = N \mu - \log(\mu) \sum_{i=1}^N y_i + \text{const},
+\]
+
+and its second derivative is
+
+\[
+-\ell''(\mu) = \frac{1}{\mu^2} \sum_{i=1}^N y_i.
+\]
+
+When $\sum_i y_i > 0$, this is strictly positive on all of $(0, \infty)$, so
+$-\ell$ is strictly convex and the stationary point
+$\hat{\mu} = N^{-1} \sum_i y_i$ identified in Example\ \@ref(exm:poisson-mle) is
+the unique global minimizer. When $\sum_i y_i = 0$ the second derivative
+vanishes identically and the negative log-likelihood reduces to $N \mu$, which
+is still convex but has no minimizer in the open parameter space, as we already
+observed in Example\ \@ref(exm:poisson-mle).
+:::
+
+::: {.example .boxed #von-Mises-mle-convex}
+The von Mises negative log-likelihood of Example\ \@ref(exm:von-Mises-mle) can
+be written as
+
+\[
+-\ell(\theta) = N \log \varphi(\theta) - \theta^\top s,
+\]
+
+where $s = \sum_{i=1}^N (\cos y_i, \sin y_i)^\top \in \mathbb{R}^2$ is a fixed
+data summary. The term $-\theta^\top s$ is linear in $\theta$ and therefore
+convex. By the nonnegative-combination rule, $-\ell$ is convex if and only if
+$\log \varphi$ is. Hölder's inequality applied to the integral defining
+$\varphi$ yields, for any $\lambda \in [0, 1]$ and any
+$\theta_a, \theta_b \in \mathbb{R}^2$,
+
+\[
+\varphi(\lambda \theta_a + (1 - \lambda) \theta_b) \leq
+  \varphi(\theta_a)^\lambda \, \varphi(\theta_b)^{1 - \lambda},
+\]
+
+so taking logarithms gives convexity of $\log \varphi$. Hence $-\ell$ is convex
+on $\Theta = \mathbb{R}^2$, and the numerical methods of Chapter\ \@ref(numopt)
+applied to it can be expected to converge to the global MLE. The convexity
+argument here is a special case of a more general result about so-called
+*canonical exponential families*, which we take up in
+Section\ \@ref(parametrization).
+:::
+
+## Optimality conditions {#opt-conditions}
+
+Section\ \@ref(convexity) introduced convexity and deferred two claims: that a
+stationary point of a convex objective minimizes it, and that any local minimum
+of a convex problem is global. In this section, we will develop the conditions
+we use throughout the rest of the book to recognize a minimizer when we have
+one. We separate *necessary* conditions, which picks candidates, from
+*sufficient* conditions, which certify one (or many) of them as optimal.
+
+Throughout the section, $H$ is at least once continuously differentiable on the
+interior of its domain. For an interior local minimizer $\theta^\star$ of $H$,
+the gradient must vanish, i.e.
+
+\[
+\nabla H(\theta^\star) = 0.
+\]
+
+If it did not, then $g(t) = H(\theta^\star - t \nabla H(\theta^\star))$ would
+satisfy $g'(0) = -\|\nabla H(\theta^\star)\|_2^2 < 0$, so
+$g(t) < g(0) = H(\theta^\star)$ for all sufficiently small $t > 0$,
+contradicting that $\theta^\star$ is a local minimum. Points satisfying
+$\nabla H(\theta^\star) = 0$ are called *stationary points*. Stationarity is
+*necessary* but not *sufficient* for a minimum: saddle points and local maxima
+are stationary too. \index{stationary point}
+
+When $H$ is convex, stationarity becomes sufficient and global.
+
+::: {.theorem #convex-stationary}
+Let $H$ be convex and differentiable on an open convex set $C$. Then
+$\theta^\star \in C$ is a global minimizer of $H$ over $C$ if and only if
+$\nabla H(\theta^\star) = 0$.
+:::
+
+::: {.proof .boxed}
+The only-if direction is the necessary condition above. For the if direction,
+the first-order characterization of convexity from Section\ \@ref(convexity)
+gives, for every $\theta \in C$,
+
+\[
+H(\theta) \geq H(\theta^\star) +
+  \nabla H(\theta^\star)^\top (\theta - \theta^\star) = H(\theta^\star),
+\]
+
+so $\theta^\star$ minimizes $H$ globally over $C$.
+:::
+
+We will repeatedly make use of Theorem\ \@ref(thm:convex-stationary) throughout
+the rest of the book. Whenever we can show that an objective is convex and a
+candidate point is stationary, the search is over.
+Theorem\ \@ref(thm:convex-local-global) provides a related and slightly more
+general statement that does not require differentiability.
+
+::: {.theorem #convex-local-global}
+Let $H$ be convex on a convex set $C$. Then every local minimizer of $H$ over
+$C$ is a global minimizer.
+:::
+
+::: {.proof .boxed}
+Suppose $\theta^\star$ is a local but not global minimizer, so there exists
+$\tilde{\theta} \in C$ with $H(\tilde{\theta}) < H(\theta^\star)$. Parametrize
+the segment from $\theta^\star$ to $\tilde{\theta}$ by
+$\theta_\lambda = (1 - \lambda) \theta^\star + \lambda \tilde{\theta}$ for
+$\lambda \in [0, 1]$. Then $\theta_\lambda \in C$ by convexity of $C$, and
+
+\[
+H(\theta_\lambda) \leq
+  (1 - \lambda) H(\theta^\star) + \lambda H(\tilde{\theta}) < H(\theta^\star)
+\]
+
+for every $\lambda \in (0, 1]$ by convexity of $H$. As $\lambda \to 0$, the
+$\theta_\lambda$ approach $\theta^\star$ while their values stay strictly below
+$H(\theta^\star)$, contradicting that $\theta^\star$ is a local minimum.
+:::
+
+If $H$ is twice continuously differentiable, the Hessian gives better
+information. At an interior local minimum, the second-order necessary condition
+
+\[
+\nabla^2 H(\theta^\star) \succeq 0
+\]
+
+holds in addition to $\nabla H(\theta^\star) = 0$. Conversely, if
+$\nabla H(\theta^\star) = 0$ and the Hessian is strictly positive definite at
+$\theta^\star$, then a second-order Taylor expansion shows that $\theta^\star$
+is a strict local minimizer, this time *without* requiring global convexity of
+$H$. The second-order test is the standard tool for sorting the stationary
+points of a non-convex objective into local minima, maxima, and saddle points.
+
+For constrained problems, the unconstrained first-order condition
+$\nabla H(\theta^\star) = 0$ need not hold at a boundary minimizer: the gradient
+can be nonzero so long as it points *outward*, since no feasible perturbation
+will then decrease $H$. The general first-order condition is the variational
+inequality
+
+\[
+\nabla H(\theta^\star)^\top (\theta - \theta^\star) \geq 0
+  \quad \text{for all } \theta \in C,
+\]
+
+which reduces to $\nabla H(\theta^\star) = 0$ when $\theta^\star$ lies in the
+interior of $C$. We return to constrained problems and their conditions,
+including the more practical formulation in terms of Lagrange multipliers and
+Karush--Kuhn--Tucker\ (KKT) conditions, in Section\ \@ref(constraints).
+
+The two examples below apply Theorem\ \@ref(thm:convex-stationary) to deliver
+closed-form solutions to two of the recurring problems set up in
+Section\ \@ref(opt-problem) and Section\ \@ref(mle-as-opt).
+
+::: {.example .boxed #poisson-mle-stationary}
+The Poisson negative log-likelihood of Example\ \@ref(exm:poisson-mle),
+
+\[
+-\ell(\mu) = N \mu - \log(\mu) \sum_{i=1}^N y_i + \text{const},
+\]
+
+has derivative
+
+\[
+-\ell'(\mu) = N - \frac{1}{\mu} \sum_{i=1}^N y_i.
+\]
+
+When $\sum_i y_i > 0$ the unique stationary point on $(0, \infty)$ is therefore
+$\hat{\mu} = N^{-1} \sum_i y_i$. Since $-\ell$ is strictly convex on
+$(0, \infty)$ in this case (Example\ \@ref(exm:poisson-mle-convex)),
+Theorem\ \@ref(thm:convex-stationary) certifies $\hat{\mu}$ as the global
+minimum of $-\ell$, and hence the MLE; Figure\ \@ref(fig:poisson-mle-curve)
+shows the convex bowl for a synthetic sample. The first-order condition alone,
+applied to a non-convex objective, would not have ruled out a saddle point or
+local maximum.
+:::
+
+```{r}
+#| label: poisson-mle-curve
+#| echo: false
+#| fig-cap: "The Poisson negative log-likelihood $-\\ell(\\mu)$ (up to an
+#|   additive constant) for a synthetic sample of size $N = 20$ from a Poisson
+#|   distribution. The curve is strictly convex on $(0, \\infty)$ and its
+#|   unique stationary point $\\hat{\\mu} = N^{-1} \\sum_i y_i$ is the global
+#|   minimizer."
+#| fig-width: 4
+#| fig-height: 3
+#| fig-align: "center"
+#| warning: false
+
+set.seed(2)
+N <- 20
+y <- rpois(N, lambda = 3)
+mu_hat <- mean(y)
+Sy <- sum(y)
+
+mu_grid <- seq(0.5, 8, length.out = 300)
+nll <- N * mu_grid - Sy * log(mu_grid)
+nll_min <- N * mu_hat - Sy * log(mu_hat)
+
+ggplot(data.frame(mu = mu_grid, nll), aes(mu, nll)) +
+  geom_line() +
+  geom_point(
+    data = data.frame(mu = mu_hat, nll = nll_min),
+    aes(mu, nll)
+  ) +
+  annotate(
+    "text",
+    x = mu_hat + 0.3,
+    y = nll_min + 4,
+    label = "hat(mu)",
+    parse = TRUE
+  ) +
+  labs(x = expression(mu), y = expression(paste("-", "l", "(", mu, ")")))
+```
+
+::: {.example .boxed #ols-normal-equations}
+The OLS objective of Section\ \@ref(opt-problem),
+
+\[
+H(\beta) = \tfrac{1}{2} \|\mathbf{y} - \mathbf{X} \beta\|_2^2,
+\]
+
+has gradient and Hessian
+
+\[
+\nabla H(\beta) = -\mathbf{X}^\top (\mathbf{y} - \mathbf{X} \beta), \quad
+\nabla^2 H(\beta) = \mathbf{X}^\top \mathbf{X}.
+\]
+
+The Hessian $\mathbf{X}^\top \mathbf{X}$ is positive semidefinite for any
+$\mathbf{X}$, so $H$ is convex; it is strictly convex precisely when
+$\mathbf{X}$ has full column rank, in which case the OLS problem has a unique
+minimizer. Setting $\nabla H(\beta) = 0$ yields the *normal equations*
+
+\[
+\mathbf{X}^\top \mathbf{X} \beta = \mathbf{X}^\top \mathbf{y},
+\]
+
+with closed-form solution
+$\hat{\beta} = (\mathbf{X}^\top \mathbf{X})^{-1} \mathbf{X}^\top \mathbf{y}$
+when $\mathbf{X}^\top \mathbf{X}$ is invertible.
+Theorem\ \@ref(thm:convex-stationary) certifies this $\hat{\beta}$ as the global
+OLS minimizer. The level sets of $H$ are then nested ellipses around
+$\hat{\beta}$. Figure\ \@ref(fig:ols-contour) shows them for a small synthetic
+problem with $p = 2$. For poorly conditioned or rank-deficient $\mathbf{X}$, the
+matrix $\mathbf{X}^\top \mathbf{X}$ is near-singular or singular, and the
+closed-form expression should be replaced by a numerical method that avoids
+forming and inverting it---we return to this point when we discuss conditioning
+in Section\ \@ref(smoothness).
+:::
+
+```{r}
+#| label: ols-contour
+#| echo: false
+#| fig-cap: "Contours of the OLS objective
+#|   $H(\\beta) = \\tfrac{1}{2} \\|\\mathbf{y} - \\mathbf{X}\\beta\\|_2^2$ for a
+#|   simulated problem with $N = 50$ observations and $p = 2$ predictors. The
+#|   level sets are nested ellipses centered at the unique minimizer
+#|   $\\hat{\\beta}$, and their orientation is determined by the eigenvectors of
+#|   $\\mathbf{X}^\\top \\mathbf{X}$."
+#| fig-width: 4
+#| fig-height: 3.5
+#| fig-align: "center"
+#| warning: false
+
+set.seed(1)
+N <- 50
+x1 <- rnorm(N)
+x2 <- 0.6 * x1 + 0.8 * rnorm(N)
+X <- cbind(x1, x2)
+y <- X %*% c(1, -0.5) + 0.5 * rnorm(N)
+
+XtX <- crossprod(X)
+Xty <- crossprod(X, y)
+yty <- sum(y^2)
+beta_hat <- as.numeric(solve(XtX, Xty))
+
+grid <- expand.grid(
+  b1 = seq(beta_hat[1] - 1.4, beta_hat[1] + 1.4, length.out = 150),
+  b2 = seq(beta_hat[2] - 1.4, beta_hat[2] + 1.4, length.out = 150)
+)
+grid$z <- with(
+  grid,
+  0.5 *
+    (XtX[1, 1] *
+      b1^2 +
+      2 * XtX[1, 2] * b1 * b2 +
+      XtX[2, 2] * b2^2 -
+      2 * (Xty[1] * b1 + Xty[2] * b2) +
+      yty)
+)
+
+ggplot(grid, aes(b1, b2, z = z)) +
+  geom_contour(color = "steelblue", bins = 10) +
+  geom_point(
+    data = data.frame(b1 = beta_hat[1], b2 = beta_hat[2]),
+    inherit.aes = FALSE,
+    aes(b1, b2)
+  ) +
+  annotate(
+    "text",
+    x = beta_hat[1] + 0.2,
+    y = beta_hat[2] - 0.1,
+    label = "hat(beta)",
+    parse = TRUE
+  ) +
+  coord_equal() +
+  labs(x = expression(beta[1]), y = expression(beta[2]))
+```
+
+## Parametrization and sufficient statistics {#parametrization}
+
+Convexity is a property of a specific objective function on a specific domain,
+not of a statistical model in the abstract. The same model produces different
+optimization landscapes under different choices of parameter, and a
+reparametrization that does not respect the convex structure can turn a convex
+problem into a non-convex one. In this section, we give the principal source of
+convex maximum-likelihood problems, the canonical exponential families, and then
+show what goes wrong when we reparametrize them into the interpretable scales we
+usually report results in.
+
+A parametric family on $\mathcal{Y}$ is a *canonical exponential family* if its
+densities take the form \index{exponential family!canonical}
+
+\[
+f_\theta(y) = \exp\left(\theta^\top t(y) - \log \varphi(\theta) + h(y)\right),
+\]
+
+for a *sufficient statistic* $t : \mathcal{Y} \to \mathbb{R}^d$, a base measure
+factor $h : \mathcal{Y} \to \mathbb{R}$, and the *log-partition function*
+
+\[
+\log \varphi(\theta) = \log \int_\mathcal{Y}
+  \exp\left(\theta^\top t(y) + h(y)\right) \, \mathrm{d}\mu(y),
+\]
+
+with $\mu$ the reference measure. The vector $\theta \in \mathbb{R}^d$ is the
+*canonical parameter*, and the *canonical parameter space*
+$\Theta = \{\theta \in \mathbb{R}^d : \varphi(\theta) < \infty\}$ is where the
+density is well defined. The Poisson distributions form a one-parameter family
+with $t(y) = y$ and canonical parameter $\theta = \log \mu$; the von Mises
+distributions of Example\ \@ref(exm:von-Mises-mle) form a two-parameter family
+with $t(y) = (\cos y, \sin y)^\top$; the Gaussian, Bernoulli, gamma, beta, and
+multinomial distributions also fit.
+
+The convexity property promised in Section\ \@ref(convexity) and proved there
+for the von Mises generalizes to the whole class:
+
+::: {.theorem #log-partition-convex}
+The log-partition function $\log \varphi$ of a canonical exponential family is a
+convex function of $\theta$ on $\Theta$.
+:::
+
+::: {.proof .boxed}
+For $\lambda \in [0, 1]$ and $\theta_a, \theta_b \in \Theta$, Hölder's
+inequality applied with conjugate exponents $1/\lambda$ and $1/(1 - \lambda)$ to
+the integral defining $\varphi$ gives
+
+\[
+\varphi(\lambda \theta_a + (1 - \lambda) \theta_b) \leq
+  \varphi(\theta_a)^\lambda \, \varphi(\theta_b)^{1 - \lambda},
+\]
+
+and taking logarithms yields the convexity of $\log \varphi$. A side benefit is
+that the same inequality shows that $\Theta$ is itself a convex set, since the
+right-hand side is finite whenever $\varphi(\theta_a)$ and $\varphi(\theta_b)$
+are.
+:::
+
+For i.i.d. observations $y_1, \ldots, y_N$ the negative log-likelihood in the
+canonical parameter is
+
+\[
+-\ell(\theta) = N \log \varphi(\theta) - \theta^\top s
+  - \sum_{i=1}^N h(y_i),
+\]
+
+where $s = \sum_{i=1}^N t(y_i) \in \mathbb{R}^d$ aggregates the data. The term
+$-\theta^\top s$ is linear in $\theta$, the last term does not depend on
+$\theta$, and Theorem\ \@ref(thm:log-partition-convex) makes the remaining piece
+convex.
+
+::: {.theorem #canonical-nll-convex}
+The negative log-likelihood of a canonical exponential family is a convex
+function of the canonical parameter $\theta$ on $\Theta$.
+:::
+
+The MLE problem is therefore convex on the entire canonical parameter space, and
+the optimality conditions of Section\ \@ref(opt-conditions) certify any
+stationary point as the global MLE.
+
+The vector $s = \sum_i t(y_i)$ in the negative log-likelihood is the only place
+where the data enters the picture. This is the *computational* reading of
+*sufficient statistic*: the cost of evaluating $-\ell$ at any $\theta$ does not
+scale with the number of observations $N$ once $s$ has been computed.
+Aggregating the data into $s$ takes $O(Nd)$ work, after which each $-\ell$ or
+$\nabla \ell$ evaluation is $O(d)$ work in the partition function and its
+derivatives, independent of $N$. For the iterative algorithms of
+Chapter\ \@ref(numopt) this is a substantial saving: the inner loop carries no
+$N$-dependence beyond the one-time aggregation.
+
+Statisticians rarely report results in canonical parameters. The Gaussian
+distribution is more naturally described by its mean and variance than by
+$\theta_1 = \mu/\sigma^2$ and $\theta_2 = -1/(2\sigma^2)$, and the von Mises
+distribution is more naturally described by a mean direction and a concentration
+than by a pair of Cartesian coordinates on $\mathbb{R}^2$. The
+reparametrizations that recover these interpretable scales are smooth, but not
+affine, and *only affine reparametrizations preserve convexity*. Composing a
+convex function with a nonlinear smooth map produces curvature terms in the
+Hessian that can be either positive or negative, and convexity is generally
+lost.
+
+In the following two examples, we examplify this point for the von Mises and
+Gaussian distributions. In both cases the practical conclusion is the same: work
+with the canonical parameter when optimizing, and transform back to the
+interpretable scale only after the algorithm has converged.
+
+::: {.example .boxed #von-Mises-polar}
+The von Mises distribution of Example\ \@ref(exm:von-Mises-mle) is more often
+described by a mean direction $\mu \in (-\pi, \pi]$ and a concentration
+parameter $\kappa \geq 0$, related to the canonical parameters by the polar map
+
+\[
+\theta_1 = \kappa \cos \mu, \quad \theta_2 = \kappa \sin \mu.
+\]
+
+In the $(\kappa, \mu)$ parametrization, the density takes the more interpretable
+form $f(y) \propto \exp\!\left(\kappa \cos(y - \mu)\right)$, and the negative
+log-likelihood is
+
+\[
+-\ell(\kappa, \mu) = N \log \varphi_0(\kappa)
+  - \kappa \sum_{i=1}^N \cos(y_i - \mu),
+\]
+
+where $\varphi_0(\kappa) = 2\pi I_0(\kappa)$ depends only on $\kappa$ through
+the modified Bessel function $I_0.$
+
+For each fixed $\kappa > 0$ the function $\mu \mapsto -\ell(\kappa, \mu)$ is
+non-constant and $2\pi$-periodic in $\mu$, and a non-constant periodic function
+on $\mathbb{R}$ cannot be convex, since a convex function bounded above is
+constant. So $-\ell$ is not convex as a function of
+$(\kappa, \mu) \in (0, \infty) \times \mathbb{R}$. Restricting $\mu$ to
+$(-\pi, \pi]$ does not save the situation either: that parameter space is not
+convex, and the function still takes equal values at the two ends of the
+interval. To compute the MLE we work in $\theta$, where the problem is convex by
+Theorem\ \@ref(thm:canonical-nll-convex), and convert back to $(\kappa, \mu)$ at
+the end through
+
+$$
+\kappa = \sqrt{\theta_1^2 + \theta_2^2}\quad \text{and} \quad \mu = \mathrm{atan2}(\theta_2, \theta_1).
+$$
+:::
+
+::: {.example .boxed #gaussian-canonical}
+The Gaussian distributions on $\mathbb{R}$ with mean $\mu \in \mathbb{R}$ and
+variance $\sigma^2 > 0$ form a canonical exponential family with sufficient
+statistic $t(y) = (y, y^2)^\top$ and canonical parameters
+
+\[
+\theta_1 = \frac{\mu}{\sigma^2}, \quad \theta_2 = -\frac{1}{2 \sigma^2}.
+\]
+
+The canonical parameter space is $\Theta = \mathbb{R} \times (-\infty, 0)$, and
+the log-partition function evaluates to
+
+\[
+\log \varphi(\theta_1, \theta_2) = -\frac{\theta_1^2}{4 \theta_2}
+  - \frac{1}{2} \log(-2\theta_2) + \frac{1}{2} \log(2\pi).
+\]
+
+By Theorem\ \@ref(thm:canonical-nll-convex) the negative log-likelihood is
+convex in $(\theta_1, \theta_2)$ on $\Theta$.
+
+In the $(\mu, \sigma^2)$ parametrization, by contrast,
+
+\[
+-\ell(\mu, \sigma^2) = \frac{N}{2} \log(2\pi \sigma^2) +
+  \frac{1}{2 \sigma^2} \sum_{i=1}^N (y_i - \mu)^2.
+\]
+
+Set $\mu = \bar{y}$ and $\hat{\sigma}^2 = N^{-1} \sum_i (y_i - \bar{y})^2$. The
+gradient in $\mu$ vanishes, and the gradient in $\sigma^2$ vanishes at
+$\sigma^2 = \hat{\sigma}^2$. The second partial derivative with respect to
+$\sigma^2$ at $\mu = \bar{y}$ is
+
+\[
+\frac{\partial^2 (-\ell)}{\partial (\sigma^2)^2} 
+  = -\frac{N}{2 \sigma^4} + \frac{1}{\sigma^6} \sum_{i=1}^N (y_i - \bar{y})^2 
+  = \frac{1}{\sigma^4} \left( \frac{N \hat\sigma^2}{\sigma^2} - \frac{N}{2} \right),
+\]
+
+which is strictly negative whenever $\sigma^2 > 2 \hat{\sigma}^2$. The negative
+log-likelihood is therefore concave in $\sigma^2$ on that region, so
+$(\mu, \sigma^2) \mapsto -\ell(\mu, \sigma^2)$ is not convex on its natural
+parameter space $\mathbb{R} \times (0, \infty)$. The maximum-likelihood
+estimates $\hat{\mu} = \bar{y}$ and
+$\hat{\sigma}^2 = N^{-1} \sum_i (y_i - \bar{y})^2$ are nevertheless well known,
+and they emerge cleanly from the moment equation
+$\nabla \log \varphi(\theta) = N^{-1} s$ in the canonical parameter, where
+convexity guarantees that the stationary point is the global MLE.
+:::
+
+## Smoothness and conditioning {#smoothness}
+
+Convexity tells us *whether* an unconstrained minimum can be found reliably, but
+not *how quickly* an iterative algorithm will find it. The convergence-rate
+claims in Chapter\ \@ref(numopt) rest on two further properties of the
+objective. The first, *smoothness*, is an upper bound on how fast the gradient
+can change. The second, *strong convexity*, is a lower bound on how curved the
+function is. Their ratio is the *condition number*, and it broadly determines
+how much work our numerical optimizer needs to perform to reach the optimum.
+
+A differentiable function $H : \mathbb{R}^p \to \mathbb{R}$ is *$L$-smooth*, or
+has *$L$-Lipschitz gradient*, if there exists $L > 0$ such that
+\index{Lipschitz gradient}\index{smoothness}
+
+\[
+\|\nabla H(\theta) - \nabla H(\theta')\|_2 \leq L \|\theta - \theta'\|_2
+\]
+
+for all $\theta, \theta'$. Figure\ \@ref(fig:lipschitz-cone) gives the cone
+picture in one dimension: at any anchor point $\theta_0$ the gradient curve
+$\nabla H$ must stay inside the cone of slope $L$ centered at
+$(\theta_0, \nabla H(\theta_0))$, and the Lipschitz constant is the smallest $L$
+for which this holds at every anchor and every $\theta$.
+
+```{r}
+#| label: lipschitz-cone
+#| echo: false
+#| fig-cap: "The Lipschitz cone of slope $L = 2$, shown at three anchor points
+#|   $\\theta_0$ along the same gradient curve $\\nabla H$ (solid). The
+#|   Lipschitz condition requires the curve to stay inside the cone for *every*
+#|   anchor; $L$ is the smallest slope for which this holds. The bound is
+#|   tight where the curve is steep (left two panels) and has slack where it is
+#|   flatter (right panel)."
+#| fig-width: 8
+#| fig-height: 2.8
+#| out-width: "100%"
+#| fig-align: "center"
+#| warning: false
+
+library(patchwork)
+
+grad <- function(theta) {
+  ifelse(theta < 0, 2 * theta - 1, -1 / (1 + theta))
+}
+
+lipschitz_panel <- function(theta0, L = 2) {
+  theta <- seq(-2, 2, length.out = 200)
+  df <- data.frame(theta = theta, y = grad(theta))
+
+  ggplot(df, aes(theta, y)) +
+    geom_ribbon(
+      aes(
+        ymin = grad(theta0) - L * abs(theta - theta0),
+        ymax = grad(theta0) + L * abs(theta - theta0)
+      ),
+      fill = "steelblue",
+      alpha = 0.25
+    ) +
+    geom_line() +
+    geom_point(
+      data = data.frame(theta = theta0, y = grad(theta0)),
+      aes(theta, y)
+    ) +
+    coord_cartesian(ylim = c(-6, 3)) +
+    labs(
+      x = expression(theta),
+      y = expression(nabla * H(theta)),
+      title = bquote(theta[0] == .(theta0))
+    ) +
+    theme(plot.title = element_text(hjust = 0.5, size = 11))
+}
+
+lipschitz_panel(-1.5) +
+  lipschitz_panel(0) +
+  lipschitz_panel(1) +
+  plot_layout(axes = "collect")
+```
+
+When $H$ is twice continuously differentiable this is equivalent to a uniform
+upper bound on the Hessian,
+
+\[
+\nabla^2 H(\theta) \preceq L I \quad \text{for all } \theta,
+\]
+
+so $L$ is an upper bound on the largest eigenvalue of $\nabla^2 H$ over the
+whole domain. The smoothness assumption translates into a quadratic *upper*
+bound on $H$ itself.
+
+::: {.lemma #descent-lemma}
+If $H$ is $L$-smooth, then for all $\theta, \theta' \in \mathbb{R}^p$,
+
+\[
+H(\theta') \leq H(\theta) + \nabla H(\theta)^\top (\theta' - \theta) +
+  \frac{L}{2} \|\theta' - \theta\|_2^2.
 \]
 :::
 
-In all three examples above we found one parametrization where 
+::: {.proof .boxed}
+Write
+$H(\theta') - H(\theta) =
+  \int_0^1 \nabla H(\theta + t(\theta' - \theta))^\top (\theta' - \theta)
+  \, \mathrm{d}t$
+and add and subtract $\nabla H(\theta)^\top (\theta' - \theta)$:
 
-* we could identify sufficient statistics
-* and where the negative log-likelihood is convex
+\begin{align*}
+H(\theta') - H(\theta) - \nabla H(\theta)^\top (\theta' - \theta)
+& = \int_0^1 \big(\nabla H(\theta + t(\theta' - \theta)) -
+    \nabla H(\theta)\big)^\top (\theta' - \theta) \, \mathrm{d}t \\
+& \leq \int_0^1 L \, t \, \|\theta' - \theta\|_2^2 \, \mathrm{d}t =
+    \frac{L}{2} \|\theta' - \theta\|_2^2,
+\end{align*}
 
-The examples are all *exponential families*\index{exponential families}, with
-their canonical parametrizations leading to the two desirable properties above.
-It is far from all statistical models that are exponential families, but even
-the more complicated models are often build from simpler components that are, in
-fact, exponential families. We will in several cases take advantage of such an
-underlying exponential family structure of the components---even though we will
-avoid a full fledged treatment of exponential families, see @Lauritzen:2023. For
-the implementation of computations and optimization algorithms, what matters
-most is the possibility to exploit sufficient statistics and convexity of the
-negative log-likelihood to yield fast computations and convergence guarantees of
-the algorithms.
+by the Cauchy-Schwarz inequality and the Lipschitz bound on $\nabla H$.
+:::
+
+Lemma\ \@ref(lem:descent-lemma) is known as the *descent lemma*.
+\index{descent
+lemma} The right-hand side is a quadratic in $\theta'$ with
+Hessian $L I$ that lies *above* $H$ everywhere and touches $H$ at
+$\theta' = \theta$. Gradient descent in Chapter\ \@ref(numopt) is exactly the
+algorithm that, at each step, replaces $H$ with this quadratic surrogate and
+jumps to its minimizer; the step size $t = 1/L$ falls out of that derivation
+rather than being imposed by hand.
+
+The matching lower bound is *strong convexity*. A function $H$ is *$m$-strongly
+convex* if there exists $m > 0$ such that \index{strong convexity}
+
+\[
+H(\theta') \geq H(\theta) + \nabla H(\theta)^\top (\theta' - \theta) +
+  \frac{m}{2} \|\theta' - \theta\|_2^2
+\]
+
+for all $\theta, \theta'$, or equivalently, for twice differentiable $H$,
+
+\[
+\nabla^2 H(\theta) \succeq m I \quad \text{for all } \theta.
+\]
+
+Figure\ \@ref(fig:smoothness-sandwich) puts the two quadratic bounds side by
+side: an upper quadratic of curvature $L$ from the descent lemma and a lower
+quadratic of curvature $m$ from strong convexity, both agreeing with $H$ in
+value and gradient at the anchor and differing only in how fast they curve away
+from it.
+
+```{r}
+#| label: smoothness-sandwich
+#| echo: false
+#| fig-cap: "Quadratic bounds on a function $H$ that is both $L$-smooth and
+#|   $m$-strongly convex. At any anchor point $\\theta_0$, $H$ lies between
+#|   $H(\\theta_0) + \\nabla H(\\theta_0)^\\top (\\theta - \\theta_0) +
+#|   \\tfrac{L}{2}\\|\\theta - \\theta_0\\|_2^2$ (upper bound, from the descent
+#|   lemma) and the same expression with $L$ replaced by $m$ (lower bound, from
+#|   strong convexity). All three curves agree in value and gradient at
+#|   $\\theta_0$. The bounds diverge as $\\theta$ moves away, at a rate
+#|   controlled by the condition number $\\kappa = L/m$. Here $\\kappa = 4$."
+#| fig-width: 5.5
+#| fig-height: 3.2
+#| out-width: "75%"
+#| fig-align: "center"
+#| warning: false
+
+H <- function(theta) theta^2 / 2 + theta^4 / 4
+H_prime <- function(theta) theta + theta^3
+
+L_val <- 4
+m_val <- 1
+theta0 <- 0.6
+H0 <- H(theta0)
+g0 <- H_prime(theta0)
+
+theta_seq <- seq(-1, 1, length.out = 200)
+
+df <- data.frame(
+  theta = rep(theta_seq, 3),
+  y = c(
+    H(theta_seq),
+    H0 + g0 * (theta_seq - theta0) + 0.5 * L_val * (theta_seq - theta0)^2,
+    H0 + g0 * (theta_seq - theta0) + 0.5 * m_val * (theta_seq - theta0)^2
+  ),
+  curve = factor(
+    rep(c("H", "L_upper", "m_lower"), each = length(theta_seq)),
+    levels = c("H", "L_upper", "m_lower")
+  )
+)
+
+label_vec <- c(
+  H = "H",
+  L_upper = "Upper bound (L)",
+  m_lower = "Lower bound (m)"
+)
+
+ggplot(df, aes(theta, y, color = curve, linetype = curve)) +
+  geom_line() +
+  geom_point(
+    data = data.frame(theta = theta0, y = H0),
+    aes(theta, y),
+    inherit.aes = FALSE
+  ) +
+  scale_color_manual(
+    name = NULL,
+    values = c(H = "black", L_upper = "steelblue", m_lower = "darkorange"),
+    labels = label_vec
+  ) +
+  scale_linetype_manual(
+    name = NULL,
+    values = c(H = "solid", L_upper = "dashed", m_lower = "dashed"),
+    labels = label_vec
+  ) +
+  labs(x = expression(theta), y = NULL) +
+  theme_schematic()
+```
+
+Strong convexity is strictly stronger than convexity: the Hessian is bounded
+*away from zero* uniformly, so the curvature never flattens out, and a unique
+minimizer is guaranteed to exist. The same lower quadratic gives a useful
+two-sided bound on how the function value, the distance to the minimizer, and
+the gradient norm relate to one another.
+
+::: {.lemma #strong-convex-suboptimality}
+If $H$ is $m$-strongly convex with minimizer $\theta^\star$, then for all
+$\theta$,
+
+\[
+\frac{m}{2} \|\theta - \theta^\star\|_2^2 \leq H(\theta) - H(\theta^\star) \leq
+  \frac{1}{2m} \|\nabla H(\theta)\|_2^2.
+\]
+:::
+
+::: {.proof .boxed}
+The left inequality is the strong-convexity bound with $\theta \leftarrow
+\theta^\star$ and $\theta' \leftarrow \theta$, using
+$\nabla H(\theta^\star) = 0$. For the right inequality, minimize both sides of
+the strong-convexity bound
+
+\[
+H(\theta') \geq H(\theta) + \nabla H(\theta)^\top (\theta' - \theta) +
+  \frac{m}{2} \|\theta' - \theta\|_2^2
+\]
+
+over $\theta'$. The left-hand side attains its minimum at $\theta' =
+\theta^\star$ with value $H(\theta^\star)$; the right-hand side is a quadratic
+in $\theta'$ minimized at $\theta' = \theta - m^{-1} \nabla H(\theta)$ with
+value $H(\theta) - (2m)^{-1} \|\nabla H(\theta)\|_2^2$. Hence
+$H(\theta^\star) \geq H(\theta) - (2m)^{-1} \|\nabla H(\theta)\|_2^2$.
+:::
+
+When $H$ is both $L$-smooth and $m$-strongly convex with $m \leq L$, the ratio
+
+\[
+\kappa = \frac{L}{m} \geq 1
+\]
+
+is called the *condition number* of $H$. \index{condition number} It measures
+the aspect ratio of the level sets of $H$ near the minimum: when $\kappa$ is
+close to $1$, the level sets are nearly spherical and the negative gradient
+points roughly toward the minimum; when $\kappa$ is large, the level sets are
+elongated ellipses with axes of very different lengths, and the negative
+gradient can point almost orthogonally to the direction of the minimizer. The
+linear convergence rate of gradient descent in Chapter\ \@ref(numopt) scales
+like $1 - 1/\kappa$ per iteration, so the number of iterations to reach a target
+accuracy is proportional to $\kappa$.
+
+::: {.example .boxed #ols-condition-number}
+For the OLS objective of Example\ \@ref(exm:ols-normal-equations) the Hessian
+$\mathbf{X}^\top \mathbf{X}$ is constant in $\beta$, so the Lipschitz and
+strong-convexity constants are exactly the largest and smallest eigenvalues:
+
+\[
+L = \lambda_{\max}(\mathbf{X}^\top \mathbf{X}), \quad
+m = \lambda_{\min}(\mathbf{X}^\top \mathbf{X}),
+\]
+
+and the condition number $\kappa = L / m$ equals the squared condition number of
+$\mathbf{X}$ itself. OLS is strongly convex precisely when $\mathbf{X}$ has full
+column rank, in which case $m > 0$---near-collinear columns drive
+$\lambda_{\min}$ toward zero and $\kappa$ toward infinity. The condition number
+is therefore the precise translation of "ill-conditioned design matrix" into
+optimization terms.
+
+The two designs below illustrate the range. Both have $N = 200$ observations and
+$p = 2$ predictors; the second has two nearly collinear columns.
+
+```{r}
+#| label: ols-condition-number-demo
+
+set.seed(42)
+
+N <- 200
+X_well <- matrix(rnorm(N * 2), N, 2)
+X_ill <- cbind(X_well[, 1], X_well[, 1] + 0.01 * rnorm(N))
+
+condition_summary <- function(X) {
+  ev <- eigen(crossprod(X), only.values = TRUE)$values
+  c(L = max(ev), m = min(ev), kappa = max(ev) / min(ev))
+}
+
+rbind(
+  well_conditioned = condition_summary(X_well),
+  ill_conditioned = condition_summary(X_ill)
+)
+```
+
+The well-conditioned design has $\kappa$ close to $1$, while the ill-conditioned
+design has $\kappa$ several orders of magnitude larger. Gradient descent applied
+to the two OLS problems with these designs would need on the order of
+$\kappa_{\text{ill}} / \kappa_{\text{well}}$ times as many iterations to reach
+the same accuracy on the second as on the first, a ratio we will see play out
+concretely in Chapter\ \@ref(numopt). Figure\ \@ref(fig:ols-condition-contour)
+makes the geometry concrete: the aspect ratio of the elliptical level sets *is*
+the condition number, and ill-conditioning collapses the bowl into a narrow
+valley along the direction of smallest curvature.
+:::
+
+```{r}
+#| label: ols-condition-contour
+#| echo: false
+#| fig-cap: "OLS objective contours for a well-conditioned design (left,
+#|   independent columns, $\\kappa \\approx 1$) and a moderately ill-conditioned
+#|   design (right, columns with correlation $0.8$, $\\kappa \\approx 9$). The
+#|   aspect ratio of the elliptical level sets equals $\\kappa$, so
+#|   ill-conditioning stretches the bowl into a narrow valley along the
+#|   direction of smallest curvature; the negative gradient at a point off the
+#|   axis then points almost across the valley rather than along it toward
+#|   $\\hat{\\beta}$."
+#| fig-width: 7
+#| fig-height: 3.5
+#| out-width: "100%"
+#| fig-align: "center"
+#| warning: false
+
+library(patchwork)
+
+contour_panel <- function(X, y, title_label) {
+  XtX <- crossprod(X)
+  Xty <- crossprod(X, y)
+  yty <- sum(y^2)
+  beta_hat <- as.numeric(solve(XtX, Xty))
+  halfwidth <- 1.5
+
+  grid <- expand.grid(
+    b1 = seq(
+      beta_hat[1] - halfwidth,
+      beta_hat[1] + halfwidth,
+      length.out = 200
+    ),
+    b2 = seq(
+      beta_hat[2] - halfwidth,
+      beta_hat[2] + halfwidth,
+      length.out = 200
+    )
+  )
+  grid$z <- with(
+    grid,
+    0.5 *
+      (XtX[1, 1] *
+        b1^2 +
+        2 * XtX[1, 2] * b1 * b2 +
+        XtX[2, 2] * b2^2 -
+        2 * (Xty[1] * b1 + Xty[2] * b2) +
+        yty)
+  )
+
+  ggplot(grid, aes(b1, b2, z = z)) +
+    geom_contour(color = "steelblue", bins = 15) +
+    geom_point(
+      data = data.frame(b1 = beta_hat[1], b2 = beta_hat[2]),
+      inherit.aes = FALSE,
+      aes(b1, b2)
+    ) +
+    coord_equal() +
+    labs(
+      x = expression(beta[1]),
+      y = expression(beta[2]),
+      title = title_label
+    ) +
+    theme(plot.title = element_text(hjust = 0.5, size = 11))
+}
+
+set.seed(24)
+
+N_fig <- 100
+beta_fig <- c(1, 2)
+
+X_well_fig <- matrix(rnorm(N_fig * 2), N_fig, 2)
+z1 <- rnorm(N_fig)
+z2 <- rnorm(N_fig)
+X_ill_fig <- cbind(z1, 0.8 * z1 + sqrt(1 - 0.8^2) * z2)
+
+y_well_fig <- X_well_fig %*% beta_fig
+y_ill_fig <- X_ill_fig %*% beta_fig
+
+p_well <- contour_panel(X_well_fig, y_well_fig, "Well-conditioned")
+p_ill <- contour_panel(X_ill_fig, y_ill_fig, "Ill-conditioned")
+
+p_well + p_ill + plot_layout(axes = "collect")
+```
+
+## Constraints {#constraints}
+
+The optimization problems we have studied so far have all been unconstrained, or
+constrained only to an open parameter set on which the gradient was free to
+vanish. Many statistical estimation problems carry genuine inequality
+constraints---probabilities must be non-negative and sum to one, variances and
+rates must be positive, allele frequencies live in fixed intervals, and so on.
+In this section, we introduce the fundamentals for such problems (the convex
+constrained standard form, its optimality conditions, and the two main
+algorithmic strategies), using the multinomial MLE on the simplex as a running
+example. The algorithms themselves are introduced in Chapter\ \@ref(numopt).
+
+An optimization problem is a *convex problem* if both the objective and the
+feasible set are convex. \index{convex problem} In standard form,
+
+\[
+\begin{aligned}
+& \operatorname*{minimize}_{\theta \in \mathbb{R}^p} && H(\theta) \\
+& \text{subject to} && g_i(\theta) \leq 0, \quad i = 1, \ldots, r, \\
+& && a_j^\top \theta = b_j, \quad j = 1, \ldots, s,
+\end{aligned}
+\]
+
+this means that $H$ and each $g_i$ are convex functions and the equality
+constraints are affine. We restrict to affine equality constraints because a
+nonlinear equality $h_j(\theta) = 0$ defines a curved manifold, which is not in
+general a convex set. Convex feasible sets are produced by intersecting the
+sublevel sets of convex inequality constraints with affine subspaces. We assume
+convex constraints throughout the rest of the book.
+
+The feasible sets that recur in statistical estimation are simple. The
+*probability simplex* \index{simplex}
+
+\[
+\Delta_K = \left\{ p \in \mathbb{R}^K \mid p_k \geq 0,\,
+  \sum_{k=1}^K p_k = 1 \right\}
+\]
+
+arises whenever we estimate a discrete distribution, for instance for
+multinomial models, mixture weights, and transition probabilities in Markov
+chains. The *positive orthant* $\{\theta \in \mathbb{R}^p \mid \theta_k > 0\}$
+arises for variances, rates, and scale parameters. A *box*
+$\{\theta \in \mathbb{R}^p \mid l_k \leq \theta_k \leq u_k\}$ arises when
+parameters are known a priori to lie in a fixed range. All three are convex.
+
+A point on the boundary of the feasible set need not satisfy
+$\nabla H(\theta^\star) = 0$: the gradient may point outward, in which case no
+feasible perturbation decreases $H$. We hinted at this phenomenon in
+Section\ \@ref(opt-conditions) and it is handled formally by the
+*Karush--Kuhn--Tucker conditions*, which extend the first-order optimality
+condition to constrained problems by associating a Lagrange multiplier with each
+constraint.
+
+::: {.theorem #kkt}
+Consider the convex problem above with differentiable $H$ and $g_i$, and
+suppose Slater's condition holds: there is a point $\tilde{\theta}$ with
+$g_i(\tilde{\theta}) < 0$ for all $i$ and $a_j^\top \tilde{\theta} = b_j$ for
+all $j$. Then $\theta^\star$ is a global minimizer if and only if there exist
+Lagrange multipliers $\lambda^\star \in \mathbb{R}_{\geq 0}^r$ and
+$\nu^\star \in \mathbb{R}^s$ such that
+\index{Karush--Kuhn--Tucker conditions}
+
+\begin{align*}
+& \nabla H(\theta^\star) +
+  \sum_{i=1}^r \lambda_i^\star \nabla g_i(\theta^\star) +
+  \sum_{j=1}^s \nu_j^\star a_j = 0
+&& \text{(stationarity)}, \\
+& g_i(\theta^\star) \leq 0, \quad a_j^\top \theta^\star = b_j
+&& \text{(primal feasibility)}, \\
+& \lambda_i^\star g_i(\theta^\star) = 0
+&& \text{(complementary slackness)}.
+\end{align*}
+:::
+
+We omit the proof, which is a standard result in convex analysis. When all
+inequality constraints are strictly inactive at $\theta^\star$, complementary
+slackness forces every $\lambda_i^\star$ to vanish and the stationarity
+condition reduces to the unconstrained $\nabla H(\theta^\star) = 0$ on the
+affine subspace defined by the equality constraints. The geometric content of
+the KKT conditions is the same intuition as in Section\ \@ref(opt-conditions):
+at a minimizer on the boundary, the negative gradient lies in the cone generated
+by the outward normals of the active constraints, since otherwise some feasible
+direction would still decrease $H$.
+
+Two strategies are available for solving convex constrained problems. The first
+is to *reparametrize* the constraint away. A probability vector $p \in \Delta_K$
+with all $p_k > 0$ can be written as $p_k = e^{\theta_k} / \sum_l e^{\theta_l}$
+for $\theta \in \mathbb{R}^K$, mapping the simplex into all of $\mathbb{R}^K$. A
+positive parameter $\sigma^2 > 0$ can be replaced by an unconstrained
+log-variance $\tau = \log \sigma^2$. The pitfall, as
+Section\ \@ref(parametrization) showed, is that these reparametrizations are
+typically nonlinear and can spoil the convexity of the underlying problem.
+
+The second strategy is to *stay in the constrained formulation* and use a method
+that handles the inequality constraints explicitly. The dominant approach in
+this family is the *barrier method*, a member of the interior-point family that
+replaces the hard inequality constraints by a sequence of smooth barrier
+penalties and solves a sequence of unconstrained problems. In
+Chapter\ \@ref(numopt), we introduce the barrier method in detail and apply it
+to the multinomial example below.
+
+::: {.example .boxed #multinomial-mle-simplex}
+The multinomial maximum-likelihood problem for observed counts
+$n_1, \ldots, n_K$ from $N = \sum_k n_k$ i.i.d. draws is
+
+\[
+\operatorname*{minimize}_{p \in \mathbb{R}^K}
+  -\sum_{k=1}^K n_k \log p_k
+\quad \text{subject to} \quad
+p_k \geq 0,\, \sum_{k=1}^K p_k = 1.
+\]
+
+In standard form the objective $-\sum_k n_k \log p_k$ is convex on the positive
+orthant (each $-\log$ term is convex), the inequalities $-p_k \leq 0$ are linear
+(and hence convex), and the equality $\sum_k p_k - 1 = 0$ is affine. Slater's
+condition holds via the uniform point $p_k = 1/K$.
+
+When all $n_k > 0$ the MLE lies in the interior, so the inequality multipliers
+vanish by complementary slackness and the KKT stationarity condition reduces to
+
+\[
+-\frac{n_k}{p_k^\star} + \nu^\star = 0 \quad \text{for all } k,
+\]
+
+giving $p_k^\star = n_k / \nu^\star$. Summing and using $\sum_k p_k^\star = 1$
+forces $\nu^\star = N$, and we recover the familiar empirical MLE
+$\hat{p}_k = n_k / N$.
+:::
 
 ## Multinomial models
 
-The multinomial model is the model of all probability distributions on 
-a finite set $\mathcal{Y} = \{1, \ldots, K\}$. We refer to each individual 
-element of the sample space $\mathcal{Y}$ as a *category*, \index{category}
-and we say that there are $K$ categories. The full model is parametrized
-by the simplex \index{simplex}
-
-$$\Delta_K = \left\{(p_1, \ldots, p_K)^T \in \mathbb{R}^K \ \Biggm| \ p_y \geq 0, \ \sum_{y=1}^K p_y = 1\right\}.$$
-
-The distributions parametrized by the relative interior of $\Delta_K$ can be 
-reparametrized as 
-
-$$p_y = \frac{e^{\theta_y}}{\sum_{k=1}^K e^{\theta_l}} \in (0,1)$$
-
-for $\theta = (\theta_1, \ldots, \theta_K)^T \in \mathbb{R}^K.$ The entries of a 
-probability vector $p \in \Delta_K$ can then be expressed as 
-
-$$p_y = \frac{e^{t(y)^T \theta}}{\varphi(\theta)}$$
-
-where $t(y) = (\delta_{1y}, \ldots, \delta_{Ky})^T \in \mathbb{R}^{K}$
-(where $\delta_{ky} \in \{0, 1\}$ is the Kronecker delta being 1 if and only
-if $k = y$), and 
-
-$$\varphi(\theta) = \sum_{k=1}^K e^{\theta_l}.$$
-
-With $N$ i.i.d. observations from a multinomial distribution we find 
-that the log-likelihood function is 
-
-\begin{align*}
-\ell(\theta) & = \sum_{i=1}^N \sum_{k=1}^K \delta_{k y_i} \log(p_k(\theta)) \\
-& = \sum_{k=1}^K \underbrace{\sum_{i=1}^N \delta_{k y_i}}_{= n_k} \log(p_k(\theta)) \\ 
-& = \sum_{k=1}^K  n_k \log(p_k(\theta)) \\ 
-& = \theta^T  \mathbf{N} - N \log \left(\varphi(\theta) \right) \\
-& = \theta^T  \mathbf{N} - N \log \left(\sum_{k=1}^{K} e^{\theta_k} \right).
-\end{align*}
-
-where $\mathbf{N} = (n_1, \ldots, n_K)^T = \sum_{i=1}^N t(y_i) \in \mathbb{N}_0^K$ is the sufficient 
-statistic, which is simply a tabulation of the times the different elements in 
-$\{1, \ldots, K\}$ were observed. The term $\log \left(\varphi(\theta) \right)$ 
-is a convex function, and since the other term is linear, $- \ell$ is 
-convex in the $\theta$-parametrization. 
-
-The distribution of the tabulated data, $\mathbf{N}$, is a 
-multinomial distribution\index{multinomial distribution} with parameters $(N, p)$,
-and we often write $\mathbf{N} \sim \textrm{Mult}(N, p)$.
-
-We call the $\theta$-parametrization above with $\theta \in \mathbb{R}^K$ 
-the *symmetric* parametrization. Unfortunately, this parameter is not 
-identifiable from the probability vector $p$; adding a constant to all entries of $\theta$ 
-will give the same probability vector. The lack of identifiability is 
-traditionally fixed by setting $\theta_K = 0$. This 
-results in the parameter $\theta = (\theta_1, \ldots, \theta_{K-1})^T \in \mathbb{R}^{K-1},$
-in the sufficient statistic $t(y) = (\delta_{1y}, \ldots, \delta_{(K-1)y})^T \in \mathbb{R}^{K-1}$,
-and 
-
-\[
-\varphi(\theta) = 1 + \sum_{k=1}^{K-1} e^{\theta_k}.
-\]
-
-With this parametrization, the category $K$ is called the reference category, 
-\index{reference category} and the parameter $\theta_y$ 
-now expresses the difference relative to the reference category:   
-
-$$p_y = \left\{\begin{array}{ll} \frac{e^{\theta_y}}{\varphi(\theta)}  & \quad \text{if } y = 1, \ldots, K-1 \\  \frac{1}{\varphi(\theta)} & \quad \text{if } y = K. \end{array}\right.$$
-
-We see that $p_y = e^{\theta_y}p_K$ for $y = 1, \ldots, K-1$,
-with the probability of the reference category $K$ acting as a baseline probability,
-and the factor $e^{\theta_y}$ acting as a multiplicative modification of this 
-baseline. Moreover, the ratios 
-
-$$\frac{p_y}{p_k} = e^{\theta_y - \theta_k},$$
-
-are independent of the chosen baseline. The log-likelihood becomes 
+The multinomial distribution on $K$ categories is the natural model for
+categorical observations, and its parameter space is the probability simplex
+$\Delta_K$ \index{simplex} introduced in Section\ \@ref(constraints). Given $N$
+i.i.d. observations $y_1, \ldots, y_N \in \{1, \ldots, K\}$ with counts
+$n_k = \sum_{i=1}^N \mathbf{1}(y_i = k)$, the log-likelihood is
 \index{log-likelihood function!multinomial distribution}
 
-\begin{align*}
-\ell(\theta) & = \theta^T  \mathbf{N} - N \log \left(1 + \sum_{k=1}^{K - 1} e^{\theta_k} \right).
-\end{align*}
-
-In the special case of $K = 2$ the two elements $\mathcal{Y}$ are often given 
-other labels than $1$ and $2$. The most common labels are $\{0, 1\}$ and $\{-1, 1\}$.
-If we use the $0$-$1$-labels the convention is to use $p_0$ as the baseline and 
-thus 
-
 \[
-p_1 = \frac{e^{\theta}}{1 + e^{\theta}} = e^{\theta} p_0 = e^{\theta} (1 - p_1)
+\ell(p) = \sum_{k=1}^K n_k \log p_k,
 \]
 
-is parametrized by $\theta \in \mathbb{R}$. As this function of $\theta$ is 
-known as the *logistic function*,\index{logistic function} this parametrization of the probability 
-distributions on $\{0,1\}$ is called the logistic model.\index{logistic model} 
-From the above we see that 
+with the count vector $\mathbf{N} = (n_1, \ldots, n_K)$ as the sufficient
+statistic in the computational sense of Section\ \@ref(parametrization): the
+data enter the likelihood only through $\mathbf{N}$, so each evaluation costs
+$O(K)$ once the counts have been aggregated. When $p$ ranges freely over the
+relative interior of $\Delta_K$, Example\ \@ref(exm:multinomial-mle-simplex)
+derived the closed-form MLE $\hat{p}_k = n_k / N$ via the KKT conditions of
+Section\ \@ref(constraints). When some $n_k = 0$ the MLE is still
+$\hat{p}_k = 0$, but now on the boundary of the simplex where $-\log p_k$
+diverges, so a numerical method that evaluates the log-likelihood at every
+category has to handle this case with care. The multinomial is also a canonical
+exponential family in the parametrization $p_k(\theta) \propto e^{\theta_k}$, so
+by Theorem\ \@ref(thm:canonical-nll-convex) the negative log-likelihood is
+convex in $\theta$ on $\mathbb{R}^K$ modulo the global shift
+$\theta \mapsto \theta + c\mathbf{1}$, which leaves $p$ unchanged and is
+traditionally fixed by setting $\theta_K = 0$ (the *reference category*).
+\index{reference category} \index{multinomial distribution}
 
-\[
-\theta = \log \frac{p_1}{1 - p_1}
-\]
-
-is the log-odds. 
-
-If we use the $\pm 1$-labels, an alternative parametrization is 
-
-\[
-p_y = \frac{e^{y\theta}}{e^\theta + e^{-\theta}}
-\]
-
-for $\theta \in \mathbb{R}$ and $y \in \{-1, 1\}$. This gives a symmetric treatment 
-of the two labels while retaining the identifiability. 
+The free-simplex case is the easy one. The richer problem, and the one we will
+use as a running constrained-estimation example in Chapter\ \@ref(numopt), is
+*collapsed* multinomial estimation: the multinomial probability vector is
+restricted to a submanifold of $\Delta_K$ specified by a smaller parameter
+$\psi$, and some of the $K$ categories are merged before observation. The
+peppered-moths example, treated below, has both features at once: the allele
+frequencies parametrize a curve on $\Delta_6$ via Hardy-Weinberg equilibrium,
+and the six genotypes are observed only as three phenotypes.
 
 ### Parametrizations and collapsing of categories {#mult-collapse}
 
-In this section we make two additions to the multinomial model. We 
-allow for a parametrization of the multinomial probability vector, 
-which is a map $\psi \mapsto p(\psi) = (p_1(\psi), \ldots, p_K(\psi))$, 
-and we allow for a certain type of incomplete observations from 
-the mutinomial distribution where some categories are collapsed. 
+In this section we make two additions to the multinomial model. We allow for a
+parametrization of the multinomial probability vector, which is a map
+$\psi \mapsto p(\psi) = (p_1(\psi), \ldots, p_K(\psi))$, and we allow for a
+certain type of incomplete observations from the multinomial distribution where
+some categories are collapsed.
 
-
-A collapse of categories is described by a partition \index{collapsing of categories} 
+A collapse of categories is described by a partition
+\index{collapsing of categories}
 $A_1 \cup \ldots \cup A_{K_0} = \{1, \ldots, K\}$ and a map
 
 \[
@@ -429,26 +1677,26 @@ given by
 M((n_1, \ldots, n_K))_j = \sum_{k \in A_j} n_k.
 \]
 
-For a single observation $x \in \{1,\ldots,K\}$ we have a corresponding 
+For a single observation $x \in \{1,\ldots,K\}$ the corresponding indicator
+vector $t(x) = (\delta_{1x}, \ldots, \delta_{Kx})^\top \in \{0,1\}^K$ collapses
+to
 
 \[
 y = M(t(x)) = \left( \sum_{k \in A_1} \delta_{kx}, \ldots,
- \sum_{k \in A_{K_0}} \delta_{kx} \right) \in \mathbb{N}_0^{K_0}
+ \sum_{k \in A_{K_0}} \delta_{kx} \right) \in \mathbb{N}_0^{K_0},
 \]
 
-indicating which of the $K_0$ collapsed categories the observation $y$
-falls into. 
+indicating which of the $K_0$ collapsed categories the observation falls into.
 
-If $\mathbf{N}^x \sim \textrm{Mult}(N, p)$ with $p = (p_1, \ldots, p_K)$ then 
+If $\mathbf{N}^x \sim \textrm{Mult}(N, p)$ with $p = (p_1, \ldots, p_K)$ then
 the corresponding tabulation of $y$-values equals
 
-\[ 
+\[
 \mathbf{N} = M(\mathbf{N}^x) \sim \textrm{Mult}(N, M(p)).
 \]
 
-In terms of the parametrization $\psi \mapsto p(\psi)$ of the 
-multinomial probability vector,
-and having observed $\mathbf{N} = (n_1, \ldots, n_{K_0})$,
+In terms of the parametrization $\psi \mapsto p(\psi)$ of the multinomial
+probability vector, and having observed $\mathbf{N} = (n_1, \ldots, n_{K_0})$,
 the log-likelihood under the collapsed multinomial model is generally
 
 \begin{equation}
@@ -457,34 +1705,36 @@ the log-likelihood under the collapsed multinomial model is generally
 (\#eq:mult-col-loglik) 
 \end{equation}
 
-
 ### Peppered Moths {#pep-moth}
 
-The peppered moth (*Birkemåler* in Danish) is a moth species that is found 
-throughout the northern hemisphere. Its color can vary considereably from 
-very dark to very light. The light colored varieties can also have patterns 
-of darker spots. Figure \@ref(fig:moth-figure)
-shows examples of the color variation among individual moths. The peppered moth
-provided an [early demonstration of
+The peppered moth (*Birkemåler* in Danish) is a moth species that is found
+throughout the northern hemisphere. Its color can vary considereably from very
+dark to very light. The light colored varieties can also have patterns of darker
+spots. Figure \@ref(fig:moth-figure) shows examples of the color variation among
+individual moths. The peppered moth provided an [early demonstration of
 evolution](https://en.wikipedia.org/wiki/Peppered_moth_evolution) in the 19th
 century England, where the light colored moth was outnumbered by the dark
 colored variety. The dark color became dominant due to the increased pollution,
-where trees were darkened by soot, and the dark colored moths thus had a 
+where trees were darkened by soot, and the dark colored moths thus had a
 selective advantage.
 
 The color is the directly observable phenotype of the moth, while the genetics
-is a little more complicated to observe. For the purpose of this example, a
-moth is classified into one of three color categories: dark, mottled, or light
+is a little more complicated to observe. For the purpose of this example, a moth
+is classified into one of three color categories: dark, mottled, or light
 colored. The color of the moth is primarily determined by one gene that occurs
-in three different alleles denoted $C$, $I$ and $T$. The alleles are ordered in terms
-of dominance as $C > I > T$. Moths with a genotype including $C$ are dark. Moths 
-with genotype $TT$ are light colored. Moths with genotypes $II$ and $IT$ are 
-mottled. 
-Thus there a total of six different genotypes 
-($CC$, $CI$, $CT$, $II$, $IT$ and $TT$), which 
-results in three different color phenotypes.
+in three different alleles denoted $C$, $I$ and $T$. The alleles are ordered in
+terms of dominance as $C > I > T$. Moths with a genotype including $C$ are dark.
+Moths with genotype $TT$ are light colored. Moths with genotypes $II$ and $IT$
+are mottled. Thus there a total of six different genotypes ($CC$, $CI$, $CT$,
+$II$, $IT$ and $TT$), which results in three different color phenotypes.
 
-```{r moth-figure, echo = FALSE, out.width="100%", fig.align='center', fig.cap="Examples of the color variation of the peppered moth."}
+```{r}
+#| label: moth-figure
+#| echo: false
+#| out-width: "100%"
+#| fig-align: "center"
+#| fig-cap: "Examples of the color variation of the peppered moth."
+
 knitr::include_graphics("figures/moth.jpg")
 ```
 
@@ -503,10 +1753,10 @@ frequencies are
   p_{II} &=  p_I^2, \ p_{IT} = 2p_Ip_T, \ p_{TT} = p_T^2.
 \end{align*}
 
-The parametrization in terms of allele frequencies maps out a subset of the 
-full parameter space for the multinomial distribution with six categories. 
-If we could observe the genotypes, the multinomial log-likelihood, 
-parametrized by allele frequencies, would be 
+The parametrization in terms of allele frequencies maps out a subset of the full
+parameter space for the multinomial distribution with six categories. If we
+could observe the genotypes, the multinomial log-likelihood, parametrized by
+allele frequencies, would be
 
 \begin{align*}
  \ell(p_C, p_I) & = 2N_{CC} \log(p_C) + N_{CI} \log (2 p_C p_I) + N_{CT} \log(2 p_C p_T)  \\
@@ -515,25 +1765,25 @@ parametrized by allele frequencies, would be
 & \ \ + 2 N_{II} \log(p_I) + N_{IT} \log(2p_I (1 - p_C - p_I)) + 2 N_{TT} \log(1 - p_C - p_I). 
 \end{align*}
 
-The log-likelihood is given in terms of the genotype counts and the two 
-probability parameters $p_C, p_I \geq 0$ with $p_C + p_I \leq 1$. By differentiation,
-it is possible to find an analytic expression for the maximum-likelihood estimate,
-but we will postpone this exercise to Section \@ref(peppered-moths), because
-collecting moths and determining their color will only identify their phenotype, 
-not their genotype. Thus we observe $(N_C, N_T, N_I)$, where
+The log-likelihood is given in terms of the genotype counts and the two
+probability parameters $p_C, p_I \geq 0$ with $p_C + p_I \leq 1$. By
+differentiation, it is possible to find an analytic expression for the
+maximum-likelihood estimate, but we will postpone this exercise to Section
+\@ref(peppered-moths), because collecting moths and determining their color will
+only identify their phenotype, not their genotype. Thus we observe
+$(N_C, N_T, N_I)$, where
 
 \[
 N = \underbrace{N_{CC} + N_{CI} + N_{CT}}_{= N_C} + 
 \underbrace{N_{IT} + N_{II}}_{=N_I} + \underbrace{N_{TT}}_{=N_T}.
 \]
 
-For maximum-likelihood estimation of the parameters from 
-the observation $(N_C, N_T, N_I)$ we need the likelihood in the marginal 
-distribution of the observed variables. This is an example of 
-collapsing of categories as treated in Section \@ref(mult-collapse) 
-with $K = 6$, corresponding to the six genotypes, and $K_0 = 3$, 
-corresponding to the three phenotypes. The partition corresponding to 
-the phenotypes is
+For maximum-likelihood estimation of the parameters from the observation
+$(N_C, N_T, N_I)$ we need the likelihood in the marginal distribution of the
+observed variables. This is an example of collapsing of categories as treated in
+Section \@ref(mult-collapse) with $K = 6$, corresponding to the six genotypes,
+and $K_0 = 3$, corresponding to the three phenotypes. The partition
+corresponding to the phenotypes is
 
 \[
 \{CC, CI, CT\} \cup \{IT, II\} \cup \{TT\} = \{CC, \ldots, TT\},
@@ -546,35 +1796,207 @@ and
 & = (N_{CC} + N_{CI} + N_{CT}, N_{IT} + N_{II}, N_{TT}).
 \end{align*}
 
-In terms of the $\psi = (p_C, p_I)$-parametrization, $p_T = 1 - p_C - p_I$ and 
+In terms of the $\psi = (p_C, p_I)$-parametrization, $p_T = 1 - p_C - p_I$ and
 
 \[
 p = (p_C^2, 2p_Cp_I, 2p_Cp_T, p_I^2,  2p_Ip_T, p_T^2).
 \]
 
-Hence 
+Hence
 
 \[
 M(p) = (p_C^2 + 2p_Cp_I + 2p_Cp_T, p_I^2 +2p_Ip_T, p_T^2).
 \]
 
+Figure\ \@ref(fig:moth-phenotype) shows the partition diagrammatically. The nine
+ordered allele pairs are arranged in a grid and colored by phenotype; summing
+the probabilities inside each color region gives the corresponding component of
+$M(p)$. The factor of $2$ on the heterozygous probabilities in the
+Hardy--Weinberg formula is exactly the count of off-diagonal cells that share a
+probability.
+
+```{r}
+#| label: moth-phenotype
+#| echo: false
+#| fig-cap: "Hardy–Weinberg probabilities for the nine ordered allele pairs,
+#|   colored by the resulting phenotype. The partition into dark, mottled, and
+#|   light cells is the collapsing map $M$, and summing the probabilities
+#|   inside each color region gives the corresponding component of $M(p)$."
+#| fig-width: 4.5
+#| fig-height: 3.5
+#| fig-align: "center"
+#| warning: false
+
+alleles <- c("C", "I", "T")
+
+phenotype_grid <- expand.grid(
+  allele_row = alleles,
+  allele_col = alleles,
+  stringsAsFactors = FALSE
+)
+
+phenotype_grid$phenotype <- with(
+  phenotype_grid,
+  ifelse(
+    allele_row == "C" | allele_col == "C",
+    "dark",
+    ifelse(allele_row == "T" & allele_col == "T", "light", "mottled")
+  )
+)
+
+prob_label <- function(a, b) {
+  if (a == b) {
+    sprintf("p[%s]^2", a)
+  } else {
+    pair <- sort(c(a, b))
+    sprintf("p[%s] * p[%s]", pair[1], pair[2])
+  }
+}
+
+phenotype_grid$prob <- mapply(
+  prob_label,
+  phenotype_grid$allele_row,
+  phenotype_grid$allele_col
+)
+
+phenotype_grid$allele_row <- factor(
+  phenotype_grid$allele_row,
+  levels = rev(alleles)
+)
+phenotype_grid$allele_col <- factor(
+  phenotype_grid$allele_col,
+  levels = alleles
+)
+phenotype_grid$phenotype <- factor(
+  phenotype_grid$phenotype,
+  levels = c("dark", "mottled", "light")
+)
+
+axis_labels <- parse(text = sprintf("italic(%s)", alleles))
+
+ggplot(
+  phenotype_grid,
+  aes(allele_col, allele_row, fill = phenotype)
+) +
+  geom_tile(color = "white", linewidth = 1.5) +
+  geom_text(
+    aes(label = prob, color = phenotype),
+    parse = TRUE,
+    size = 3.8
+  ) +
+  scale_fill_manual(
+    values = c(dark = "grey25", mottled = "grey70", light = "grey92")
+  ) +
+  scale_color_manual(
+    values = c(dark = "white", mottled = "white", light = "black"),
+    guide = "none"
+  ) +
+  scale_x_discrete(labels = axis_labels) +
+  scale_y_discrete(labels = rev(axis_labels)) +
+  coord_equal() +
+  labs(x = NULL, y = NULL, fill = "Phenotype") +
+  theme_minimal() +
+  theme(
+    panel.grid = element_blank(),
+    axis.ticks = element_blank()
+  )
+```
+
 The log-likelihood equals
 
 \begin{align*}
-\ell(p_C, p_I) & = N_C \log(p_C^2 + 2p_Cp_I + 2p_Cp_T) + 
+\ell(p_C, p_I) & = N_C \log(p_C^2 + 2p_Cp_I + 2p_Cp_T) +
 N_I \log(p_I^2 +2p_Ip_T) + N_T \log (p_T^2).
 \end{align*}
 
-We first implement the (negative) log-likelihood in a very problem 
-specific way below.
-The implementation checks if the parameter constraints 
-are fulfilled, that is, if  $(p_C, p_I, p_T)$ is a probability vector.
-If the parameters are out of bounds the function returns the value 
-$+\infty$. It is fairly standard in optimization to encode constraints by 
-letting the function return the value $+\infty$ (for minimization) 
-when parameters are out of bounds.
+Figure\ \@ref(fig:moth-contour) shows the contours of $-\ell(p_C, p_I)$ on the
+simplex for the data $(N_C, N_I, N_T) = (85, 196, 341)$ we use throughout this
+section. The objective tends to $+\infty$ on the boundary, where one of the
+three phenotype probabilities vanishes, and has a unique interior minimizer.
 
-```{r moth-likelihood}
+```{r}
+#| label: moth-contour
+#| echo: false
+#| fig-cap: "Contours of the negative log-likelihood $-\\ell(p_C, p_I)$ for the
+#|   peppered moth data $(N_C, N_I, N_T) = (85, 196, 341)$. The feasible region
+#|   is the simplex $\\{(p_C, p_I) : p_C, p_I \\geq 0, \\ p_C + p_I \\leq 1\\}$,
+#|   outlined in black; outside it the objective is undefined. The unique
+#|   interior minimizer is marked."
+#| fig-width: 4
+#| fig-height: 3.5
+#| fig-align: "center"
+#| warning: false
+
+ny <- c(85, 196, 341)
+
+grid <- expand.grid(
+  p_C = seq(0.005, 0.995, length.out = 200),
+  p_I = seq(0.005, 0.995, length.out = 200)
+)
+grid$p_T <- 1 - grid$p_C - grid$p_I
+grid$z <- ifelse(
+  grid$p_T > 0,
+  -(ny[1] *
+    log(grid$p_C^2 + 2 * grid$p_C * grid$p_I + 2 * grid$p_C * grid$p_T) +
+    ny[2] * log(grid$p_I^2 + 2 * grid$p_I * grid$p_T) +
+    ny[3] * log(grid$p_T^2)),
+  NA_real_
+)
+
+p_hat <- optim(
+  c(0.3, 0.3),
+  function(p) {
+    p_T <- 1 - p[1] - p[2]
+    if (p[1] <= 0 || p[2] <= 0 || p_T <= 0) {
+      return(Inf)
+    }
+    -(ny[1] *
+      log(p[1]^2 + 2 * p[1] * p[2] + 2 * p[1] * p_T) +
+      ny[2] * log(p[2]^2 + 2 * p[2] * p_T) +
+      ny[3] * log(p_T^2))
+  }
+)$par
+
+z_min <- min(grid$z, na.rm = TRUE)
+levels <- z_min * exp(seq(0, log(5), length.out = 18))
+
+simplex <- data.frame(p_C = c(0, 1, 0), p_I = c(0, 0, 1))
+
+ggplot(grid, aes(p_C, p_I, z = z)) +
+  geom_contour(color = "steelblue", breaks = levels) +
+  geom_polygon(
+    data = simplex,
+    inherit.aes = FALSE,
+    aes(p_C, p_I),
+    fill = NA,
+    color = "black"
+  ) +
+  geom_point(
+    data = data.frame(p_C = p_hat[1], p_I = p_hat[2]),
+    inherit.aes = FALSE,
+    aes(p_C, p_I)
+  ) +
+  coord_equal(xlim = c(0, 1), ylim = c(0, 1)) +
+  labs(x = expression(p[C]), y = expression(p[I]))
+```
+
+<!-- TODO: revisit in ch 22 / 25 — show the softmax reparametrization
+$p_j = e^{\theta_j} / \sum_i e^{\theta_i}$ as the canonical example of an
+unconstrained reformulation that removes the simplex constraint at the cost
+of convexity. A companion contour plot of $-\ell$ in $(\theta_1, \theta_2)$
+makes the non-convexity (curved level sets, ridge through the optimum)
+visible at a glance. Slide draft of the figure exists. -->
+
+We first implement the (negative) log-likelihood in a very problem specific way
+below. The implementation checks if the parameter constraints are fulfilled,
+that is, if $(p_C, p_I, p_T)$ is a probability vector. If the parameters are out
+of bounds the function returns the value $+\infty$. It is fairly standard in
+optimization to encode constraints by letting the function return the value
+$+\infty$ (for minimization) when parameters are out of bounds.
+
+```{r}
+#| label: moth-likelihood
+
 # p = c(p_C, p_I), p_T = 1 - p_C - p_I
 # ny is the data vector of counts of length 3
 neg_loglik_pep <- function(p, ny) {
@@ -582,166 +2004,192 @@ neg_loglik_pep <- function(p, ny) {
 
   out_of_bounds <-
     p[1] > 1 || p[1] < 0 || p[2] > 1 || p[2] < 0 || p_T < 0
-  if (out_of_bounds) return(Inf)
+
+  if (out_of_bounds) {
+    return(Inf)
+  }
 
   p_dark <- p[1]^2 + 2 * p[1] * p[2] + 2 * p[1] * p_T
   p_mott <- p[2]^2 + 2 * p[2] * p_T
   p_light <- p_T^2
+
   # The function returns the negative log-likelihood
-  - (ny[1] * log(p_dark) + ny[2] * log(p_mott) + ny[3] * log(p_light))
+  -(ny[1] * log(p_dark) + ny[2] * log(p_mott) + ny[3] * log(p_light))
 }
 ```
 
-It is possible to use `optim()` in R with just this implementation to 
-compute the maximum-likelihood estimate of the allele parameters. 
+It is possible to use `optim()` in R with just this implementation to compute
+the maximum-likelihood estimate of the allele parameters.
 
-```{r moth-optim, dependson="moth-likelihood"}
+```{r, dependson="moth-likelihood"}
+#| label: moth-optim
+
 optim(c(0.3, 0.3), neg_loglik_pep, ny = c(85, 196, 341))
 ```
 
-The `optim()` function uses an algorithm called [Nelder-Mead](https://en.wikipedia.org/wiki/Nelder–Mead_method) 
-as the default algorithm, which relies on log-likelihood evaluations only. It
-is slow but fairly robust. A bit of thought has to go into the initial 
-parameter choice, though. 
-Starting the algorithm at a boundary value, where the negative log-likelihood attains
-the value $\infty$, does not work. 
+The `optim()` function uses an algorithm called
+[Nelder-Mead](https://en.wikipedia.org/wiki/Nelder–Mead_method) as the default
+algorithm, which relies on log-likelihood evaluations only. It is slow but
+fairly robust. A bit of thought has to go into the initial parameter choice,
+though. Starting the algorithm at a boundary value, where the negative
+log-likelihood attains the value $\infty$, does not work.
 
-```{r  moth-optim-error, error = TRUE, dependson="moth-likelihood"}
+```{r, dependson="moth-likelihood"}
+#| label: moth-optim-error
+#| error: true
+
 optim(c(0, 0), neg_loglik_pep, ny = c(85, 196, 341))
 ```
 
 The computations can beneficially be implemented in greater generality. The R
-function `mult_collapse()` below implements collapsing of categories for  
-multinomial data---the 
-map denoted $M$ in the mathematical formulas. The implementation 
-works by adding up the entries of all
-cells belonging to the same group as specified by the `group` argument.
+function `mult_collapse()` below implements collapsing of categories for\
+multinomial data---the map denoted $M$ in the mathematical formulas. The
+implementation works by adding up the entries of all cells belonging to the same
+group as specified by the `group` argument.
 
-```{r moth-M}
+```{r}
+#| label: moth-M
+
 mult_collapse <- function(ny, group) {
   as.vector(tapply(ny, group, sum))
 }
 ```
 
-The log-likelihood for possibly collapsed data, `loglik_mult()` below,
-is implemented via `mult_collapse()` and two problem specific arguments. 
-One argument, `prob`, is a function that determines the 
-parametrization mapping the parameter that we optimize over to the
-multinomial probability vector. The other argument is a vector specifying 
-the grouping structure of the collapsing. In the implementation it is assumed 
-that the function passed on `prob` encodes parameter constraints 
-by returning `NULL` if parameters are out of bounds. 
+The log-likelihood for possibly collapsed data, `loglik_mult()` below, is
+implemented via `mult_collapse()` and two problem specific arguments. One
+argument, `prob`, is a function that determines the parametrization mapping the
+parameter that we optimize over to the multinomial probability vector. The other
+argument is a vector specifying the grouping structure of the collapsing. In the
+implementation it is assumed that the function passed on `prob` encodes
+parameter constraints by returning `NULL` if parameters are out of bounds.
 
-```{r moth-loglikelihood, dependson=c("moth-M", "moth-prob")}
+```{r, dependson=c("moth-M", "moth-prob")}
+#| label: moth-loglikelihood
+
 neg_loglik_mult <- function(par, ny, prob, group) {
   p <- prob(par)
-  if (is.null(p)) return(Inf)
-  - sum(ny * log(mult_collapse(p, group)))
+
+  if (is.null(p)) {
+    return(Inf)
+  }
+
+  -sum(ny * log(mult_collapse(p, group)))
 }
 ```
 
 The function `prob()` is implemented specifically for the peppered moth example
-as follows. 
+as follows.
 
-```{r moth-prob}
+```{r}
+#| label: moth-prob
+
 prob_pep <- function(p) {
   p[3] <- 1 - p[1] - p[2]
 
   out_of_bounds <-
     p[1] > 1 || p[1] < 0 || p[2] > 1 || p[2] < 0 || p[3] < 0
-  if (out_of_bounds) return(NULL)
 
-  c(p[1]^2, 2 * p[1] * p[2], 2 * p[1] * p[3],
-    p[2]^2, 2 * p[2] * p[3], p[3]^2
-  )
+  if (out_of_bounds) {
+    return(NULL)
+  }
+
+  c(p[1]^2, 2 * p[1] * p[2], 2 * p[1] * p[3], p[2]^2, 2 * p[2] * p[3], p[3]^2)
 }
 ```
 
-We test that the new implementation gives the same maximum-likelihood estimate 
+We test that the new implementation gives the same maximum-likelihood estimate
 as the problem specific implementation above.
 
-```{r moth-optim2, dependson=c("moth-likelihood", "moth-prob", "moth-M")}
-optim(c(0.3, 0.3), neg_loglik_mult,
+```{r, dependson=c("moth-likelihood", "moth-prob", "moth-M")}
+#| label: moth-optim2
+
+optim(
+  c(0.3, 0.3),
+  neg_loglik_mult,
   ny = c(85, 196, 341),
   prob = prob_pep,
   group = c(1, 1, 1, 2, 2, 3)
 )
 ```
 
-Once we have found an estimate of the parameters, we can compute a prediction 
-of the unobserved genotype counts from the phenotype counts, $\mathbf{N}^x$, using 
-the conditional distribution of the genotypes given the phenotypes. 
-This is straightforward as the conditional distribution of $\mathbf{N}_{A_j}^x = (N_k^x)_{k \in A_j}$
-given $N_j = n_j$ is also a multinomial distribution;
+Once we have found an estimate of the parameters, we can compute a prediction of
+the unobserved genotype counts from the phenotype counts, $\mathbf{N}^x$, using
+the conditional distribution of the genotypes given the phenotypes. This is
+straightforward as the conditional distribution of
+$\mathbf{N}_{A_j}^x = (N_k^x)_{k \in A_j}$ given $N_j = n_j$ is also a
+multinomial distribution;
 
 \[
 \mathbf{N}_{A_j}^x \mid N_j = n_j \sim \textrm{Mult}\left( n_j, \frac{p_{A_j}}{M(p)_j} \right).
 \]
 
-The probability parameters are simply $p$ restricted to $A_j$ and renormalized 
+The probability parameters are simply $p$ restricted to $A_j$ and renormalized
 to a probability vector. Observe that this gives
 
 \[
 E (N_k^x \mid N_j = n_j) = \frac{n_j p_k}{M(p)_j}
 \]
 
-for $k \in A_j$. Using the estimated parameters and the `mult_collapse()` function implemented above, we can compute a prediction of the genotype counts as follows.
+for $k \in A_j$. Using the estimated parameters and the `mult_collapse()`
+function implemented above, we can compute a prediction of the genotype counts
+as follows.
 
-```{r moth-predict, dependson=c("moth-M", "moth-prob")}
+```{r, dependson=c("moth-M", "moth-prob")}
+#| label: moth-predict
+
 ny <- c(85, 196, 341)
 group <- c(1, 1, 1, 2, 2, 3)
 p <- prob_pep(c(0.07084643, 0.18871900))
 ny[group] * p / mult_collapse(p, group)[group]
 ```
 
-This is of interest in itself, but computing these conditional expectations
-will also be central for the EM algorithm in Chapter \@ref(em). 
-
+This is of interest in itself, but computing these conditional expectations will
+also be central for the EM algorithm in Chapter \@ref(em).
 
 ## Finite mixture models
 
-A finite mixture model is a model of a pair of random variables $(Y, Z)$
-with $Z \in \{1, \ldots, K\}$, $P(Z = k) = p_k$, and the conditional distribution 
-of $Y$ given $Z = k$ having density $f_k( \cdot \mid \theta_k)$. The joint 
-density is then 
+A finite mixture model is a model of a pair of random variables $(Y, Z)$ with
+$Z \in \{1, \ldots, K\}$, $P(Z = k) = p_k$, and the conditional distribution of
+$Y$ given $Z = k$ having density $f_k( \cdot \mid \theta_k)$. The joint density
+is then
 
 \[
- (y, k) \mapsto f_k(y \mid \theta_k) p_k,
+(y, k) \mapsto f_k(y \mid \theta_k) p_k,
 \]
 
 and the marginal density for the distribution of $Y$ is
 
-\[ 
+\[
 f(y \mid \theta) =  \sum_{k=1}^K f_k(y \mid \theta_k) p_k
 \]
 
-where $\theta$ is the vector of all parameters. We say that the 
-model has $K$ mixture components and call $f_k( \cdot \mid \theta_k)$
-the mixture distributions and $p_k$ the mixture weights. 
+where $\theta$ is the vector of all parameters. We say that the model has $K$
+mixture components and call $f_k( \cdot \mid \theta_k)$ the mixture
+distributions and $p_k$ the mixture weights.
 
-The main usage of mixture models is to situations where $Z$ is not observed. 
-In practice, only $Y$ is observed, and parameter estimation has to be 
-based on the marginal distribution of $Y$ with density $f(\cdot \mid \theta)$,
-which is a weighted sum of the mixture distributions.
+The main usage of mixture models is to situations where $Z$ is not observed. In
+practice, only $Y$ is observed, and parameter estimation has to be based on the
+marginal distribution of $Y$ with density $f(\cdot \mid \theta)$, which is a
+weighted sum of the mixture distributions.
 
-The set of all probability measures on $\{1, \ldots, K\}$ is an exponential 
+The set of all probability measures on $\{1, \ldots, K\}$ is an exponential
 family with sufficient statistic
 
 \[
 \tilde{t}_0(k) = (\delta_{1k}, \delta_{2k}, \ldots, \delta_{(K-1)k}) \in \mathbb{R}^{K-1},
 \]
 
-canonical parameter $\alpha = (\alpha_1, \ldots, \alpha_{K-1}) \in \mathbb{R}^{K-1}$
-and 
+canonical parameter
+$\alpha = (\alpha_1, \ldots, \alpha_{K-1}) \in \mathbb{R}^{K-1}$ and
 
 \[
 p_k = \frac{e^{\alpha_k}}{1 + \sum_{l=1}^{K-1} e^{\alpha_l}}.
 \]
 
 When $f_k$ is an exponential family as well with sufficient statistic
-$\tilde{t}_k : \mathcal{Y} \to \mathbb{R}^{p_k}$ and $\theta_k$ the 
-canonical parameter, we bundle $\alpha, \theta_1, \ldots, \theta_K$ 
-into $\theta$ and define
+$\tilde{t}_k : \mathcal{Y} \to \mathbb{R}^{p_k}$ and $\theta_k$ the canonical
+parameter, we bundle $\alpha, \theta_1, \ldots, \theta_K$ into $\theta$ and
+define
 
 \[
 t_1(y) = \left(\begin{array}{c}
@@ -754,7 +2202,7 @@ t_1(y) = \left(\begin{array}{c}
 \right)
 \]
 
-together with 
+together with
 
 \[
 t_2(y \mid k) = \left(\begin{array}{c}
@@ -768,309 +2216,89 @@ t_2(y \mid k) = \left(\begin{array}{c}
 \]
 
 we see that we have an exponential family of the joint distribution of $(Y, Z)$
-with the $p = K-1 +  p_1 + \ldots + p_K$-dimensional canonical parameter $\theta$,
-with the sufficient statistic $t_1$ determining the marginal distribution of $Z$
-and with the sufficient statistic $t_2$ determining the *conditional* distribution
-of $Y$ given $Z$. We have here made the conditioning variable explicit.
+with the $p = K-1 +  p_1 + \ldots + p_K$-dimensional canonical parameter
+$\theta$, with the sufficient statistic $t_1$ determining the marginal
+distribution of $Z$ and with the sufficient statistic $t_2$ determining the
+*conditional* distribution of $Y$ given $Z$. We have here made the conditioning
+variable explicit.
 
-The marginal density of $Y$ in the exponential family parametrization then 
+The marginal density of $Y$ in the exponential family parametrization then
 becomes
 
 \[
-  f(y \mid \theta) = \sum_{k=1}^K  e^{\theta^T (t_1(k) + t_2(y \mid k)) - \log \varphi_1(\theta) - \log \varphi_2(\theta \mid k)}.
+f(y \mid \theta) = \sum_{k=1}^K  e^{\theta^\top (t_1(k) + t_2(y \mid k)) - \log \varphi_1(\theta) - \log \varphi_2(\theta \mid k)}.
 \]
 
-For small $K$ it is usually unproblematic to implement the computation of 
-the marginal density using the formula above.
-
-### Gaussian mixtures {#Gauss-mix-ex}
-
-A Gaussian mixture model is a mixture model where all the  mixture distributions are  
-Gaussian distributions but potentially with different means and variances. In this 
-section we focus on the simplest Gaussian mixture model with $K = 2$ mixture 
-components. 
-
-When $K = 2$, the Gaussian mixture model is parametrized by the five parameters: 
-the mixture weight $p = \P(Z = 1) \in (0, 1)$, the two means $\mu_1, \mu_2 \in \mathbb{R}$, 
-and the two standard deviations $\sigma_1, \sigma_2 > 0$. First 
-we will simply simulate random variables from this model. 
-
-```{r mixture-gaus-sim}
-sigma1 <- 1
-sigma2 <- 2
-mu1 <- -0.5
-mu2 <- 4
-p <- 0.5
-N <- 5000
-z <- sample(c(TRUE, FALSE), N, replace = TRUE, prob = c(p, 1 - p))
-## Conditional simulation from the mixture components
-y <- numeric(N)
-N1 <- sum(z)
-y[z] <- rnorm(N1, mu1, sigma1)
-y[!z] <- rnorm(N - N1, mu2, sigma2)
-```
-
-The simulation above generated `r N` observations from a two-component
-Gaussian mixture model with mixture distributions $\mathcal{N}(-0.5, 1)$
-and $\mathcal{N}(4, 4)$, and with each component having weight $0.5$. 
-This gives a bimodal distribution as illustrated by the histogram on Figure 
-\@ref(fig:mixture-gaus-histogram). 
-
-```{r mixture-gaus-histogram, dependson="mixture-gaus-sim", fig.cap="Histogram and density estimate (red) of data simulated from a two-component Gaussian mixture distribution. The true mixture distribution has "}
-yy <- seq(-3, 11, 0.1)
-dens <- p * dnorm(yy, mu1, sigma1) + (1 - p) * dnorm(yy, mu2, sigma2)
-ggplot(mapping = aes(y, after_stat(density))) +
-  geom_histogram(bins = 20) +
-  geom_line(aes(yy, dens), color = "blue", size = 1) +
-  stat_density(bw = "sj", geom = "line", color = "red", size = 1)
-```
-
-It is possible to give a mathematically different representation of the 
-marginal distribution of $Y$ that is sometimes useful. Though it gives
-the same marginal distribution from the same components, it does provide a
-different interpretation of what a mixture model is a model of, and it does 
-provide a different way of simulating from a mixture distribution. 
-
-If we let $Y_1 \sim \mathcal{N}(\mu_1, \sigma_1^2)$ and $Y_2 \sim \mathcal{N}(\mu_2, \sigma_2^2)$ 
-be independent, and independent of $Z$, we can define 
-
-\begin{equation}
-Y = 1(Z = 1) Y_1 + 1(Z = 2) Y_2 = Y_{Z}.
-(\#eq:mixturerep)
-\end{equation}
-
-Clearly, the conditional distribution of $Y$ given $Z = k$ is $f_k$.
-From \@ref(eq:mixturerep) it follows directly that
-
-$$
-  E(Y^N) = P(Z = 1) E(Y_1^N) + P(Z = 2) E(Y_2^N) = p m_1(n) + (1 - p) m_2(n)
-$$
-
-where $m_k(n)$ denotes the $N$th non-central moment of the $k$th mixture
-component. In particular,
-
-$$E(Y) = p \mu_1 + (1 - p) \mu_2.$$
-
-The variance can be found from the second moment as
-
-\begin{align}
-V(Y) & = p(\mu_1^2 + \sigma_1^2) + (1-p)(\mu_2^2 + \sigma_2^2) -  (p \mu_1 + (1 - p) \mu_2)^2 \\
-& = p\sigma_1^2 + (1 - p) \sigma_2^2 + p(1-p)(\mu_1^2 + \mu_2^2 - 2 \mu_1 \mu_2).
-\end{align}
-
-While it is certainly possible to derive this formula by other means, using 
-\@ref(eq:mixturerep) gives a simple argument based on 
-elementary properties of expectation and independence
-of $(Y_1, Y_2)$ and $Z$.  
-
-The construction via \@ref(eq:mixturerep) has an interpretation that differs 
-from how a mixture model was defined in the first place. Though $(Y, Z)$ has 
-the correct joint distribution, $Y$ is by \@ref(eq:mixturerep) the result of $Z$ *selecting* one 
-out of two possible observations. The difference is illustrated by 
-the following example. Suppose that we have a population of twins 
-with each pair of twins consisting of a male and a female. 
-We can draw a sample of individuals (ignoring the relations 
-between the twins) from this population and let $Z$ denote the sex and $Y$ the 
-height of the individual. Then $Y$ follows a mixture distribution with two 
-components corresponding to males and females according to the definition. 
-We could then also draw a sample
-of twins, and for each pair of twins flip a coin to decide whether to report
-the male's or the female's height. This corresponds to the construction 
-of $Y$ by \@ref(eq:mixturerep). We get the same marginal mixture 
-distribution of heights though. 
-
-Arguably the heights of two twins are not 
-independent, but this is actually immaterial. Any dependence structure between
-$Y_1$ and $Y_2$ is lost in the transformation  \@ref(eq:mixturerep), and we
-can just as well assume them independent for mathematical convenience. 
-We will not be able to tell the difference from observing only $Y$ (and $Z$) anyway. 
-
-We illustrate below how \@ref(eq:mixturerep) can be used for alternative
-implementations of ways to simulate from the mixture model. We compare empirical 
-means and variances to the theoretical values to test if all the implementations
-actually simulate from the Gaussian mixture model.
-
-```{r sim-gaus-mix, dependson="mixture-gaus-sim"}
-## Mean
-mu <- p * mu1 + (1 - p) * mu2
-
-## Variance
-sigmasq <- p * sigma1^2 + (1 - p) * sigma2^2 +
-  p * (1 - p) * (mu1^2 + mu2^2 - 2 * mu1 * mu2)
-
-## Simulation using the selection formulation via 'ifelse'
-y2 <- ifelse(z, rnorm(n, mu1, sigma1), rnorm(n, mu2, sigma2))
-
-## Yet another way of simulating from a mixture model
-## using arithmetic instead of 'ifelse' for the selection
-## and with Y_1 and Y_2 actually being dependent
-y3 <- rnorm(n)
-y3 <- z * (sigma1 * y3 + mu1) + (!z) * (sigma2 * y3 + mu2)
-
-## Returning to the definition again, this last method simulates conditionally
-## from the mixture components via transformation of an underlying Gaussian
-## variable with me an 0 and variance 1
-y4 <- rnorm(N)
-y4[z] <- sigma1 * y4[z] + mu1
-y4[!z] <- sigma2 * y4[!z] + mu2
-
-## Tests
-data.frame(
-  mean = c(mu, mean(y), mean(y2), mean(y3), mean(y4)),
-  variance = c(sigmasq, var(y), var(y2), var(y3), var(y4)),
-  row.names = c("true", "conditional", "ifelse",
-                "arithmetic", "conditional2")
-)
-```
-
-In terms of runtime there is not a big difference between three of 
-the ways of simulating from a mixture model. A benchmark study (not shown)  
-revealed that the first and third methods are comparable in terms of runtime
-and a bit faster than the fourth, while the second using `ifelse()` takes 
-about twice as long time as the two fastest. This is 
-unsurprising as the `ifelse()` method takes \@ref(eq:mixturerep) very literally 
-and generates twice the number of Gaussian variables actually needed. 
-
-
-```{r mix-sim-bench, eval = FALSE, include=FALSE}
-N <- 10000
-z <- sample(c(TRUE, FALSE), N, replace = TRUE, prob = c(p, 1 - p))
-bench::mark({
-  x <- numeric(N)
-  N1 <- sum(z)
-  x[z] <- rnorm(N1, mu1, sigma1)
-  x[!z] <- rnorm(N - N1, mu2, sigma2)
-},
-x <- ifelse(z, rnorm(N, mu1, sigma1), rnorm(N, mu2, sigma2)),
-{
-  x <- rnorm(N)
-  x <- z * (sigma1 * x + mu1) + (!z) * (sigma2 * x + mu2)
-},
-{
-  x <- rnorm(N)
-  x[z] <- sigma1 * x[z] + mu1
-  x[!z] <- sigma2 * x[!z] + mu2
-},
-  check = FALSE
-)
-```
-
-
-The marginal density of $Y$ is
-
-\[
-f(y) = p \frac{1}{\sqrt{2 \pi \sigma_1^2}} e^{-\frac{(y - \mu_1)^2}{2 \sigma_1^2}} + 
-(1 - p)\frac{1}{\sqrt{2 \pi \sigma_2^2}}e^{-\frac{(y - \mu_2)^2}{2 \sigma_2^2}}
-\]
-
-as given in terms of the parameters $p$, $\mu_1, \mu_2$, $\sigma_1^2$ and $\sigma_2^2$. 
-
-
-Returning to the canonical parameters we see that they are given as 
-follows: 
-
-\[
-\theta_1  = \log \frac{p}{1 - p}, \quad 
-\theta_2  = \frac{\mu_1}{2\sigma_1^2}, \quad
-\theta_3  = \frac{1}{2\sigma_1^2}, \quad
-\theta_4  = \frac{\mu_2}{\sigma_2^2}, \quad
-\theta_5  = \frac{1}{2\sigma_2^2}.
-\]
-
-The joint density in this parametrization then becomes 
-
-\[
-(y,k) \mapsto \left\{ \begin{array}{ll} 
-\exp\left(\theta_1 + \theta_2 y - \theta_3 y^2 - \log (1 + e^{\theta_1}) - \frac{ \theta_2^2}{4\theta_3}+ \frac{1}{2} \log(\theta_3) \right) & \quad \text{if } k = 1 \\
-\exp\left(\theta_4 y - \theta_5 y^2 - \log (1 + e^{\theta_1}) - \frac{\theta_4^2}{4\theta_5} + \frac{1}{2}\log(\theta_5) \right) &  \quad \text{if } k = 2 
-\end{array} \right. 
-\]
-
-and the marginal density for $Y$ is 
-
-\begin{align}
-f(y \mid \theta) & = \exp\left(\theta_1 + \theta_2 y - \theta_3 y^2 - \log (1 + e^{\theta_1}) - \frac{ \theta_2^2}{4\theta_3}+ \frac{1}{2} \log(\theta_3) \right) \\ 
-& + \exp\left(\theta_4 y - \theta_5 y^2 - \log (1 + e^{\theta_1}) - \frac{\theta_4^2}{4\theta_5} + \frac{1}{2}\log(\theta_5) \right).
-\end{align}
-
-There is no apparent benefit to the canonical parametrization when considering
-the marginal density. It is, however, of value when we need the logarithm of 
-the joint density as we will for the EM algorithm. 
+For small $K$ it is usually unproblematic to implement the computation of the
+marginal density using the formula above.
 
 ## Regression models {#regression}
 
-Regression models are models of one variable, called the response,
-conditionally on one or more other variables, called the predictors.
-Typically we use models that assume conditional independence of the responses 
-given the predictors, and a particularly convenient class of regression 
-models is based on exponential families. 
+Regression models describe a *response* variable conditionally on one or more
+*predictors*. Section\ \@ref(parametrization) developed the convex-analysis
+picture in the i.i.d. setting; the regression version is the same picture with a
+predictor-dependent canonical parameter $\theta_i = x_i^\top \beta$, where
+$x_i \in \mathbb{R}^p$ is the predictor vector for the $i$th observation and
+$\beta \in \mathbb{R}^p$ collects the regression coefficients. Stacking the
+$x_i^\top$ as rows produces the $N \times p$ *model matrix* $\mathbf{X}$.
 
-If we let $y_i \in \mathbb{R}$ denote the $i$th response and $x_i \in \mathbb{R}^p$ 
-the $i$th predictor we can consider the exponential family of models with joint density
+We will use Poisson regression as the running example for the algorithms of
+Chapter\ \@ref(numopt). For counts $y_i \in \mathbb{N}_0$ with mean $\mu(x_i)$,
+the log-linear parametrization $\log \mu(x_i) = x_i^\top \beta$ makes $\beta$
+the canonical parameter of an exponential family, so by
+Theorem\ \@ref(thm:canonical-nll-convex) the negative log-likelihood
 
 \[
-f(\mathbf{y} \mid \mathbf{X}, \beta) = \prod_{i=1}^N e^{\theta^T t_i(y_i \mid x_i) - \log \varphi_i(\theta)}
+H(\beta) = \sum_{i=1}^N \left( e^{x_i^\top \beta} - y_i x_i^\top \beta \right)
 \]
 
-for suitably chosen base measures. Here 
+is convex on $\mathbb{R}^p$ (dropping the $\beta$-independent $\log y_i!$
+terms). The data enter only through the sufficient statistic
+$\mathbf{X}^\top \mathbf{y}$, so once that vector has been precomputed each
+evaluation of $H$, $\nabla H$, or $\nabla^2 H$ scales with the parameter
+dimension rather than the sample size. Direct differentiation gives
 
 \[
-\mathbf{X} = \left( \begin{array}{c} x_1^T \\ x_2^T \\ \vdots \\ x_{n-1}^T \\ x_N^T \end{array} \right)
+\nabla H(\beta) = \mathbf{X}^\top \left( e^{\mathbf{X} \beta} - \mathbf{y} \right),
+\qquad
+\nabla^2 H(\beta) = \mathbf{X}^\top \mathbf{W}(\beta)\, \mathbf{X},
 \]
 
-is called the *model matrix* and is an $n \times p$ matrix. 
+where $\mathbf{W}(\beta)$ is the diagonal weight matrix with entries
+$e^{x_i^\top \beta}$. The Hessian is positive semidefinite, and positive
+definite whenever $\mathbf{X}$ has full column rank, so $H$ is strictly convex
+and the MLE is unique under that mild design condition.
 
-::: {.example .boxed #poisson-regression} 
-If $y_i \in \mathbb{N}_0$ are counts we often use a Poisson regression model 
-with point probabilities (density w.r.t. counting measure)
-$$p_i(y_i \mid x_i) = e^{-\mu(x_i)} \frac{\mu(x_i)^{y_i}}{y_i!}.$$
-If the mean depends on the predictors in a log-linear way, $\log(\mu(x_i)) = x_i^T \beta$,
-then 
-$$p_i(y_i \mid x_i) = e^{\beta^T x_i y_i - \exp( x_i^T \beta)} \frac{1}{y_i!}.$$
-The factor $1/y_i!$ can be absorbed into the base measure, and we recognize 
-this Poisson regression model as an exponential family with sufficient statistics
-$$t_i(y_i) = x_i y_i$$
-and 
-$$\log \varphi_i(\beta) =  \exp( x_i^T \beta).$$
+To illustrate the use of a Poisson regression model we consider the following
+dataset from a major Swedish supermarket chain. It contains the number of bags
+of frozen vegetables sold in a given week in a given store under a marketing
+campaign. A predicted number of items sold in a normal week (without a campaign)
+based on historic sales is included. It is of interest to recalibrate this
+number to give a good prediction of the number of items actually sold.\
 
-To implement numerical optimization algorithms for computing the 
-maximum-likelihood estimate we note that 
-$$t(\mathbf{y}) = \sum_{i=1}^N x_i y_i = \mathbf{X}^T \mathbf{y} \quad \text{and} \quad
-\kappa(\beta) = \sum_{i=1}^N e^{x_i^T \beta},$$
-that 
-$$\nabla \kappa(\beta) = \sum_{i=1}^N x_i e^{x_i^T \beta},$$
-and that
-$$D^2 \kappa(\beta) = \sum_{i=1}^N x_i x_i^T e^{x_i^T \beta} = \mathbf{X}^T \mathbf{W}(\beta) \mathbf{X}$$
-where $\mathbf{W}(\beta)$ is a diagonal matrix with $\mathbf{W}(\beta)_{ii} = \exp(x_i^T \beta).$ 
-All these formulas follow directly from the general formulas for exponential 
-families.
-:::
+```{r}
+#| label: vegetables-summary
 
-To illustrate the use of a Poisson regression model we consider 
-the following data set from a major Swedish supermarket chain. It contains
-the number of bags of frozen vegetables sold in a given week in a given store
-under a marketing campaign. A predicted number of items sold in a normal week 
-(without a campaign) based on historic sales is included. It is of interest to 
-recalibrate this number to give a good prediction of the number of items 
-actually sold.  
-
-```{r vegetables-summary}
 summary(CSwR::vegetables)
 ```
 
-It is natural to model the number of sold items using a Poisson regression 
+It is natural to model the number of sold items using a Poisson regression
 model, and we will consider the following simple log-linear model:
 
-$$\log(E(\text{sale} \mid \text{normalSale})) = \beta_0 + \beta_1 \log(\text{normalSale}).$$
+$$
+\log(E(\text{sale} \mid \text{normalSale})) = \beta_0 + \beta_1 \log(\text{normalSale}).
+$$
 
-This is an example of an exponential family regression model as above with 
-a Poisson response distribution. It is a standard regression model that can
-be fitted to data using the `glm` function and using the formula interface 
-to specify how the response should depend on the normal sale. The model is 
-fitted by computing the maximum-likelihood estimate of the two parameters 
-$\beta_0$ and $\beta_1$. 
+This is an example of an exponential family regression model as above with a
+Poisson response distribution. It is a standard regression model that can be
+fitted to data using the `glm()` function and using the formula interface to
+specify how the response should depend on the normal sale. The model is fitted
+by computing the maximum-likelihood estimate of the two parameters $\beta_0$ and
+$\beta_1$.
 
-```{r pois-model-null}
+```{r}
+#| label: pois-model-null
+
 # A Poisson regression model
 pois_model_null <- glm(
   sale ~ log(normalSale),
@@ -1079,28 +2307,36 @@ pois_model_null <- glm(
 )
 ```
 
-```{r pois-sum-null, echo=2, dependson="pois-model-null"}
+```{r, echo=2, dependson="pois-model-null"}
+#| label: pois-sum-null
+
 old_options <- options(digits = 4)
 summary(pois_model_null)
 options(digits = old_options$digits)
 ```
 
-The fitted model of the expected sale as a function of the normal sale, $x$, is    
-$$x \mapsto e^{1.46 + 0.92 \times \log(x)} = (4.31 \times x^{-0.08}) \times x.$$
-This model roughly predicts a four-fold increase of the sale during a 
-campaign, though the effect decays with increasing $x$. If the normal 
-sale is 10 items the factor is $4.31 \times 10^{-0.08} = 3.58$, and if 
-the normal sale is 100 items the factor reduces to $4.31 \times 100^{-0.08} = 2.98$.
+The fitted model of the expected sale as a function of the normal sale, $x$, is\
+$$
+x \mapsto e^{1.46 + 0.92 \times \log(x)} = (4.31 \times x^{-0.08}) \times x.
+$$
+This model roughly predicts a four-fold increase of the sale during a campaign,
+though the effect decays with increasing $x$. If the normal sale is 10 items the
+factor is $4.31 \times 10^{-0.08} = 3.58$, and if the normal sale is 100 items
+the factor reduces to $4.31 \times 100^{-0.08} = 2.98$.
 
-We are not entirely satisfied with this model. It is fitted across all 
-stores in the data set, and it is not obvious that the same effect should 
-apply across all stores. Thus we would like to fit a model of the form
+We are not entirely satisfied with this model. It is fitted across all stores in
+the dataset, and it is not obvious that the same effect should apply across all
+stores. Thus we would like to fit a model of the form
 
-$$\log(E(\text{sale})) = \beta_{\text{store}} + \beta_1 \log(\text{normalSale})$$
+$$
+\log(E(\text{sale})) = \beta_{\text{store}} + \beta_1 \log(\text{normalSale})
+$$
 
-instead. Fortunately, this is also straightforward using `glm`. 
+instead. Fortunately, this is also straightforward using `glm()`.
 
-```{r pois-model, dependson="data"}
+```{r, dependson="data"}
+#| label: pois-model
+
 ## Note, variable store is a factor! The 'intercept' is removed
 ## in the formula to obtain a parametrization as above.
 pois_model <- glm(
@@ -1110,93 +2346,107 @@ pois_model <- glm(
 )
 ```
 
-We will not print all the individual store effects as there are 352
-individual stores. 
+We will not print all the individual store effects as there are 352 individual
+stores.
 
-```{r pois-sum, echo=2, dependson="pois-model"}
+```{r, echo=2, dependson="pois-model"}
+#| label: pois-sum
+
 old_options <- options(digits = 4)
 summary(pois_model)$coefficients[c(1, 2, 3, 4, 353), ]
 options(digits = old_options$digits)
 ```
 
-We should note that the coefficient of $\log(\text{normalSale})$ has 
-changed considerably, and the model is a somewhat different model now 
-for the individual stores. 
+We should note that the coefficient of $\log(\text{normalSale})$ has changed
+considerably, and the model is a somewhat different model now for the individual
+stores.
 
-From a computational viewpoint the most important thing that has changed is
-that the number of parameters has increased a lot. In the first and simple 
-model there are two parameters. In the second model there are 353 parameters. 
+From a computational viewpoint the most important thing that has changed is that
+the number of parameters has increased a lot. In the first and simple model
+there are two parameters. In the second model there are 353 parameters.
 Computing the maximum-likelihood estimate is a considerably more difficult
-problem in the second case. 
+problem in the second case.
 
 ## Mixed models
 
-A mixed model is a regression model of observations that allows for 
-random variation at two different levels. In this section we will 
-focus on mixed models in an exponential family context. Mixed models can be 
-considered in greater generality but there will then be little shared
-structure and one has to deal with the models much more on a case-by-case
-manner.
+A mixed model is a regression model of observations that allows for random
+variation at two different levels. In this section we will focus on mixed models
+in an exponential family context. Mixed models can be considered in greater
+generality but there will then be little shared structure and one has to deal
+with the models much more on a case-by-case manner.
 
-In a mixed model we have observations $y_j \in \mathcal{Y}$
-and $z \in \mathcal{Z}$ such that: 
+In a mixed model we have observations $y_j \in \mathcal{Y}$ and
+$z \in \mathcal{Z}$ such that:
 
-* the distribution of $z$ is an exponential family with canonical parameter
-$\theta_0$ 
-* *conditionally* on $z$ the $y_j$s are independent with a distribution from an exponential
-family with sufficient statistics $t_j( \cdot \mid z)$. 
+- the distribution of $z$ is an exponential family with canonical parameter
+  $\theta_0$
+- *conditionally* on $z$ the $y_j$s are independent with a distribution from an
+  exponential family with sufficient statistics $t_j( \cdot \mid z)$.
 
-This definition emphasizes how the $y_j$s have variation at two levels. 
-There is variation in the underlying $z$, which is the first level of variation 
-(often called the *random effect*), 
-and then there is variation among the $y_j$s given the $z$, which is the 
-second level of variation. It is a special case of hierarchical models
-(Bayesian networks with tree graphs) also known as *multilevel* models, with the 
-mixed model having only two levels. When we observe data from such a model 
-we typically observe independent replications, $(y_{ij})_{j=1, \ldots, m_i}$ 
-for $i = 1, \ldots, n$, of the $y_j$s only. Note that we allow for a different
-number, $m_i$, of $y_j$s for each $i$. 
+This definition emphasizes how the $y_j$s have variation at two levels. There is
+variation in the underlying $z$, which is the first level of variation (often
+called the *random effect*), and then there is variation among the $y_j$s given
+the $z$, which is the second level of variation. It is a special case of
+hierarchical models (Bayesian networks with tree graphs) also known as
+*multilevel* models, with the mixed model having only two levels. When we
+observe data from such a model we typically observe independent replications,
+$(y_{ij})_{j=1, \ldots, m_i}$ for $i = 1, \ldots, n$, of the $y_j$s only. Note
+that we allow for a different number, $m_i$, of $y_j$s for each $i$.
 
-The simplest class of mixed models is obtained by $t_j = t$ not 
-depending on $j$, and 
-$$t(y_j \mid z) = \left(\begin{array}{cc} t_1(y_j) \\ t_2(y_j, z) \end{array} \right)$$
-for some fixed maps $t_1 : \mathcal{Y} \mapsto \mathbb{R}^{p_1}$ and $t_2 : \mathcal{Y} \times \mathcal{Z} \mapsto \mathbb{R}^{p_2}$. 
-This is called a *random effects* model (this is a model where there are no *fixed effects* in
-the sense that $t_j$ does not depend on $j$, and given the random effect 
-$z$ the $y_j$s are i.i.d.). The canonical parameters associated with such a model
-are $\theta_0$ that enters into the distribution of the random effect, 
+The simplest class of mixed models is obtained by $t_j = t$ not depending on
+$j$, and
+
+$$
+t(y_j \mid z) = \left(\begin{array}{cc} t_1(y_j) \\ t_2(y_j, z) \end{array} \right)
+$$
+
+for some fixed maps $t_1 : \mathcal{Y} \mapsto \mathbb{R}^{p_1}$ and
+$t_2 : \mathcal{Y} \times \mathcal{Z} \mapsto \mathbb{R}^{p_2}$. This is called
+a *random effects* model (this is a model where there are no *fixed effects* in
+the sense that $t_j$ does not depend on $j$, and given the random effect $z$ the
+$y_j$s are i.i.d.). The canonical parameters associated with such a model are
+$\theta_0$ that enters into the distribution of the random effect,
 $\theta_1 \in \mathbb{R}^{p_1}$ and $\theta_2 \in \mathbb{R}^{p_2}$ that enter
-into the conditional distribution of $y_j$ given $z$. 
+into the conditional distribution of $y_j$ given $z$.
 
 ::: {.example .boxed #gaussian-mixed}
-The special case of a *Gaussian, linear* random effects model is the model where 
-$z$ is $\mathcal{N}(0, 1)$ distributed, $\mathcal{Y} = \mathbb{R}$ 
-  (with base measure proportional to Lebesgue measure)
-and the sufficient statistic is
-$$t(y_j \mid z) = \left(\begin{array}{cc} y_j \\ - y_j^2 \\ zy_j \end{array}\right).$$
-There are no free parameters in the distribution of $z$. 
+The special case of a *Gaussian, linear* random effects model is the model where
+$z$ is $\mathcal{N}(0, 1)$ distributed, $\mathcal{Y} = \mathbb{R}$ (with base
+measure proportional to Lebesgue measure) and the sufficient statistic is
 
-From Example \@ref(exm:gaussian-exponential)
-it follows that the conditional variance of $y$ given $z$ is 
-$$\sigma^2 = \frac{1}{2\theta_2}$$
-and the conditional mean of $y$ given $z$ is 
-$$\frac{\theta_1 + \theta_3 z}{2 \theta_2} = \sigma^2 \theta_1 + \sigma^2 \theta_3 z.$$
-Reparametrizing in terms of $\sigma^2$, $\beta_0 = \sigma^2 \theta_1$ and 
-$\nu = \sigma^2 \theta_3$ we see how the conditional distribution of $y_j$ 
-given $z$ is $\mathcal{N}(\beta_0 + \nu z, \sigma^2)$. From this it is clear
-how the mixed model of $y_j$ *conditionally on $z$* is a regression model. However,
-we do not observe $z$ in practice. 
+$$
+t(y_j \mid z) = \left(\begin{array}{cc} y_j \\ - y_j^2 \\ zy_j \end{array}\right).
+$$
+There are no free parameters in the distribution of $z$.
 
-Using the above distributional result we can see that
-the Gaussian random effects model of observations $y_{ij}$ can 
-equivalently be stated as 
+From Example\ \@ref(exm:gaussian-canonical) it follows that the conditional
+variance of $y$ given $z$ is
 
-$$Y_{ij} = \beta_0 + \nu Z_i + \varepsilon_{ij}$$
+$$
+\sigma^2 = \frac{1}{2\theta_2}
+$$
 
-for $i = 1, \ldots, n$ and $j = 1, \ldots, m_i$ where 
-$Z_1, \ldots, Z_N$ are i.i.d. $\mathcal{N}(0, 1)$-distributed
-and independent of 
+and the conditional mean of $y$ given $z$ is
+
+$$
+\frac{\theta_1 + \theta_3 z}{2 \theta_2} = \sigma^2 \theta_1 + \sigma^2 \theta_3 z.
+$$
+
+Reparametrizing in terms of $\sigma^2$, $\beta_0 = \sigma^2 \theta_1$ and
+$\nu = \sigma^2 \theta_3$ we see how the conditional distribution of $y_j$ given
+$z$ is $\mathcal{N}(\beta_0 + \nu z, \sigma^2)$. From this it is clear how the
+mixed model of $y_j$ *conditionally on $z$* is a regression model. However, we
+do not observe $z$ in practice.
+
+Using the above distributional result we can see that the Gaussian random
+effects model of observations $y_{ij}$ can equivalently be stated as
+
+$$
+Y_{ij} = \beta_0 + \nu Z_i + \varepsilon_{ij}
+$$
+
+for $i = 1, \ldots, n$ and $j = 1, \ldots, m_i$ where $Z_1, \ldots, Z_N$ are
+i.i.d. $\mathcal{N}(0, 1)$-distributed and independent of
 $\varepsilon_{11}, \varepsilon_{12}, \ldots, \varepsilon_{1n_1}, \ldots, \varepsilon_{mn_m}$
-that are themselves i.i.d. $\mathcal{N}(0, \sigma^2)$-distributed. 
+that are themselves i.i.d. $\mathcal{N}(0, \sigma^2)$-distributed.
 :::
-

--- a/21-Examples.Rmd
+++ b/21-Examples.Rmd
@@ -46,14 +46,14 @@ satisfies all of the constraints, and the set of feasible points is the
 *feasible set* $C$. The *optimal value* of the problem is
 
 \[
-H^\star = \inf \{ H(\theta) : \theta \in C \},
+  H^\star = \inf \{ H(\theta) : \theta \in C \},
 \]
 
 and any feasible point that achieves this value is an *optimal point* or
 *minimizer*, which we denote by \index{argmin}
 
 \[
-\theta^\star \in \argmin_{\theta \in C} H(\theta),
+  \theta^\star \in \argmin_{\theta \in C} H(\theta),
 \]
 
 with the understanding that $\argmin$ is in general a *set*---there may be no
@@ -78,7 +78,7 @@ $\hat{\theta}$ that makes the data most probable. We will see in the next
 section that this is the optimization problem
 
 \[
-\operatorname*{minimize}_{\theta \in \Theta} \left(-\ell(\theta) = -\sum_{i=1}^{N} \log f_\theta(y_i) \right).
+  \operatorname*{minimize}_{\theta \in \Theta} \left(-\ell(\theta) = -\sum_{i = 1}^{N} \log f_\theta(y_i) \right).
 \]
 
 The second is *ordinary least squares*\ (OLS): given a response vector
@@ -87,7 +87,7 @@ $\mathbf{X} \in \mathbb{R}^{N \times p}$, find the coefficient vector $\beta$
 that minimizes the residual sum of squares,
 
 \[
-\operatorname*{minimize}_{\beta \in \mathbb{R}^p} \frac{1}{2}\; \|\mathbf{y} - \mathbf{X} \beta\|_2^2.
+  \operatorname*{minimize}_{\beta \in \mathbb{R}^p} \frac{1}{2}\; \|\mathbf{y} - \mathbf{X} \beta\|_2^2.
 \]
 
 OLS turns out to be a maximum-likelihood problem in disguise. It is the MLE for
@@ -110,14 +110,14 @@ respect to a $\theta$-independent reference measure. In most applications the
 sample space is a product space
 
 \[
-\mathcal{Y} = \mathcal{Y}_1 \times \ldots \times \mathcal{Y}_N
+  \mathcal{Y} = \mathcal{Y}_1 \times \ldots \times \mathcal{Y}_N
 \]
 
 corresponding to observations $y_1, \ldots, y_N$ that we model as independent.
 The joint density then factors into
 
 \[
-f_\theta(y_1, \ldots, y_N) = \prod_{i=1}^N f_{i,\theta}(y_i),
+  f_\theta(y_1, \ldots, y_N) = \prod_{i = 1}^N f_{i,\theta}(y_i),
 \]
 
 although the individual densities $f_{i,\theta}$ may differ, for instance when
@@ -129,13 +129,14 @@ The *likelihood function* for fixed data $y = (y_1, \ldots, y_N)$ is the joint
 density formulated as a function of the parameter, \index{likelihood function}
 
 \[
-\mathcal{L}(\theta) = \prod_{i=1}^N f_{i,\theta}(y_i),
+  \mathcal{L}(\theta) = \prod_{i = 1}^N f_{i,\theta}(y_i),
 \]
 
 and the *log-likelihood* is its logarithm, \index{log-likelihood function}
 
 \[
-\ell(\theta) = \log \mathcal{L}(\theta) = \sum_{i=1}^N \log f_{i,\theta}(y_i).
+  \ell(\theta) = \log \mathcal{L}(\theta)
+               = \sum_{i = 1}^N \log f_{i,\theta}(y_i).
 \]
 
 The *maximum-likelihood estimate* is any $\hat{\theta}$ that maximizes
@@ -143,7 +144,7 @@ $\mathcal{L}$ over $\Theta$. Equivalently, $\hat{\theta}$ minimizes the
 *negative log-likelihood* $-\ell$: \index{maximum-likelihood!estimate}
 
 \[
-\hat{\theta} \in \argmin_{\theta \in \Theta} \, -\ell(\theta).
+  \hat{\theta} \in \argmin_{\theta \in \Theta} \, - \ell(\theta).
 \]
 
 The jump from $\mathcal{L}$ to $-\ell$ is a matter of convenience that does not
@@ -172,15 +173,15 @@ parametrized by the mean parameter $\mu > 0$, with density (with respect to
 counting measure)
 
 \[
-f_\mu(y) = e^{-\mu} \frac{\mu^y}{y!}.
+  f_\mu(y) = e^{-\mu} \frac{\mu^y}{y!}.
 \]
 
 The parameter space is $\Theta = (0, \infty)$. With i.i.d. observations
 $y_1, \ldots, y_N$ the negative log-likelihood is
 
 \[
--\ell(\mu) = \sum_{i=1}^N \left( \mu - y_i \log \mu + \log(y_i!) \right) =
-  N \mu - \log(\mu) \sum_{i=1}^N y_i + \sum_{i=1}^N \log(y_i!).
+  -\ell(\mu) = \sum_{i = 1}^N \left( \mu - y_i \log \mu + \log(y_i!) \right)
+             = N \mu - \log(\mu) \sum_{i = 1}^N y_i + \sum_{i = 1}^N \log(y_i!).
 \]
 
 The final term does not depend on $\mu$ and therefore plays no role in the
@@ -188,13 +189,13 @@ minimization. Differentiating with respect to $\mu$ and setting the result to
 zero gives
 
 \[
-N - \frac{1}{\mu} \sum_{i=1}^N y_i = 0,
+  N - \frac{1}{\mu} \sum_{i = 1}^N y_i = 0,
 \]
 
 so when $\sum_i y_i > 0$, the unique stationary point is
 
 \[
-\hat{\mu} = \frac{1}{N} \sum_{i=1}^N y_i.
+  \hat{\mu} = \frac{1}{N} \sum_{i = 1}^N y_i.
 \]
 
 That the stationary point is the *global* minimizer of $-\ell$, rather than,
@@ -226,14 +227,14 @@ them as a parametric statistical model. The density is
 \index{von Mises distribution!statistical model}
 
 \[
-f_\theta(y) = \frac{1}{\varphi(\theta)} e^{\theta_1 \cos(y) + \theta_2 \sin(y)}
+  f_\theta(y) = \frac{1}{\varphi(\theta)} e^{\theta_1 \cos(y) + \theta_2 \sin(y)}
 \]
 
 for $\theta = (\theta_1, \theta_2) \in \mathbb{R}^2 = \Theta$. The normalizing
 constant
 
 \[
-\varphi(\theta) = \int_{-\pi}^{\pi} e^{\theta_1 \cos(u) + \theta_2 \sin(u)} \, \mathrm{d}u
+  \varphi(\theta) = \int_{-\pi}^{\pi} e^{\theta_1 \cos(u) + \theta_2 \sin(u)} \, \mathrm{d}u
 \]
 
 is finite for every $\theta \in \Theta$ and can be expressed in terms of a
@@ -242,9 +243,9 @@ modified Bessel function, but not in terms of elementary functions.
 With observations $y_1, \ldots, y_N$ the negative log-likelihood becomes
 
 \[
--\ell(\theta) = N \log \varphi(\theta) -
-  \theta_1 \sum_{i=1}^N \cos(y_i) -
-  \theta_2 \sum_{i=1}^N \sin(y_i).
+  -\ell(\theta) = N \log \varphi(\theta)
+                  - \theta_1 \sum_{i = 1}^N \cos(y_i)
+                  - \theta_2 \sum_{i = 1}^N \sin(y_i).
 \]
 
 Unlike the Poisson case, setting the gradient to zero does not lead to a
@@ -288,7 +289,7 @@ $\theta_1, \theta_2 \in C$ and any $\lambda \in [0, 1]$ the line segment between
 them stays inside $C$, that is, \index{convex set}
 
 \[
-\lambda \theta_1 + (1 - \lambda) \theta_2 \in C.
+  \lambda \theta_1 + (1 - \lambda) \theta_2 \in C.
 \]
 
 Affine subspaces, half-spaces, balls, and the probability simplex
@@ -409,8 +410,8 @@ A function $H : C \to \mathbb{R}$ defined on a convex domain $C$ is *convex* if
 \index{convex function}
 
 \[
-H(\lambda \theta_1 + (1 - \lambda) \theta_2) \leq
-  \lambda H(\theta_1) + (1 - \lambda) H(\theta_2)
+  H(\lambda \theta_1 + (1 - \lambda) \theta_2) \leq \lambda H(\theta_1)
+                                                    + (1 - \lambda) H(\theta_2)
 \]
 
 for all $\theta_1, \theta_2 \in C$ and $\lambda \in [0, 1]$. Geometrically, the
@@ -497,7 +498,7 @@ If $H$ is differentiable, convexity has an equivalent first-order
 characterization: $H$ is convex if and only if
 
 \[
-H(\theta_1) \geq H(\theta_2) + \nabla H(\theta_2)^\top (\theta_1 - \theta_2)
+  H(\theta_1) \geq H(\theta_2) + \nabla H(\theta_2)^\top (\theta_1 - \theta_2)
 \]
 
 for all $\theta_1, \theta_2 \in C$. The right-hand side is the first-order
@@ -510,7 +511,9 @@ lower bound on $H$ in terms of purely local first-order information.
 ```{r}
 #| label: convex-tangent
 #| echo: false
-#| fig-cap: "First-order characterization of convexity. The tangent hyperplane (dashed) at any point lies below the graph of a convex function."
+#| fig-cap: >-
+#|   First-order characterization of convexity. The tangent hyperplane (dashed)
+#|   at any point lies below the graph of a convex function.
 #| fig-width: 4.5
 #| fig-height: 2.5
 #| out-width: "70%"
@@ -548,7 +551,7 @@ If $H$ is twice differentiable, there is a still simpler test: $H$ is convex if
 and only if the Hessian is positive semidefinite at every point,
 
 \[
-\nabla^2 H(\theta) \succeq 0 \quad \text{for all } \theta \in C.
+  \nabla^2 H(\theta) \succeq 0 \quad \text{for all } \theta \in C.
 \]
 
 In a single variable this reduces to $H''(\theta) \geq 0$. When the Hessian is
@@ -585,13 +588,13 @@ Example\ \@ref(exm:poisson-mle), the negative log-likelihood on
 $\Theta = (0, \infty)$ is
 
 \[
--\ell(\mu) = N \mu - \log(\mu) \sum_{i=1}^N y_i + \text{const},
+  -\ell(\mu) = N \mu - \log(\mu) \sum_{i = 1}^N y_i + \text{const},
 \]
 
 and its second derivative is
 
 \[
--\ell''(\mu) = \frac{1}{\mu^2} \sum_{i=1}^N y_i.
+  -\ell''(\mu) = \frac{1}{\mu^2} \sum_{i = 1}^N y_i.
 \]
 
 When $\sum_i y_i > 0$, this is strictly positive on all of $(0, \infty)$, so
@@ -608,10 +611,10 @@ The von Mises negative log-likelihood of Example\ \@ref(exm:von-Mises-mle) can
 be written as
 
 \[
--\ell(\theta) = N \log \varphi(\theta) - \theta^\top s,
+  -\ell(\theta) = N \log \varphi(\theta) - \theta^\top s,
 \]
 
-where $s = \sum_{i=1}^N (\cos y_i, \sin y_i)^\top \in \mathbb{R}^2$ is a fixed
+where $s = \sum_{i = 1}^N (\cos y_i, \sin y_i)^\top \in \mathbb{R}^2$ is a fixed
 data summary. The term $-\theta^\top s$ is linear in $\theta$ and therefore
 convex. By the nonnegative-combination rule, $-\ell$ is convex if and only if
 $\log \varphi$ is. Hölder's inequality applied to the integral defining
@@ -619,8 +622,7 @@ $\varphi$ yields, for any $\lambda \in [0, 1]$ and any
 $\theta_a, \theta_b \in \mathbb{R}^2$,
 
 \[
-\varphi(\lambda \theta_a + (1 - \lambda) \theta_b) \leq
-  \varphi(\theta_a)^\lambda \, \varphi(\theta_b)^{1 - \lambda},
+  \varphi(\lambda \theta_a + (1 - \lambda) \theta_b) \leq \varphi(\theta_a)^\lambda \, \varphi(\theta_b)^{1 - \lambda},
 \]
 
 so taking logarithms gives convexity of $\log \varphi$. Hence $-\ell$ is convex
@@ -645,7 +647,7 @@ interior of its domain. For an interior local minimizer $\theta^\star$ of $H$,
 the gradient must vanish, i.e.
 
 \[
-\nabla H(\theta^\star) = 0.
+  \nabla H(\theta^\star) = 0.
 \]
 
 If it did not, then $g(t) = H(\theta^\star - t \nabla H(\theta^\star))$ would
@@ -654,9 +656,10 @@ $g(t) < g(0) = H(\theta^\star)$ for all sufficiently small $t > 0$,
 contradicting that $\theta^\star$ is a local minimum. Points satisfying
 $\nabla H(\theta^\star) = 0$ are called *stationary points*. Stationarity is
 *necessary* but not *sufficient* for a minimum: saddle points and local maxima
-are stationary too. \index{stationary point}
-
-When $H$ is convex, stationarity becomes sufficient and global.
+are stationary too.\index{stationary point} When $H$ is convex, however,
+stationarity becomes sufficient and
+global\ (Theorem\ \@ref(thm:convex-stationary)), and any local minimum is global
+(Theorem\ \@ref(thm:convex-local-global)). The proofs are short and instructive.
 
 ::: {.theorem #convex-stationary}
 Let $H$ be convex and differentiable on an open convex set $C$. Then
@@ -670,8 +673,9 @@ the first-order characterization of convexity from Section\ \@ref(convexity)
 gives, for every $\theta \in C$,
 
 \[
-H(\theta) \geq H(\theta^\star) +
-  \nabla H(\theta^\star)^\top (\theta - \theta^\star) = H(\theta^\star),
+  H(\theta) \geq H(\theta^\star)
+              + \nabla H(\theta^\star)^\top (\theta - \theta^\star)
+            = H(\theta^\star),
 \]
 
 so $\theta^\star$ minimizes $H$ globally over $C$.
@@ -696,8 +700,9 @@ $\theta_\lambda = (1 - \lambda) \theta^\star + \lambda \tilde{\theta}$ for
 $\lambda \in [0, 1]$. Then $\theta_\lambda \in C$ by convexity of $C$, and
 
 \[
-H(\theta_\lambda) \leq
-  (1 - \lambda) H(\theta^\star) + \lambda H(\tilde{\theta}) < H(\theta^\star)
+  H(\theta_\lambda) \leq (1 - \lambda) H(\theta^\star)
+                      + \lambda H(\tilde{\theta})
+                    < H(\theta^\star)
 \]
 
 for every $\lambda \in (0, 1]$ by convexity of $H$. As $\lambda \to 0$, the
@@ -709,7 +714,7 @@ If $H$ is twice continuously differentiable, the Hessian gives better
 information. At an interior local minimum, the second-order necessary condition
 
 \[
-\nabla^2 H(\theta^\star) \succeq 0
+  \nabla^2 H(\theta^\star) \succeq 0
 \]
 
 holds in addition to $\nabla H(\theta^\star) = 0$. Conversely, if
@@ -726,8 +731,8 @@ will then decrease $H$. The general first-order condition is the variational
 inequality
 
 \[
-\nabla H(\theta^\star)^\top (\theta - \theta^\star) \geq 0
-  \quad \text{for all } \theta \in C,
+  \nabla H(\theta^\star)^\top (\theta - \theta^\star)
+    \geq 0 \quad \text{for all } \theta \in C,
 \]
 
 which reduces to $\nabla H(\theta^\star) = 0$ when $\theta^\star$ lies in the
@@ -735,7 +740,7 @@ interior of $C$. We return to constrained problems and their conditions,
 including the more practical formulation in terms of Lagrange multipliers and
 Karush--Kuhn--Tucker\ (KKT) conditions, in Section\ \@ref(constraints).
 
-The two examples below apply Theorem\ \@ref(thm:convex-stationary) to deliver
+The two examples below apply Theorem\ \@ref(thm:convex-stationary) to yield
 closed-form solutions to two of the recurring problems set up in
 Section\ \@ref(opt-problem) and Section\ \@ref(mle-as-opt).
 
@@ -743,13 +748,13 @@ Section\ \@ref(opt-problem) and Section\ \@ref(mle-as-opt).
 The Poisson negative log-likelihood of Example\ \@ref(exm:poisson-mle),
 
 \[
--\ell(\mu) = N \mu - \log(\mu) \sum_{i=1}^N y_i + \text{const},
+  -\ell(\mu) = N \mu - \log(\mu) \sum_{i = 1}^N y_i + \text{const},
 \]
 
 has derivative
 
 \[
--\ell'(\mu) = N - \frac{1}{\mu} \sum_{i=1}^N y_i.
+  -\ell'(\mu) = N - \frac{1}{\mu} \sum_{i = 1}^N y_i.
 \]
 
 When $\sum_i y_i > 0$ the unique stationary point on $(0, \infty)$ is therefore
@@ -805,14 +810,14 @@ ggplot(data.frame(mu = mu_grid, nll), aes(mu, nll)) +
 The OLS objective of Section\ \@ref(opt-problem),
 
 \[
-H(\beta) = \tfrac{1}{2} \|\mathbf{y} - \mathbf{X} \beta\|_2^2,
+  H(\beta) = \tfrac{1}{2} \|\mathbf{y} - \mathbf{X} \beta\|_2^2,
 \]
 
 has gradient and Hessian
 
 \[
-\nabla H(\beta) = -\mathbf{X}^\top (\mathbf{y} - \mathbf{X} \beta), \quad
-\nabla^2 H(\beta) = \mathbf{X}^\top \mathbf{X}.
+  \nabla H(\beta) = -\mathbf{X}^\top (\mathbf{y} - \mathbf{X} \beta), \quad \nabla^2 H(\beta)
+                  = \mathbf{X}^\top \mathbf{X}.
 \]
 
 The Hessian $\mathbf{X}^\top \mathbf{X}$ is positive semidefinite for any
@@ -821,7 +826,7 @@ $\mathbf{X}$ has full column rank, in which case the OLS problem has a unique
 minimizer. Setting $\nabla H(\beta) = 0$ yields the *normal equations*
 
 \[
-\mathbf{X}^\top \mathbf{X} \beta = \mathbf{X}^\top \mathbf{y},
+  \mathbf{X}^\top \mathbf{X} \beta = \mathbf{X}^\top \mathbf{y},
 \]
 
 with closed-form solution
@@ -911,15 +916,14 @@ A parametric family on $\mathcal{Y}$ is a *canonical exponential family* if its
 densities take the form \index{exponential family!canonical}
 
 \[
-f_\theta(y) = \exp\left(\theta^\top t(y) - \log \varphi(\theta) + h(y)\right),
+  f_\theta(y) = \exp\left(\theta^\top t(y) - \log \varphi(\theta) + h(y)\right),
 \]
 
 for a *sufficient statistic* $t : \mathcal{Y} \to \mathbb{R}^d$, a base measure
 factor $h : \mathcal{Y} \to \mathbb{R}$, and the *log-partition function*
 
 \[
-\log \varphi(\theta) = \log \int_\mathcal{Y}
-  \exp\left(\theta^\top t(y) + h(y)\right) \, \mathrm{d}\mu(y),
+  \log \varphi(\theta) = \log \int_\mathcal{Y} \exp\left(\theta^\top t(y) + h(y)\right) \, \mathrm{d}\mu(y),
 \]
 
 with $\mu$ the reference measure. The vector $\theta \in \mathbb{R}^d$ is the
@@ -945,8 +949,7 @@ inequality applied with conjugate exponents $1/\lambda$ and $1/(1 - \lambda)$ to
 the integral defining $\varphi$ gives
 
 \[
-\varphi(\lambda \theta_a + (1 - \lambda) \theta_b) \leq
-  \varphi(\theta_a)^\lambda \, \varphi(\theta_b)^{1 - \lambda},
+  \varphi(\lambda \theta_a + (1 - \lambda) \theta_b) \leq \varphi(\theta_a)^\lambda \, \varphi(\theta_b)^{1 - \lambda},
 \]
 
 and taking logarithms yields the convexity of $\log \varphi$. A side benefit is
@@ -959,11 +962,12 @@ For i.i.d. observations $y_1, \ldots, y_N$ the negative log-likelihood in the
 canonical parameter is
 
 \[
--\ell(\theta) = N \log \varphi(\theta) - \theta^\top s
-  - \sum_{i=1}^N h(y_i),
+  -\ell(\theta) = N \log \varphi(\theta)
+                  - \theta^\top s
+                  - \sum_{i = 1}^N h(y_i),
 \]
 
-where $s = \sum_{i=1}^N t(y_i) \in \mathbb{R}^d$ aggregates the data. The term
+where $s = \sum_{i = 1}^N t(y_i) \in \mathbb{R}^d$ aggregates the data. The term
 $-\theta^\top s$ is linear in $\theta$, the last term does not depend on
 $\theta$, and Theorem\ \@ref(thm:log-partition-convex) makes the remaining piece
 convex.
@@ -1009,7 +1013,7 @@ described by a mean direction $\mu \in (-\pi, \pi]$ and a concentration
 parameter $\kappa \geq 0$, related to the canonical parameters by the polar map
 
 \[
-\theta_1 = \kappa \cos \mu, \quad \theta_2 = \kappa \sin \mu.
+  \theta_1 = \kappa \cos \mu, \quad \theta_2 = \kappa \sin \mu.
 \]
 
 In the $(\kappa, \mu)$ parametrization, the density takes the more interpretable
@@ -1017,8 +1021,8 @@ form $f(y) \propto \exp\!\left(\kappa \cos(y - \mu)\right)$, and the negative
 log-likelihood is
 
 \[
--\ell(\kappa, \mu) = N \log \varphi_0(\kappa)
-  - \kappa \sum_{i=1}^N \cos(y_i - \mu),
+  -\ell(\kappa, \mu) = N \log \varphi_0(\kappa)
+                       - \kappa \sum_{i = 1}^N \cos(y_i - \mu),
 \]
 
 where $\varphi_0(\kappa) = 2\pi I_0(\kappa)$ depends only on $\kappa$ through
@@ -1036,7 +1040,8 @@ Theorem\ \@ref(thm:canonical-nll-convex), and convert back to $(\kappa, \mu)$ at
 the end through
 
 $$
-\kappa = \sqrt{\theta_1^2 + \theta_2^2}\quad \text{and} \quad \mu = \mathrm{atan2}(\theta_2, \theta_1).
+  \kappa = \sqrt{\theta_1^2 + \theta_2^2}\quad \text{and} \quad \mu
+         = \mathrm{atan2}(\theta_2, \theta_1).
 $$
 :::
 
@@ -1046,15 +1051,16 @@ variance $\sigma^2 > 0$ form a canonical exponential family with sufficient
 statistic $t(y) = (y, y^2)^\top$ and canonical parameters
 
 \[
-\theta_1 = \frac{\mu}{\sigma^2}, \quad \theta_2 = -\frac{1}{2 \sigma^2}.
+  \theta_1 = \frac{\mu}{\sigma^2}, \quad \theta_2 = -\frac{1}{2 \sigma^2}.
 \]
 
 The canonical parameter space is $\Theta = \mathbb{R} \times (-\infty, 0)$, and
 the log-partition function evaluates to
 
 \[
-\log \varphi(\theta_1, \theta_2) = -\frac{\theta_1^2}{4 \theta_2}
-  - \frac{1}{2} \log(-2\theta_2) + \frac{1}{2} \log(2\pi).
+  \log \varphi(\theta_1, \theta_2) = -\frac{\theta_1^2}{4 \theta_2}
+                                     - \frac{1}{2} \log(-2\theta_2)
+                                     + \frac{1}{2} \log(2\pi).
 \]
 
 By Theorem\ \@ref(thm:canonical-nll-convex) the negative log-likelihood is
@@ -1063,8 +1069,8 @@ convex in $(\theta_1, \theta_2)$ on $\Theta$.
 In the $(\mu, \sigma^2)$ parametrization, by contrast,
 
 \[
--\ell(\mu, \sigma^2) = \frac{N}{2} \log(2\pi \sigma^2) +
-  \frac{1}{2 \sigma^2} \sum_{i=1}^N (y_i - \mu)^2.
+  -\ell(\mu, \sigma^2) = \frac{N}{2} \log(2\pi \sigma^2)
+                         + \frac{1}{2 \sigma^2} \sum_{i = 1}^N (y_i - \mu)^2.
 \]
 
 Set $\mu = \bar{y}$ and $\hat{\sigma}^2 = N^{-1} \sum_i (y_i - \bar{y})^2$. The
@@ -1073,9 +1079,9 @@ $\sigma^2 = \hat{\sigma}^2$. The second partial derivative with respect to
 $\sigma^2$ at $\mu = \bar{y}$ is
 
 \[
-\frac{\partial^2 (-\ell)}{\partial (\sigma^2)^2} 
-  = -\frac{N}{2 \sigma^4} + \frac{1}{\sigma^6} \sum_{i=1}^N (y_i - \bar{y})^2 
-  = \frac{1}{\sigma^4} \left( \frac{N \hat\sigma^2}{\sigma^2} - \frac{N}{2} \right),
+  \frac{\partial^2 (-\ell)}{\partial (\sigma^2)^2} = -\frac{N}{2 \sigma^4}
+                                                     + \frac{1}{\sigma^6} \sum_{i = 1}^N (y_i - \bar{y})^2
+                                                   = \frac{1}{\sigma^4} \left( \frac{N \hat\sigma^2}{\sigma^2} - \frac{N}{2} \right),
 \]
 
 which is strictly negative whenever $\sigma^2 > 2 \hat{\sigma}^2$. The negative
@@ -1104,7 +1110,7 @@ has *$L$-Lipschitz gradient*, if there exists $L > 0$ such that
 \index{Lipschitz gradient}\index{smoothness}
 
 \[
-\|\nabla H(\theta) - \nabla H(\theta')\|_2 \leq L \|\theta - \theta'\|_2
+  \|\nabla H(\theta) - \nabla H(\theta')\|_2 \leq L \|\theta - \theta'\|_2
 \]
 
 for all $\theta, \theta'$. Figure\ \@ref(fig:lipschitz-cone) gives the cone
@@ -1171,7 +1177,7 @@ When $H$ is twice continuously differentiable this is equivalent to a uniform
 upper bound on the Hessian,
 
 \[
-\nabla^2 H(\theta) \preceq L I \quad \text{for all } \theta,
+  \nabla^2 H(\theta) \preceq L I \quad \text{for all } \theta,
 \]
 
 so $L$ is an upper bound on the largest eigenvalue of $\nabla^2 H$ over the
@@ -1182,24 +1188,24 @@ bound on $H$ itself.
 If $H$ is $L$-smooth, then for all $\theta, \theta' \in \mathbb{R}^p$,
 
 \[
-H(\theta') \leq H(\theta) + \nabla H(\theta)^\top (\theta' - \theta) +
-  \frac{L}{2} \|\theta' - \theta\|_2^2.
+  H(\theta') \leq H(\theta)
+                  + \nabla H(\theta)^\top (\theta' - \theta)
+                  + \frac{L}{2} \|\theta'
+                  - \theta\|_2^2.
 \]
 :::
 
 ::: {.proof .boxed}
 Write
-$H(\theta') - H(\theta) =
-  \int_0^1 \nabla H(\theta + t(\theta' - \theta))^\top (\theta' - \theta)
-  \, \mathrm{d}t$
+$H(\theta') - H(\theta) = \int_0^1 \nabla H(\theta + t(\theta' - \theta))^\top (\theta' - \theta) \, \mathrm{d}t$
 and add and subtract $\nabla H(\theta)^\top (\theta' - \theta)$:
 
 \begin{align*}
-H(\theta') - H(\theta) - \nabla H(\theta)^\top (\theta' - \theta)
-& = \int_0^1 \big(\nabla H(\theta + t(\theta' - \theta)) -
-    \nabla H(\theta)\big)^\top (\theta' - \theta) \, \mathrm{d}t \\
-& \leq \int_0^1 L \, t \, \|\theta' - \theta\|_2^2 \, \mathrm{d}t =
-    \frac{L}{2} \|\theta' - \theta\|_2^2,
+  H(\theta') - H(\theta) - \nabla H(\theta)^\top (\theta' - \theta)
+   & = \int_0^1 \big(\nabla H(\theta + t(\theta' - \theta)) -
+  \nabla H(\theta)\big)^\top (\theta' - \theta) \, \mathrm{d}t \\
+   & \leq \int_0^1 L \, t \, \|\theta' - \theta\|_2^2 \, \mathrm{d}t =
+  \frac{L}{2} \|\theta' - \theta\|_2^2,
 \end{align*}
 
 by the Cauchy-Schwarz inequality and the Lipschitz bound on $\nabla H$.
@@ -1218,14 +1224,16 @@ The matching lower bound is *strong convexity*. A function $H$ is *$m$-strongly
 convex* if there exists $m > 0$ such that \index{strong convexity}
 
 \[
-H(\theta') \geq H(\theta) + \nabla H(\theta)^\top (\theta' - \theta) +
-  \frac{m}{2} \|\theta' - \theta\|_2^2
+  H(\theta') \geq H(\theta)
+                  + \nabla H(\theta)^\top (\theta' - \theta)
+                  + \frac{m}{2} \|\theta'
+                  - \theta\|_2^2
 \]
 
 for all $\theta, \theta'$, or equivalently, for twice differentiable $H$,
 
 \[
-\nabla^2 H(\theta) \succeq m I \quad \text{for all } \theta.
+  \nabla^2 H(\theta) \succeq m I \quad \text{for all } \theta.
 \]
 
 Figure\ \@ref(fig:smoothness-sandwich) puts the two quadratic bounds side by
@@ -1313,33 +1321,35 @@ If $H$ is $m$-strongly convex with minimizer $\theta^\star$, then for all
 $\theta$,
 
 \[
-\frac{m}{2} \|\theta - \theta^\star\|_2^2 \leq H(\theta) - H(\theta^\star) \leq
-  \frac{1}{2m} \|\nabla H(\theta)\|_2^2.
+  \frac{m}{2} \|\theta - \theta^\star\|_2^2 \leq H(\theta) - H(\theta^\star)
+                                            \leq \frac{1}{2m} \|\nabla H(\theta)\|_2^2.
 \]
 :::
 
 ::: {.proof .boxed}
-The left inequality is the strong-convexity bound with $\theta \leftarrow
-\theta^\star$ and $\theta' \leftarrow \theta$, using
+The left inequality is the strong-convexity bound with
+$\theta \leftarrow \theta^\star$ and $\theta' \leftarrow \theta$, using
 $\nabla H(\theta^\star) = 0$. For the right inequality, minimize both sides of
 the strong-convexity bound
 
 \[
-H(\theta') \geq H(\theta) + \nabla H(\theta)^\top (\theta' - \theta) +
-  \frac{m}{2} \|\theta' - \theta\|_2^2
+  H(\theta') \geq H(\theta)
+                  + \nabla H(\theta)^\top (\theta' - \theta)
+                  + \frac{m}{2} \|\theta'
+                  - \theta\|_2^2
 \]
 
-over $\theta'$. The left-hand side attains its minimum at $\theta' =
-\theta^\star$ with value $H(\theta^\star)$; the right-hand side is a quadratic
-in $\theta'$ minimized at $\theta' = \theta - m^{-1} \nabla H(\theta)$ with
-value $H(\theta) - (2m)^{-1} \|\nabla H(\theta)\|_2^2$. Hence
+over $\theta'$. The left-hand side attains its minimum at
+$\theta' = \theta^\star$ with value $H(\theta^\star)$; the right-hand side is a
+quadratic in $\theta'$ minimized at $\theta' = \theta - m^{-1} \nabla H(\theta)$
+with value $H(\theta) - (2m)^{-1} \|\nabla H(\theta)\|_2^2$. Hence
 $H(\theta^\star) \geq H(\theta) - (2m)^{-1} \|\nabla H(\theta)\|_2^2$.
 :::
 
 When $H$ is both $L$-smooth and $m$-strongly convex with $m \leq L$, the ratio
 
 \[
-\kappa = \frac{L}{m} \geq 1
+  \kappa = \frac{L}{m} \geq 1
 \]
 
 is called the *condition number* of $H$. \index{condition number} It measures
@@ -1358,8 +1368,8 @@ $\mathbf{X}^\top \mathbf{X}$ is constant in $\beta$, so the Lipschitz and
 strong-convexity constants are exactly the largest and smallest eigenvalues:
 
 \[
-L = \lambda_{\max}(\mathbf{X}^\top \mathbf{X}), \quad
-m = \lambda_{\min}(\mathbf{X}^\top \mathbf{X}),
+  L = \lambda_{\max}(\mathbf{X}^\top \mathbf{X}), \quad m
+    = \lambda_{\min}(\mathbf{X}^\top \mathbf{X}),
 \]
 
 and the condition number $\kappa = L / m$ equals the squared condition number of
@@ -1521,8 +1531,7 @@ The feasible sets that recur in statistical estimation are simple. The
 *probability simplex* \index{simplex}
 
 \[
-\Delta_K = \left\{ p \in \mathbb{R}^K \mid p_k \geq 0,\,
-  \sum_{k=1}^K p_k = 1 \right\}
+  \Delta_K = \left\{ p \in \mathbb{R}^K \mid p_k \geq 0,\, \sum_{k = 1}^K p_k = 1 \right\}
 \]
 
 arises whenever we estimate a discrete distribution, for instance for
@@ -1550,14 +1559,14 @@ $\nu^\star \in \mathbb{R}^s$ such that
 \index{Karush--Kuhn--Tucker conditions}
 
 \begin{align*}
-& \nabla H(\theta^\star) +
-  \sum_{i=1}^r \lambda_i^\star \nabla g_i(\theta^\star) +
-  \sum_{j=1}^s \nu_j^\star a_j = 0
-&& \text{(stationarity)}, \\
-& g_i(\theta^\star) \leq 0, \quad a_j^\top \theta^\star = b_j
-&& \text{(primal feasibility)}, \\
-& \lambda_i^\star g_i(\theta^\star) = 0
-&& \text{(complementary slackness)}.
+   & \nabla H(\theta^\star) +
+  \sum_{i = 1}^r \lambda_i^\star \nabla g_i(\theta^\star) +
+  \sum_{j = 1}^s \nu_j^\star a_j = 0
+   &                                                             & \text{(stationarity)},            \\
+   & g_i(\theta^\star) \leq 0, \quad a_j^\top \theta^\star = b_j
+   &                                                             & \text{(primal feasibility)},      \\
+   & \lambda_i^\star g_i(\theta^\star) = 0
+   &                                                             & \text{(complementary slackness)}.
 \end{align*}
 :::
 
@@ -1593,10 +1602,7 @@ The multinomial maximum-likelihood problem for observed counts
 $n_1, \ldots, n_K$ from $N = \sum_k n_k$ i.i.d. draws is
 
 \[
-\operatorname*{minimize}_{p \in \mathbb{R}^K}
-  -\sum_{k=1}^K n_k \log p_k
-\quad \text{subject to} \quad
-p_k \geq 0,\, \sum_{k=1}^K p_k = 1.
+  \operatorname*{minimize}_{p \in \mathbb{R}^K} - \sum_{k = 1}^K n_k \log p_k \quad \text{subject to} \quad p_k \geq 0,\, \sum_{k = 1}^K p_k = 1.
 \]
 
 In standard form the objective $-\sum_k n_k \log p_k$ is convex on the positive
@@ -1608,7 +1614,7 @@ When all $n_k > 0$ the MLE lies in the interior, so the inequality multipliers
 vanish by complementary slackness and the KKT stationarity condition reduces to
 
 \[
--\frac{n_k}{p_k^\star} + \nu^\star = 0 \quad \text{for all } k,
+  -\frac{n_k}{p_k^\star} + \nu^\star = 0 \quad \text{for all } k,
 \]
 
 giving $p_k^\star = n_k / \nu^\star$. Summing and using $\sum_k p_k^\star = 1$
@@ -1622,11 +1628,11 @@ The multinomial distribution on $K$ categories is the natural model for
 categorical observations, and its parameter space is the probability simplex
 $\Delta_K$ \index{simplex} introduced in Section\ \@ref(constraints). Given $N$
 i.i.d. observations $y_1, \ldots, y_N \in \{1, \ldots, K\}$ with counts
-$n_k = \sum_{i=1}^N \mathbf{1}(y_i = k)$, the log-likelihood is
+$n_k = \sum_{i = 1}^N \mathbf{1}(y_i = k)$, the log-likelihood is
 \index{log-likelihood function!multinomial distribution}
 
 \[
-\ell(p) = \sum_{k=1}^K n_k \log p_k,
+  \ell(p) = \sum_{k = 1}^K n_k \log p_k,
 \]
 
 with the count vector $\mathbf{N} = (n_1, \ldots, n_K)$ as the sufficient
@@ -1668,13 +1674,13 @@ A collapse of categories is described by a partition
 $A_1 \cup \ldots \cup A_{K_0} = \{1, \ldots, K\}$ and a map
 
 \[
-M : \mathbb{N}_0^K \to \mathbb{N}_0^{K_0}
+  M : \mathbb{N}_0^K \to \mathbb{N}_0^{K_0}
 \]
 
 given by
 
 \[
-M((n_1, \ldots, n_K))_j = \sum_{k \in A_j} n_k.
+  M((n_1, \ldots, n_K))_j = \sum_{k \in A_j} n_k.
 \]
 
 For a single observation $x \in \{1,\ldots,K\}$ the corresponding indicator
@@ -1682,8 +1688,9 @@ vector $t(x) = (\delta_{1x}, \ldots, \delta_{Kx})^\top \in \{0,1\}^K$ collapses
 to
 
 \[
-y = M(t(x)) = \left( \sum_{k \in A_1} \delta_{kx}, \ldots,
- \sum_{k \in A_{K_0}} \delta_{kx} \right) \in \mathbb{N}_0^{K_0},
+  y = M(t(x))
+    = \left( \sum_{k \in A_1} \delta_{kx}, \ldots, \sum_{k \in A_{K_0}} \delta_{kx} \right)
+    \in \mathbb{N}_0^{K_0},
 \]
 
 indicating which of the $K_0$ collapsed categories the observation falls into.
@@ -1692,7 +1699,7 @@ If $\mathbf{N}^x \sim \textrm{Mult}(N, p)$ with $p = (p_1, \ldots, p_K)$ then
 the corresponding tabulation of $y$-values equals
 
 \[
-\mathbf{N} = M(\mathbf{N}^x) \sim \textrm{Mult}(N, M(p)).
+  \mathbf{N} = M(\mathbf{N}^x) \sim \textrm{Mult}(N, M(p)).
 \]
 
 In terms of the parametrization $\psi \mapsto p(\psi)$ of the multinomial
@@ -1700,9 +1707,9 @@ probability vector, and having observed $\mathbf{N} = (n_1, \ldots, n_{K_0})$,
 the log-likelihood under the collapsed multinomial model is generally
 
 \begin{equation}
-\ell(\psi) = \sum_{j = 1}^{K_0} n_j \log (M(p(\psi))_j) = 
-\sum_{j = 1}^{K_0} n_j \log \left(\sum_{k \in A_j} p_k(\psi)\right).
-(\#eq:mult-col-loglik) 
+  \ell(\psi) = \sum_{j = 1}^{K_0} n_j \log (M(p(\psi))_j) =
+  \sum_{j = 1}^{K_0} n_j \log \left(\sum_{k \in A_j} p_k(\psi)\right).
+  (\#eq:mult-col-loglik)
 \end{equation}
 
 ### Peppered Moths {#pep-moth}
@@ -1749,8 +1756,8 @@ principle](https://en.wikipedia.org/wiki/Hardy–Weinberg_principle), the genoty
 frequencies are
 
 \begin{align*}
-  p_{CC} &= p_C^2, \ p_{CI} = 2p_Cp_I, \ p_{CT} = 2p_Cp_T \\
-  p_{II} &=  p_I^2, \ p_{IT} = 2p_Ip_T, \ p_{TT} = p_T^2.
+  p_{CC} & = p_C^2, \ p_{CI} = 2p_Cp_I, \ p_{CT} = 2p_Cp_T \\
+  p_{II} & = p_I^2, \ p_{IT} = 2p_Ip_T, \ p_{TT} = p_T^2.
 \end{align*}
 
 The parametrization in terms of allele frequencies maps out a subset of the full
@@ -1759,10 +1766,10 @@ could observe the genotypes, the multinomial log-likelihood, parametrized by
 allele frequencies, would be
 
 \begin{align*}
- \ell(p_C, p_I) & = 2N_{CC} \log(p_C) + N_{CI} \log (2 p_C p_I) + N_{CT} \log(2 p_C p_T)  \\
-& \ \ + 2 N_{II} \log(p_I) + N_{IT} \log(2p_I p_T) + 2 N_{TT} \log(p_T) \\
-& = 2N_{CC} \log(p_C) + N_{CI} \log (2 p_C p_I) + N_{CT} \log(2 p_C (1 - p_C - p_I))  \\
-& \ \ + 2 N_{II} \log(p_I) + N_{IT} \log(2p_I (1 - p_C - p_I)) + 2 N_{TT} \log(1 - p_C - p_I). 
+  \ell(p_C, p_I) & = 2N_{CC} \log(p_C) + N_{CI} \log (2 p_C p_I) + N_{CT} \log(2 p_C p_T)                       \\
+                 & \ \ + 2 N_{II} \log(p_I) + N_{IT} \log(2p_I p_T) + 2 N_{TT} \log(p_T)                        \\
+                 & = 2N_{CC} \log(p_C) + N_{CI} \log (2 p_C p_I) + N_{CT} \log(2 p_C (1 - p_C - p_I))           \\
+                 & \ \ + 2 N_{II} \log(p_I) + N_{IT} \log(2p_I (1 - p_C - p_I)) + 2 N_{TT} \log(1 - p_C - p_I).
 \end{align*}
 
 The log-likelihood is given in terms of the genotype counts and the two
@@ -1774,8 +1781,9 @@ only identify their phenotype, not their genotype. Thus we observe
 $(N_C, N_T, N_I)$, where
 
 \[
-N = \underbrace{N_{CC} + N_{CI} + N_{CT}}_{= N_C} + 
-\underbrace{N_{IT} + N_{II}}_{=N_I} + \underbrace{N_{TT}}_{=N_T}.
+  N = \underbrace{N_{CC} + N_{CI} + N_{CT}}_{ = N_C}
+      + \underbrace{N_{IT} + N_{II}}_{ = N_I}
+      + \underbrace{N_{TT}}_{ = N_T}.
 \]
 
 For maximum-likelihood estimation of the parameters from the observation
@@ -1786,26 +1794,26 @@ and $K_0 = 3$, corresponding to the three phenotypes. The partition
 corresponding to the phenotypes is
 
 \[
-\{CC, CI, CT\} \cup \{IT, II\} \cup \{TT\} = \{CC, \ldots, TT\},
+  \{CC, CI, CT\} \cup \{IT, II\} \cup \{TT\} = \{CC, \ldots, TT\},
 \]
 
 and
 
 \begin{align*}
-(N_C, N_I, N_T) & = M(N_{CC}, \ldots, N_{TT}) \\
-& = (N_{CC} + N_{CI} + N_{CT}, N_{IT} + N_{II}, N_{TT}).
+  (N_C, N_I, N_T) & = M(N_{CC}, \ldots, N_{TT})                            \\
+                  & = (N_{CC} + N_{CI} + N_{CT}, N_{IT} + N_{II}, N_{TT}).
 \end{align*}
 
 In terms of the $\psi = (p_C, p_I)$-parametrization, $p_T = 1 - p_C - p_I$ and
 
 \[
-p = (p_C^2, 2p_Cp_I, 2p_Cp_T, p_I^2,  2p_Ip_T, p_T^2).
+  p = (p_C^2, 2p_Cp_I, 2p_Cp_T, p_I^2, 2p_Ip_T, p_T^2).
 \]
 
 Hence
 
 \[
-M(p) = (p_C^2 + 2p_Cp_I + 2p_Cp_T, p_I^2 +2p_Ip_T, p_T^2).
+  M(p) = (p_C^2 + 2p_Cp_I + 2p_Cp_T, p_I^2 + 2p_Ip_T, p_T^2).
 \]
 
 Figure\ \@ref(fig:moth-phenotype) shows the partition diagrammatically. The nine
@@ -1905,8 +1913,8 @@ ggplot(
 The log-likelihood equals
 
 \begin{align*}
-\ell(p_C, p_I) & = N_C \log(p_C^2 + 2p_Cp_I + 2p_Cp_T) +
-N_I \log(p_I^2 +2p_Ip_T) + N_T \log (p_T^2).
+  \ell(p_C, p_I) & = N_C \log(p_C^2 + 2p_Cp_I + 2p_Cp_T) +
+  N_I \log(p_I^2 + 2p_Ip_T) + N_T \log (p_T^2).
 \end{align*}
 
 Figure\ \@ref(fig:moth-contour) shows the contours of $-\ell(p_C, p_I)$ on the
@@ -2120,14 +2128,16 @@ $\mathbf{N}_{A_j}^x = (N_k^x)_{k \in A_j}$ given $N_j = n_j$ is also a
 multinomial distribution;
 
 \[
-\mathbf{N}_{A_j}^x \mid N_j = n_j \sim \textrm{Mult}\left( n_j, \frac{p_{A_j}}{M(p)_j} \right).
+  \mathbf{N}_{A_j}^x \mid N_j
+                     = n_j
+                     \sim \textrm{Mult}\left( n_j, \frac{p_{A_j}}{M(p)_j} \right).
 \]
 
 The probability parameters are simply $p$ restricted to $A_j$ and renormalized
 to a probability vector. Observe that this gives
 
 \[
-E (N_k^x \mid N_j = n_j) = \frac{n_j p_k}{M(p)_j}
+  E (N_k^x \mid N_j = n_j) = \frac{n_j p_k}{M(p)_j}
 \]
 
 for $k \in A_j$. Using the estimated parameters and the `mult_collapse()`
@@ -2154,13 +2164,13 @@ $Y$ given $Z = k$ having density $f_k( \cdot \mid \theta_k)$. The joint density
 is then
 
 \[
-(y, k) \mapsto f_k(y \mid \theta_k) p_k,
+  (y, k) \mapsto f_k(y \mid \theta_k) p_k,
 \]
 
 and the marginal density for the distribution of $Y$ is
 
 \[
-f(y \mid \theta) =  \sum_{k=1}^K f_k(y \mid \theta_k) p_k
+  f(y \mid \theta) = \sum_{k = 1}^K f_k(y \mid \theta_k) p_k
 \]
 
 where $\theta$ is the vector of all parameters. We say that the model has $K$
@@ -2176,14 +2186,15 @@ The set of all probability measures on $\{1, \ldots, K\}$ is an exponential
 family with sufficient statistic
 
 \[
-\tilde{t}_0(k) = (\delta_{1k}, \delta_{2k}, \ldots, \delta_{(K-1)k}) \in \mathbb{R}^{K-1},
+  \tilde{t}_0(k) = (\delta_{1k}, \delta_{2k}, \ldots, \delta_{(K - 1)k})
+                 \in \mathbb{R}^{K - 1},
 \]
 
 canonical parameter
-$\alpha = (\alpha_1, \ldots, \alpha_{K-1}) \in \mathbb{R}^{K-1}$ and
+$\alpha = (\alpha_1, \ldots, \alpha_{K - 1}) \in \mathbb{R}^{K - 1}$ and
 
 \[
-p_k = \frac{e^{\alpha_k}}{1 + \sum_{l=1}^{K-1} e^{\alpha_l}}.
+  p_k = \frac{e^{\alpha_k}}{1 + \sum_{l = 1}^{K - 1} e^{\alpha_l}}.
 \]
 
 When $f_k$ is an exponential family as well with sufficient statistic
@@ -2192,31 +2203,17 @@ parameter, we bundle $\alpha, \theta_1, \ldots, \theta_K$ into $\theta$ and
 define
 
 \[
-t_1(y) = \left(\begin{array}{c}
-\tilde{t}_0 \\
-0 \\
-0 \\
-\vdots \\
-0
-\end{array}
-\right)
+  t_1(y) = \left(\begin{array}{c} \tilde{t}_0 \\ 0 \\ 0 \\ \vdots \\ 0 \end{array} \right)
 \]
 
 together with
 
 \[
-t_2(y \mid k) = \left(\begin{array}{c}
-0 \\
-\delta_{1k} \tilde{t}_1(y) \\
-\delta_{2k} \tilde{t}_2(y) \\
-\vdots \\
-\delta_{Kk} \tilde{t}_K(y)
-\end{array}
-\right)
+  t_2(y \mid k) = \left(\begin{array}{c} 0 \\ \delta_{1k} \tilde{t}_1(y) \\ \delta_{2k} \tilde{t}_2(y) \\ \vdots \\ \delta_{Kk} \tilde{t}_K(y) \end{array} \right)
 \]
 
 we see that we have an exponential family of the joint distribution of $(Y, Z)$
-with the $p = K-1 +  p_1 + \ldots + p_K$-dimensional canonical parameter
+with the $p = K - 1 + p_1 + \ldots + p_K$-dimensional canonical parameter
 $\theta$, with the sufficient statistic $t_1$ determining the marginal
 distribution of $Z$ and with the sufficient statistic $t_2$ determining the
 *conditional* distribution of $Y$ given $Z$. We have here made the conditioning
@@ -2226,7 +2223,7 @@ The marginal density of $Y$ in the exponential family parametrization then
 becomes
 
 \[
-f(y \mid \theta) = \sum_{k=1}^K  e^{\theta^\top (t_1(k) + t_2(y \mid k)) - \log \varphi_1(\theta) - \log \varphi_2(\theta \mid k)}.
+  f(y \mid \theta) = \sum_{k = 1}^K e^{\theta^\top (t_1(k) + t_2(y \mid k)) - \log \varphi_1(\theta) - \log \varphi_2(\theta \mid k)}.
 \]
 
 For small $K$ it is usually unproblematic to implement the computation of the
@@ -2249,7 +2246,7 @@ the canonical parameter of an exponential family, so by
 Theorem\ \@ref(thm:canonical-nll-convex) the negative log-likelihood
 
 \[
-H(\beta) = \sum_{i=1}^N \left( e^{x_i^\top \beta} - y_i x_i^\top \beta \right)
+  H(\beta) = \sum_{i = 1}^N \left( e^{x_i^\top \beta} - y_i x_i^\top \beta \right)
 \]
 
 is convex on $\mathbb{R}^p$ (dropping the $\beta$-independent $\log y_i!$
@@ -2259,9 +2256,8 @@ evaluation of $H$, $\nabla H$, or $\nabla^2 H$ scales with the parameter
 dimension rather than the sample size. Direct differentiation gives
 
 \[
-\nabla H(\beta) = \mathbf{X}^\top \left( e^{\mathbf{X} \beta} - \mathbf{y} \right),
-\qquad
-\nabla^2 H(\beta) = \mathbf{X}^\top \mathbf{W}(\beta)\, \mathbf{X},
+  \nabla H(\beta) = \mathbf{X}^\top \left( e^{\mathbf{X} \beta} - \mathbf{y} \right), \qquad \nabla^2 H(\beta)
+                  = \mathbf{X}^\top \mathbf{W}(\beta)\, \mathbf{X},
 \]
 
 where $\mathbf{W}(\beta)$ is the diagonal weight matrix with entries
@@ -2286,7 +2282,8 @@ It is natural to model the number of sold items using a Poisson regression
 model, and we will consider the following simple log-linear model:
 
 $$
-\log(E(\text{sale} \mid \text{normalSale})) = \beta_0 + \beta_1 \log(\text{normalSale}).
+  \log(E(\text{sale} \mid \text{normalSale})) = \beta_0
+                                                + \beta_1 \log(\text{normalSale}).
 $$
 
 This is an example of an exponential family regression model as above with a
@@ -2317,7 +2314,7 @@ options(digits = old_options$digits)
 
 The fitted model of the expected sale as a function of the normal sale, $x$, is\
 $$
-x \mapsto e^{1.46 + 0.92 \times \log(x)} = (4.31 \times x^{-0.08}) \times x.
+  x \mapsto e^{1.46 + 0.92 \times \log(x)} = (4.31 \times x^{-0.08}) \times x.
 $$
 This model roughly predicts a four-fold increase of the sale during a campaign,
 though the effect decays with increasing $x$. If the normal sale is 10 items the
@@ -2329,7 +2326,7 @@ the dataset, and it is not obvious that the same effect should apply across all
 stores. Thus we would like to fit a model of the form
 
 $$
-\log(E(\text{sale})) = \beta_{\text{store}} + \beta_1 \log(\text{normalSale})
+  \log(E(\text{sale})) = \beta_{\text{store}} + \beta_1 \log(\text{normalSale})
 $$
 
 instead. Fortunately, this is also straightforward using `glm()`.
@@ -2390,14 +2387,14 @@ the $z$, which is the second level of variation. It is a special case of
 hierarchical models (Bayesian networks with tree graphs) also known as
 *multilevel* models, with the mixed model having only two levels. When we
 observe data from such a model we typically observe independent replications,
-$(y_{ij})_{j=1, \ldots, m_i}$ for $i = 1, \ldots, n$, of the $y_j$s only. Note
+$(y_{ij})_{j = 1, \ldots, m_i}$ for $i = 1, \ldots, n$, of the $y_j$s only. Note
 that we allow for a different number, $m_i$, of $y_j$s for each $i$.
 
 The simplest class of mixed models is obtained by $t_j = t$ not depending on
 $j$, and
 
 $$
-t(y_j \mid z) = \left(\begin{array}{cc} t_1(y_j) \\ t_2(y_j, z) \end{array} \right)
+  t(y_j \mid z) = \left(\begin{array}{cc} t_1(y_j) \\ t_2(y_j, z) \end{array} \right)
 $$
 
 for some fixed maps $t_1 : \mathcal{Y} \mapsto \mathbb{R}^{p_1}$ and
@@ -2415,7 +2412,7 @@ $z$ is $\mathcal{N}(0, 1)$ distributed, $\mathcal{Y} = \mathbb{R}$ (with base
 measure proportional to Lebesgue measure) and the sufficient statistic is
 
 $$
-t(y_j \mid z) = \left(\begin{array}{cc} y_j \\ - y_j^2 \\ zy_j \end{array}\right).
+  t(y_j \mid z) = \left(\begin{array}{cc} y_j \\-y_j^2 \\ zy_j \end{array}\right).
 $$
 There are no free parameters in the distribution of $z$.
 
@@ -2423,13 +2420,14 @@ From Example\ \@ref(exm:gaussian-canonical) it follows that the conditional
 variance of $y$ given $z$ is
 
 $$
-\sigma^2 = \frac{1}{2\theta_2}
+  \sigma^2 = \frac{1}{2\theta_2}
 $$
 
 and the conditional mean of $y$ given $z$ is
 
 $$
-\frac{\theta_1 + \theta_3 z}{2 \theta_2} = \sigma^2 \theta_1 + \sigma^2 \theta_3 z.
+  \frac{\theta_1 + \theta_3 z}{2 \theta_2} = \sigma^2 \theta_1
+                                             + \sigma^2 \theta_3 z.
 $$
 
 Reparametrizing in terms of $\sigma^2$, $\beta_0 = \sigma^2 \theta_1$ and
@@ -2442,7 +2440,7 @@ Using the above distributional result we can see that the Gaussian random
 effects model of observations $y_{ij}$ can equivalently be stated as
 
 $$
-Y_{ij} = \beta_0 + \nu Z_i + \varepsilon_{ij}
+  Y_{ij} = \beta_0 + \nu Z_i + \varepsilon_{ij}
 $$
 
 for $i = 1, \ldots, n$ and $j = 1, \ldots, m_i$ where $Z_1, \ldots, Z_N$ are

--- a/22-Optimization.Rmd
+++ b/22-Optimization.Rmd
@@ -1,1037 +1,800 @@
 ---
 output: html_document
-editor_options: 
+editor_options:
   chunk_output_type: console
 ---
 
 # Numerical optimization {#numopt}
 
-The main application of numerical optimization in statistics is computation of
-parameter estimates, typically by maximizing the likelihood function or by
-maximizing or minimizing another estimation criterion. The focus of this chapter
-is on optimization algorithms for (penalized) maximum likelihood estimation. Out
-of tradition, we formulate all results and algorithms in terms of minimization
-and not maximization.
+In Chapter\ \@ref(opt-problem), we framed maximum-likelihood and penalized
+estimation as the minimization of $H = -\ell$ or $H = -\ell + J$, where $J$ is a
+penalty that does not depend on the data.
+\index{negative log-likelihood!minimization}\index{penalty function} In this
+chapter, we introduce algorithms for actually computing those minimizers.
+Throughout we assume $H : \Theta \to \mathbb{R}$ is twice continuously
+differentiable on an open set $\Theta \subseteq \mathbb{R}^p$.
 
-The generic optimization problem considered is the minimization of a function 
-$H: \Theta \to \mathbb{R}$ for an open set $\Theta \subseteq \mathbb{R}^p$ and $H$
-twice differentiable. In applications, we might consider $H = -\ell$, the negative
-log-likelihood function, or $H = -\ell + J$, where $J : \Theta \to \mathbb{R}$
-is a *penalty function*, likewise twice differentiable, that does not depend
-upon data.\index{negative log-likelihood!minimization}\index{penalty function}
+When $H$ is convex, every stationary point is a global minimizer
+(Section\ \@ref(opt-conditions)) and the algorithms considered in this section
+produce a certified optimum. When it is not, they produce a local minimizer or
+merely a stationary point. That does not, however, mean that the solutions are
+meaningless. @Kiefer:1978, for instance, showed that the Gaussian-mixture
+likelihood of Section\ \@ref(Gauss-mix-ex) is unbounded above, yet $\nabla
+H(\theta) = 0$ admits a consistent sequence of solutions as $N \to \infty$.
+Convexity is convenient but not essential.
 
-Most statistical optimization problems share a common structure that we 
-should pay attention to. Given data points $y_1, \ldots, y_N$ 
-the negative log-likelihood 
+Throughout the rest of this chapter, two recurrent themes will emerge. First,
+our goal is typically not the minimizer of $H$ for a particular dataset---what
+matters is the statistical estimate it represents. Driving an optimizer to
+machine precision is rarely worth the computational effort when the statistical
+uncertainty of the estimate is orders of magnitude larger, and our budget is
+then better spent exploring many models and starting values and quantifying
+parameter uncertainty. Second, the runtime of every algorithm in this chapter is
+dominated by the cost of evaluating $H$ and its derivatives. For
+exponential-family models, that cost collapses to a one-time
+sufficient-statistic computation (Section\ \@ref(parametrization)), making each
+iteration $O(p)$ rather than $O(Np)$. We will exploit this structure repeatedly.
 
-\[
--\ell(\theta) = - \sum_{i=1}^N \log(f_{\theta}(y_i))
-\]
+## Iterative algorithms
 
-is a sum over the data, and the more data we have, the more computationally demanding 
-it is to evaluate $-\ell$ and its derivatives. There are exceptions, though, 
-when a sufficient statistic can be computed upfront, but generally 
-we must expect runtime to grow with data size. 
-
-We should also note that blindly pursuing the global maximum of the likelihood
-can lead us astray if our model is not well behaved. @Kiefer:1978 demonstrated
-that for the Gaussian mixture model introduced in Section \@ref(Gauss-mix-ex),
-the likelihood (with unknown variance parameters) is unbounded. Yet Kiefer
-showed that for $H = -\ell$ there exists a consistent sequence of solutions to
-the equation $\nabla H(\theta) = 0$ as $N \to \infty$. That is, the unknown
-parameters can be estimated consistently by computing stationary points of
-$H$---even if these do not globally minimize $H$. In situations where $H$ is not
-convex and where $H$ may be unbounded below, it might still be possible to
-compute a good parameter estimate as a local minimizer. So even if we phrase the
-objective as a global optimization problem, we may be equally interested in
-local minima or even just stationary points; solutions to $\nabla H(\theta) =
-0$.
-
-Optimization is a computational technique used in statistics for adapting models to
-data---but the minimizer of $H$ for a particular data set is not intrinsically
-interesting. It is typically unnecessary to compute a (local) minimizer to high
-numerical precision. If the numerical error is already orders of magnitudes
-smaller than the statistical uncertainty of the parameter estimate being
-computed, further optimization makes no relevant difference. Rather than
-computing a single numerically accurate minimizer we should use our
-computational resources to explore many models and many starting values for the
-numerical optimizers, and we should assess the various model fits and
-quantify the model and parameter uncertainties.
-
-For the generic minimization problem considered in this chapter, the practical
-challenge when implementing algorithms in R is typically to implement efficient
-evaluation of $H$ and its derivatives. In particular, efficient evaluations of
-the negative log-likelihood, $-\ell$. Several choices of standard optimization algorithms are possible and
-some are already implemented and available in R. For many practical purposes the
-BFGS-algorithms, as implemented via `optim()`, work well and require only the
-computation of gradients. It is, of course, paramount that $H$ and $\nabla H$
-are correctly implemented, and efficiency of the algorithms is largely
-determined by the efficiency of the implementation of $H$ and $\nabla H$ as well
-as by the choice of parametrization.
-
-## Peppered moths {#pep-moth-descent}
-
-We revisit in this section the peppered moth example from Section \@ref(pep-moth),
-where we implemented the log-likelihood for general multinomial distributions
-with collapsing of categories, and where we 
-computed the maximum-likelihood estimate via 
-`optim()`. We used the default Nelder-Mead algorithm, which does not require 
-derivatives. In this section we implement the gradient as well and 
-illustrate how to optimize a function via `optim()` using the conjugate 
-gradient algorithm and the BFGS-algorithm. 
-
-From the 
-expression for the log-likelihood in \@ref(eq:mult-col-loglik) it follows
-that the gradient equals
+Optimization algorithms are typically *iterative*: from an initial value
+$\theta_0 \in \Theta$ they generate a sequence $\theta_1, \theta_2, \ldots$ via
+a step map $\Phi : \Theta \to \Theta$ with
 
 \[
-\nabla \ell(\theta) = \sum_{j = 1}^{K_0}  \frac{ n_j }{ M(p(\theta))_j}\nabla M(p(\theta))_j = \sum_{j = 1}^{K_0} \sum_{k \in A_j}  \frac{ n_j}{ M(p(\theta))_j} \nabla p_k(\theta).
+\theta_n = \Phi(\theta_{n-1}).
 \]
 
-Letting $j(k)$ be defined by $k \in A_{j(k)}$ we see that the gradient 
-can also be written as
+We hope that $\theta_n \to \theta^\star$ for some minimizer
+$\theta^\star \in \argmin_\theta H(\theta)$. When this happens, continuity of
+$\Phi$ forces $\Phi(\theta^\star) = \theta^\star$, so the limit is a *fixed
+point* of the step map. We thus specify $\Phi$ so that its fixed points are
+exactly the points we want to converge to, typically the stationary points of
+$H$, and then verify that the iterates do converge.
+
+Less than full convergence is often the best we can guarantee. The global
+minimizer may not exist or may not be unique, in which case the limit is defined
+only up to that ambiguity. The iterates may converge only to a *local* minimizer
+rather than the global one. And $\theta_n$ may not converge at all even if
+$H(\theta_n)$ converges to a (local) minimum, as the iterates can wander along a
+flat valley while the function value stabilizes.
+
+Most of the algorithms in this chapter are unified via a common feature: each
+step moves $\theta_n$ in a *descent direction* $\rho_n \in \mathbb{R}^p$ scaled
+by a *step size* $t_n > 0$:
 
 \[
-\nabla \ell(\theta) = \sum_{k=1}^K    \frac{n_{j(k)}}{ M(p(\theta))_{j(k)}} \nabla p_k(\theta) = \tilde{\mathbf{x}}(\theta) \mathrm{D}p(\theta),
+\theta_{n+1} = \theta_n + t_n \rho_n.
 \]
 
-where $\mathrm{D}p(\theta)$ is the Jacobian of the parametrization $\theta \mapsto p(\theta)$,
-and $\tilde{\mathbf{x}}(\theta)$ is the vector with 
- 
+The direction $\rho_n$ is called a descent direction at $\theta_n$ when
+
 \[
-\tilde{\mathbf{x}}(\theta)_k = \frac{ n_{j(k)}}{M(p(\theta))_{j(k)}}.
+\rho_n^\top \nabla H(\theta_n) < 0
 \]
- 
-We first recall the implementation of the general log-likelihood function
-in the multinomial model with cell collapsing before implementing the 
-gradient based on the formula above. The gradient takes the Jacobian
-of the parametrization, $Dp$, as an argument. If the parameters are out of 
-bounds, it returns a vector of `NA`s.
 
-```{r grad-loglik-pep}
-mult_collapse <- function(ny, group) {
-  as.vector(tapply(ny, group, sum))
-}
+whenever $\theta_n$ is not a stationary point. The first-order Taylor expansion
 
-neg_loglik_mult <- function(par, ny, prob, group, ...) {
-  p <- prob(par)
-  if (is.null(p)) return(Inf)
-  - sum(ny * log(mult_collapse(p, group)))
-}
+\[
+H(\theta_n + t \rho_n) = H(\theta_n) + t \rho_n^\top \nabla H(\theta_n) + o(t)
+\]
 
-grad_neg_loglik_mult <- function(par, ny, prob, Dprob, group) {
-  p <- prob(par)
-  if (is.null(p)) return(rep(NA, length(par)))
-  - (ny[group] / mult_collapse(p, group)[group]) %*% Dprob(par)
-}
+then guarantees $H(\theta_n + t \rho_n) < H(\theta_n)$ for sufficiently small
+$t > 0$. The algorithms in this chapter differ in how they choose $\rho_n$ and
+$t_n$. The simplest choice is gradient descent (Section\ \@ref(grad-descent)),
+which moves opposite the gradient, taking $\rho_n = -\nabla H(\theta_n)$.
+Newton's method (Section\ \@ref(Newton)) uses the curvature of $H$ (the Hessian)
+to correct the gradient direction, resulting in
+$\rho_n = -\nabla^2 H(\theta_n)^{-1} \nabla H(\theta_n)$, provided the Hessian
+is positive definite. Quasi-Newton methods replace the Hessian inverse with a
+cheaper surrogate. Step sizes can be fixed, chosen by line search, or obtained
+by minimizing exactly along the ray $t \mapsto H(\theta_n + t \rho_n)$.
+
+A sequence generated this way is called a *descent sequence* if
+
+\[
+H(\theta_0) \geq H(\theta_1) \geq H(\theta_2) \geq \ldots,
+\]
+
+and a *strict* descent sequence if the inequalities are sharp at every
+non-stationary $\theta_n$. The sequence $H(\theta_n)$ converges whenever $H$ is
+bounded below on the level set
+$\mathrm{lev}(\theta_0) = \{\theta \in \Theta \mid H(\theta) \leq H(\theta_0)\}$,
+which holds in particular when that level set is compact. But descent alone does
+not imply convergence to a stationary point---an algorithm can take ever-smaller
+steps and stall short of any minimizer. What we need is *sufficient* descent at
+each step, controlled by a quantitative lower bound on
+$H(\theta_n) - H(\theta_{n+1})$ in terms of the gradient. The rest of the
+chapter is largely devoted to establishing such bounds and deriving convergence
+rates from them.
+
+## Gradient descent {#grad-descent}
+
+Gradient descent is the quintessential first-order optimization algorithm. At
+each iteration we take $\rho_n = -\nabla H(\theta_n)$, the steepest descent
+direction, pick a step size $t_n > 0$, and update our current best guess of
+$\theta$ (Algorithm\ 1).
+
+```{algorithm, gd-basic}
+\begin{algorithm}
+  \caption{Gradient descent}
+  \begin{algorithmic}
+    \Require step size $t > 0$
+    \Repeat
+        \State $\theta \gets \theta - t \nabla H(\theta)$
+    \Until{convergence}
+    \Return $\theta$
+  \end{algorithmic}
+\end{algorithm}
 ```
 
-For the specific example of peppered moths we recall how to implement 
-the parametrization of the multinomial probabilities. 
+Geometrically, the step replaces $\theta_n$ with the point
+$\theta_n - t \nabla H(\theta_n)$ on the parameter axis: a move opposite to the
+local slope, by an amount proportional to its magnitude.
+Figure\ \@ref(fig:gd-step-1d) shows a single step on a one-dimensional convex
+$H$.
 
-```{r prob-pep-reimplement}
-prob_pep <- function(p) {
-  p[3] <- 1 - p[1] - p[2]
+```{r}
+#| label: gd-step-1d
+#| echo: false
+#| fig-width: 5
+#| fig-height: 3
+#| fig-cap: "One step of gradient descent. The tangent at $\\theta_n$ has slope
+#|   $\\nabla H(\\theta_n)$; the update moves $\\theta_n$ by $-t \\nabla H(\\theta_n)$
+#|   along the parameter axis, towards lower $H$."
+#| warning: false
 
-  out_of_bounds <-
-    p[1] > 1 || p[1] < 0 || p[2] > 1 || p[2] < 0 || p[3] < 0
-  if (out_of_bounds) return(NULL)
+f <- function(x) 0.4 * (x - 2)^2 + 0.5
+f_prime <- function(x) 0.8 * (x - 2)
 
-  c(p[1]^2, 2 * p[1] * p[2], 2 * p[1] * p[3],
-    p[2]^2, 2 * p[2] * p[3], p[3]^2
-  )
-}
-```
+theta_n <- -0.5
+t <- 0.6
+theta_n1 <- theta_n - t * f_prime(theta_n)
 
-Finally, we also need to implement the problem 
-specific Jacobian for the peppered moths example. 
+x_grid <- seq(-1.5, 4, length.out = 200)
+curve_df <- data.frame(x = x_grid, y = f(x_grid))
 
-```{r pep-jacobian}
-Dprob_pep <- function(p) {
-  p[3] <- 1 - p[1] - p[2]
-  matrix(
-    c(2 * p[1],             0,
-      2 * p[2],             2 * p[1],
-      2 * p[3] - 2 * p[1], -2 * p[1],
-      0,                    2 * p[2],
-      -2 * p[2],            2 * p[3] - 2 * p[2],
-      -2 * p[3],           -2 * p[3]),
-    ncol = 2, nrow = 6, byrow = TRUE)
-}
-```
-
-We can then use the conjugate gradient algorithm, say, to compute the 
-maximum-likelihood estimate. 
-
-```{r pep-cg,  dependson=c("moth-likelihood", "moth-prob", "moth-M", "grad-loglik-pep", "pep-jacobian")}
-optim(c(0.3, 0.3), neg_loglik_mult, grad_neg_loglik_mult,
-  ny = c(85, 196, 341),
-  prob = prob_pep,
-  Dprob = Dprob_pep,
-  group = c(1, 1, 1, 2, 2, 3),
-  method = "CG"
+tan_x <- c(theta_n - 0.9, theta_n + 0.9)
+tan_df <- data.frame(
+  x = tan_x,
+  y = f(theta_n) + f_prime(theta_n) * (tan_x - theta_n)
 )
-```
 
-NOTE ON THE `...` in the implementation of `neg_loglike_mult()`.
-
-The peppered moth example is very simple. 
-The log-likelihood can easily be computed, and we used this 
-problem to illustrate ways of implementing a 
-likelihood in R and how to use `optim()` to maximize it. 
-
-The first likelihood implementation in Section \@ref(pep-moth) 
-is very problem specific 
-while the second is more abstract and general, and we used the same general and abstract
-approach to implement the gradient above. The gradient could then 
-be used for other optimization algorithms, still using `optim()`, such as 
-conjugate gradient. In fact, we can use conjugate gradient without
-computing and implementing the gradient.
-
-```{r pep-cg-nograd, dependson=c("moth-likelihood", "moth-prob", "moth-M")}
-optim(c(0.3, 0.3), neg_loglik_mult,
-  ny = c(85, 196, 341),
-  prob = prob_pep,
-  group = c(1, 1, 1, 2, 2, 3),
-  method = "CG"
+pts <- data.frame(
+  x = c(theta_n, theta_n1),
+  y = c(f(theta_n), f(theta_n1)),
+  label = c("theta[n]", "theta[n+1]")
 )
+
+ggplot(curve_df, aes(x, y)) +
+  geom_line() +
+  geom_line(data = tan_df, linetype = "dashed", color = "steelblue") +
+  geom_segment(
+    data = pts,
+    aes(x = x, xend = x, y = 0, yend = y),
+    linetype = "dotted"
+  ) +
+  geom_segment(
+    aes(x = theta_n, xend = theta_n1, y = -0.15, yend = -0.15),
+    arrow = arrow(length = unit(0.15, "cm"), type = "closed")
+  ) +
+  annotate(
+    "text",
+    x = (theta_n + theta_n1) / 2,
+    y = -0.4,
+    label = "-t * nabla * H(theta[n])",
+    parse = TRUE
+  ) +
+  geom_point(data = pts) +
+  geom_text(
+    data = pts,
+    aes(label = label),
+    parse = TRUE,
+    nudge_y = 0.3,
+    nudge_x = c(0.15, 0.15)
+  ) +
+  labs(x = expression(theta), y = expression(H(theta))) +
+  coord_cartesian(ylim = c(-0.6, NA)) +
+  theme_schematic()
 ```
 
-If we do not implement a gradient, a numerical gradient is used by `optim()`.
-This can result in a slower algorithm than if the gradient is implemented, but
-more seriously, in can result in convergence problems. This is because there is
-a subtle trade-off between numerical accuracy and accuracy of the finite
-difference approximation used to approximate the gradient. We did not experience
-convergence problems in the example above, but if one encounters such problems 
-a possible solution is to change the `parscale` or `fnscale` entries 
-in the `control` list argument to `optim()`.
-
-Chapter \@ref(em) revisits the peppered moth example and use it to illustrate the
-EM algorithm for computing the maximum-likelihood estimate. It is important to
-understand that the EM algorithm does not rely on the ability to compute the
-(log-)likelihood---or the gradient of the (log-)likelihood for that matter. In
-some applications of the EM algorithm the computation of the likelihood is
-challenging or even impossible, in which case most standard optimization 
-algorithms will not be directly applicable.
-
-## Algorithms and convergence
-
-In the subsequent sections of this chapter we will investigate the implementation 
-of several standard optimization algorithms---including the conjugate gradient 
-algorithm used for the peppered moth example in the previous section. In this section 
-we develop a minimal theoretical framework 
-for presenting and analyzing optimization algorithms and their convergence. 
-This establishes a rudimentary theoretical understanding of sufficient conditions 
-for convergence, but equally importantly it provides us with a precise 
-framework for quantifying and measuring convergence of algorithms in practice. 
-
-A numerical optimization algorithm computes from an initial value 
-$\theta_0 \in \Theta$ a sequence $\theta_1, \theta_2, \ldots \in \Theta$.
-We could hope for 
+But how do we set $t$? If we set it too large, then we risk overshooting the
+target, possibly even diverging. If we set it too small, then we might never
+reach the optimum within our time budget. The answer hinges on the *smoothness*
+of $H$. Recall from Section\ \@ref(smoothness) that $H$ is *$L$-smooth* on
+$\Theta$ when $\nabla^2 H(\theta) \preceq L I$ for all $\theta \in \Theta$, and
+that the descent lemma (Lemma\ \@ref(lem:descent-lemma)) then guarantees
 
 \[
-\theta_n \rightarrow \theta_{\infty} = \argmin_{\theta} H(\theta)
+H(\theta') \leq H(\theta) + \nabla H(\theta)^\top (\theta' - \theta) + \frac{L}{2} \|\theta' - \theta\|_2^2
 \]
 
-for $n \to \infty$, but less can typically be guaranteed. First, 
-the global minimizer may not exist or it may not be unique, in which 
-case the convergence itself is undefined or ambiguous. Second, $\theta_n$
-can in general only be shown to converge to a *local* minimizer if anything. 
-Third, $\theta_n$ may not converge, even if $H(\theta_n)$
-converges to a local minimum. 
-
-To discuss properties of optimization algorithms in greater detail we 
-need ways to quantify, analyze and monitor their convergence. This can be 
-done in terms of $\theta_n$, $H(\theta_n)$ or $\nabla H(\theta_n)$. 
-Focusing on $H(\theta_n)$ we say that an algorithm is a *descent algorithm* if
-
-\[
-  H(\theta_0) \geq H(\theta_1) \geq H(\theta_2) \geq \ldots.
-\]
-
-If all inequalities are sharp (except if some $\theta_i$ is a local minimizer), 
-the algorithm is called a *strict* descent algorithm. The 
-sequence $H(\theta_n)$ is convergent for any descent algorithm if $H$ 
-is bounded from below, e.g., if the *level set*
-
-\[
-  \mathrm{lev}(\theta_0) =  \{\theta \in \Theta \mid H(\theta) \leq H(\theta_0)\}
-\]
-
-is compact. However, even for a strict descent algorithm, 
-$H(\theta_n)$ may descent in smaller and smaller steps toward a limit that is 
-not a (local) minimum. A good optimization algorithm needs to 
-guarantee more than descent---it needs to guarantee *sufficient* descent 
-in each step. 
-
-Many algorithms can be phrased as
-
-\[
-  \theta_n = \Phi(\theta_{n-1})
-\]
-
-for a map $\Phi : \Theta \to \Theta$.
-When $\Phi$ is continuous and $\theta_n \rightarrow \theta_{\infty}$
-it follows that 
-
-\[
-  \Phi(\theta_n) \rightarrow \Phi(\theta_{\infty}).
-\]
-
-Since $\Phi(\theta_n) = \theta_{n+1} \rightarrow \theta_{\infty}$ we see that
-
-\[
-  \Phi(\theta_{\infty}) = \theta_{\infty}.
-\]
-
-That is, $\theta_{\infty}$ is a *fixed point* of $\Phi$. If $\theta_n$ is 
-not convergent, any accumulation point of $\theta_n$ will still be a 
-fixed point of $\Phi$. Thus we can search for potential accumulation 
-points by searching for fixed points of the map $\Phi: \Theta \to \Theta$. 
-
-Mathematics is full of *fixed point theorems* that: i) give conditions under which a map 
-has a fixed point; and ii) in some cases guarantee that the iterates $\Phi^{\circ n}(\theta_0)$
-converge to a fixed point. The most prominent result is [Banach's fixed point 
-theorem](https://en.wikipedia.org/wiki/Banach_fixed-point_theorem). 
-It states that if $\Phi$ is a *contraction*, that is,
-
-\[
-  \| \Phi(\theta) - \Phi(\theta')\| \leq c \|\theta - \theta'\|
-\]
-
-for a constant $c \in [0,1)$ (using any norm), then $\Phi$ has a unique 
-fixed point and $\theta_n = \Phi^{\circ n}(\theta_0)$ converges to that fixed 
-point for any starting point $\theta_0 \in \Theta$. 
-
-We will show how a simple gradient descent algorithm can be 
-analyzed---both as a descent algorithm and through Banach's 
-fixed point theorem. This will demonstrate basic proof techniques as
-well as typical conditions on $H$ that can give convergence results 
-for optimization algorithms. 
-We will only scratch the surface here with the intention that it can motivate
-the algorithms introduced in subsequent sections and chapters as well 
-as empirical techniques for practical assessment of 
-convergence.
-
-Indeed, theory rarely provides us with sharp quantitative results on 
-the rate of convergence and we will need computational techniques to monitor and measure convergence of algorithms in practice. Otherwise we cannot compare 
-the efficiency of different algorithms. 
-
-### Gradient descent {#grad-descent}
-
-We will assume in this section that $\Theta = \mathbb{R}^p$. This will 
-simplify the analysis a bit, but with minor modifications it can 
-be generalized to the case where $\Theta$ is open and convex. 
-
-Suppose that $D^2H(\theta)$ has *numerical radius* uniformly bounded by $L$, that is,
-
-\[
-  |\gamma^T D^2H(\theta) \gamma| \leq L \|\gamma\|_2^2
-\]
-
-for all $\theta \in \Theta$ and $\gamma \in \mathbb{R}^p$. The 
-*gradient descent* algorithm with a fixed step length $1/(L + 1)$ is given by
+for all $\theta, \theta' \in \Theta$. Setting
+$\theta' = \theta - t \nabla H(\theta)$ in this inequality yields
 
 \begin{align}
-\theta_{n} & = \theta_{n-1} - \frac{1}{L + 1} \nabla H(\theta_{n-1}).  (\#eq:grad-descent)
+H(\theta - t \nabla H(\theta)) & \leq H(\theta) - t \left(1 - \frac{tL}{2}\right) \|\nabla H(\theta)\|_2^2.
+(\#eq:gd-descent-bound)
 \end{align}
 
-Fixing $n$ there is by Taylor's theorem a
-$\tilde{\theta} = \alpha \theta_{n} + (1- \alpha)\theta_{n-1}$ (where $\alpha \in [0,1]$) 
-on the line between $\theta_n$ and $\theta_{n-1}$ such that
-
-\begin{align*}
-H(\theta_n) & = H(\theta_{n-1}) - \frac{1}{L+1} \|\nabla H(\theta_{n-1})\|_2^2 +  
- \\  & \qquad \frac{1}{(L+1)^2} \nabla H(\theta_{n-1})^T D^2H(\tilde{\theta}) \nabla H(\theta_{n-1}) \\
-& \leq H(\theta_{n-1}) - \frac{1}{L+1} \|\nabla H(\theta_{n-1})\|_2^2 + 
-   \frac{L}{(L+1)^2} \|\nabla H(\theta_{n-1})\|_2^2 \\
-& = H(\theta_{n-1}) - \frac{1}{(L+1)^2} \|\nabla H(\theta_{n-1})\|_2^2.
-\end{align*}
-  
-This shows that $H(\theta_n) \leq H(\theta_{n-1})$, and if $\theta_{n-1}$ is not a 
-stationary point, $H(\theta_n) < H(\theta_{n-1})$. That is, the algorithm 
-is a descent algorithm, and unless it 
-hits a stationary point it is a strict descent algorithm. 
-
-It furthermore follows that
-
-\begin{align*}
-H(\theta_n) & = 
-(H(\theta_n) - H(\theta_{n-1})) + (H(\theta_{n-1}) - H(\theta_{n-2})) + ... \\
-& \qquad + (H(\theta_1) - H(\theta_0)) + H(\theta_0) \\
-& \leq H(\theta_0) - \frac{1}{(L + 1)^2} \sum_{k=1}^n \|\nabla H(\theta_{k-1})\|_2^2.
-\end{align*}
-
-If $H$ is bounded below, $\sum_{k=1}^{\infty} \|\nabla H(\theta_{k-1})\|_2^2 < \infty$
-and hence
+The right-hand side is minimized over $t > 0$ at $t = 1/L$, where the bound
+collapses to
 
 \[
-  \|\nabla H(\theta_{n})\|_2 \rightarrow 0
+H(\theta - L^{-1} \nabla H(\theta)) \leq H(\theta) - \frac{1}{2L} \|\nabla H(\theta)\|_2^2.
 \]
 
-for $n \to \infty$. For any accumulation point, $\theta_{\infty}$, of 
-the sequence $\theta_n$, it follows by continuity of $\nabla H$ that 
+The gradient descent step we will analyze in this section is correspondingly
+
+\begin{align}
+\theta_{n+1} & = \theta_n - \frac{1}{L} \nabla H(\theta_n).  (\#eq:gd-step)
+\end{align}
+
+Every iteration decreases $H$ by at least
+$(2L)^{-1} \|\nabla H(\theta_n)\|_2^2$, so $(\theta_n)$ is a strict descent
+sequence unless it hits a stationary point. The corresponding step map
 
 \[
-  \nabla H(\theta_{\infty}) = 0,
+\Phi(\theta) = \theta - \frac{1}{L} \nabla H(\theta)
 \]
 
-and $\theta_{\infty}$ is a stationary point. If $H$ has a *unique*
-stationary point in $\mathrm{lev}(\theta_0)$, $\theta_{\infty}$ is a (local) 
-minimizer, and 
+has $\theta$ as a fixed point if and only if $\nabla H(\theta) = 0$, so the
+fixed points of $\Phi$ are exactly the stationary points of $H$. Knowing $L$ in
+advance is rarely realistic in practice, and Section\ \@ref(stop-crit) and the
+line-search material that follows show how a backtracking step size adapts the
+step length without requiring it explicitly.
+
+Figure\ \@ref(fig:gd-step-sizes) illustrates the three regimes on a simple step
+near $1/L$ converges in a handful of iterations; a step approaching the step
+near $1/L$ converges in a handful of iterations; a step approaching the
+stability boundary $2/L$ (where the descent inequality
+\@ref(eq:gd-descent-bound) becomes vacuous) oscillates across the steep
+direction. For $t > 2/L$ the iterates diverge.
+
+```{r}
+#| label: gd-step-sizes
+#| echo: false
+#| fig-width: 7
+#| fig-height: 3
+#| fig-cap: "Gradient descent on $H(\\theta) = (\\theta_1^2 + 4\\theta_2^2)/2$ (so $L = 4$) for three step sizes, starting from $\\theta_0 = (-2.5, 1.5)$. Contours are level sets of $H$; dots are the iterates. A step much smaller than $1/L$ descends slowly; a step near $1/L$ converges efficiently; a step near the stability boundary $2/L = 0.5$ oscillates across the steep direction."
+
+library(patchwork)
+
+A <- diag(c(1, 4))
+grad_H <- function(theta) drop(A %*% theta)
+
+gd_path <- function(t, theta0, n_steps) {
+  path <- matrix(0, n_steps + 1, 2)
+  path[1, ] <- theta0
+  for (i in 1:n_steps) {
+    path[i + 1, ] <- path[i, ] - t * grad_H(path[i, ])
+  }
+  data.frame(theta1 = path[, 1], theta2 = path[, 2])
+}
+
+theta0 <- c(-2.5, 1.5)
+n_steps <- 12
+grid <- expand.grid(
+  theta1 = seq(-3, 1, length.out = 120),
+  theta2 = seq(-2, 2, length.out = 120)
+)
+grid$H <- 0.5 * (grid$theta1^2 + 4 * grid$theta2^2)
+
+make_panel <- function(t, title) {
+  path <- gd_path(t, theta0, n_steps)
+  ggplot(grid, aes(theta1, theta2)) +
+    geom_contour(aes(z = H), color = "grey70", bins = 8) +
+    geom_path(data = path) +
+    geom_point(data = path, size = 1) +
+    labs(
+      title = title,
+      x = expression(theta[1]),
+      y = expression(theta[2])
+    )
+}
+
+make_panel(0.05, "t = 0.05") +
+  make_panel(0.20, "t = 0.20") +
+  make_panel(0.45, "t = 0.45") +
+  plot_layout(axes = "collect")
+```
+
+### Convergence rates
+
+Two convergence-rate results follow from the descent inequality
+\@ref(eq:gd-descent-bound), one assuming only convexity (Theorem
+\@ref(thm:gd-sublinear)) and one assuming strong convexity
+(Theorem\ \@ref(thm:gd-linear)).
+
+::: {.theorem #gd-sublinear}
+Let $H : \mathbb{R}^p \to \mathbb{R}$ be convex and $L$-smooth, and suppose $H$
+attains its minimum at some $\theta^\star$. The gradient descent iterates
+\@ref(eq:gd-step) starting from $\theta_0 \in \mathbb{R}^p$ satisfy
 
 \[
-  \theta_n \rightarrow \theta_{\infty}
+H(\theta_n) - H(\theta^\star) \leq \frac{L \|\theta_0 - \theta^\star\|_2^2}{2n}
 \]
 
-for $n \to \infty$. 
-
-The gradient descent algorithm \@ref(eq:grad-descent) is given 
-by the map 
-
-\[
-  \Phi_{\nabla}(\theta) = \theta - \frac{1}{L + 1} \nabla H(\theta).
-\]
-
-The gradient descent map, $\Phi_{\nabla}$, has $\theta$ as fixed point if and only if  
-
-\[
-  \nabla H(\theta) = 0,
-\]
-
-that is, if and only if $\theta$ is a stationary point. 
-
-We will show that $\Phi_{\nabla}$ is a contraction on $\Theta$
-under the assumption that the eigenvalues of the (symmetric) matrix 
-$D^2H(\theta)$ for all $\theta \in \Theta$ are contained in an interval $[l, L]$ 
-with $0 < l \leq L$. If $\theta, \theta' \in \Theta$ we find 
-by Taylor's theorem that 
-
-\[
-  \nabla H(\theta) = \nabla H(\theta') + D^2H(\tilde{\theta})(\theta - \theta')
-\]
-
-for some $\tilde{\theta}$ on the line between $\theta$ and $\theta'$. 
-For the gradient descent map this gives that
-
-\begin{align*}
-\|\Phi_{\nabla}(\theta) - \Phi_{\nabla}(\theta')\|_2 & = 
-\left\|\theta - \theta' - \frac{1}{L+1}\left(\nabla H(\theta) - \nabla H(\theta')\right)\right\|_2 \\
-& = 
-\left\|\theta - \theta' - \frac{1}{L+1}\left( D^2H(\tilde{\theta})(\theta - \theta')\right)\right\|_2 \\
-& = 
-\left\|\left(I - \frac{1}{L+1} D^2H(\tilde{\theta}) \right) (\theta - \theta')\right\|_2 \\
-& \leq \left(1 - \frac{l}{L + 1}\right) \|\theta - \theta'\|_2,
-\end{align*}
-
-since the eigenvalues of $I - \frac{1}{L+1} D^2H(\tilde{\theta})$ are all between 
-$1 - L/(L + 1)$ and $1 - l/(L+1)$. This shows that $\Phi_{\nabla}$ is a 
-contraction for the $2$-norm with $c = 1 - l/(L + 1) < 1$. From Banach's fixed
-point theorem it follows that there is a unique stationary point, $\theta_{\infty}$,
-and $\theta_n \rightarrow \theta_{\infty}$. Since $D^2H(\theta_{\infty})$ is 
-positive definite, $\theta_{\infty}$ is a (global) minimizer.
-
-To summarize, if $D^2H(\theta)$ has uniformly bounded numerical radius, and if
-$H$ has a unique stationary point $\theta_{\infty}$ in the compact set $\mathrm{lev}(\theta_0)$, then the gradient descent algorithm is a strict descent
-algorithm that converges toward that (local) minimizer $\theta_{\infty}.$
-The fixed step length was key to this analysis. 
-The upper bound on the numerical radius 
-of $D^2H(\theta)$ guarantees descent with a fixed step length, and the
-fixed step length then guarantees sufficient descent.
-
-When the eigenvalues of $D^2H(\theta)$ are in $[l, L]$ for $0 < l \leq L$, 
-$H$ is a *strongly convex function* with a unique global minimizer 
-$\theta_{\infty}$ and all level sets $\mathrm{lev}(\theta_0)$ compact.
-Convergence can then also be established via Banach's fixed point theorem. 
-The constant $c = 1 - l/(L + 1) = 1 - \kappa^{-1}$ with $\kappa = (L + 1) / l$
-then quantifies the rate of the convergence, as will be discussed in greater 
-detail in the next section. The constant $\kappa$ is an upper bound on the
-[conditioning number](https://en.wikipedia.org/wiki/Condition_number#Matrices)
-of the matrix $D^2H(\theta)$ uniformly in $\theta$, and a large value of 
-$\kappa$ means that $c$ is close to 1 and the convergence can be slow. 
-A large conditioning number for the second derivative indicates that the graph 
-of $H$ looks like a narrow ravine, in which case we can expect the 
-gradient descent algorithm to be slow.
-
-### Convergence rate
-
-When $\theta_n = \Phi^{\circ n}(\theta_0)$ for a contraction $\Phi$, 
-Banach's fixed point theorem tells us that there is a unique fixed point 
-$\theta_{\infty}.$ That $\Phi$ is a contraction further implies that  
-
-\[
-  \|\theta_n - \theta_{\infty}\| = \|\Phi(\theta_{n-1}) - \theta_{\infty}\| \leq c \|\theta_{n-1} - \theta_{\infty}\| \leq c^n \|\theta_0 - \theta_{\infty}\|.
-\]
-
-That is, $\|\theta_n - \theta_{\infty}\| \to 0$ with at least geometric rate $c < 1$. 
-
-In the numerical optimization literature, convergence at a geometric rate is 
-known as linear convergence (the number of correct digits increases linearly 
-with the number of iterations), and a linearly convergent algorithm is often 
-quantified in terms of its asymptotic convergence rate. 
-
-::: {.definition #order-rate}
-Let $(\theta_n)_{n \geq 1}$ be a convergent sequence in $\mathbb{R}^p$ with 
-limit $\theta_{\infty}$. Let $\| \cdot \|$ be a norm on $\mathbb{R}^p$. We say 
-that the convergence is linear if 
-
-\[
-  \limsup_{n \to \infty} \frac{\|\theta_{n} - \theta_{\infty}\|}{\|\theta_{n-1} - \theta_{\infty}\|} = r
-\]
-
-for some $r \in (0, 1)$, in which case $r$ is called the asymptotic rate.
-:::
-
-
-Convergence of an algorithm can be faster or slower than linear. If      
-
-\[
-  \limsup_{n \to \infty} \frac{\|\theta_{n} - \theta_{\infty}\|}{\|\theta_{n-1} - \theta_{\infty}\|} = 1
-\]
-
-we say that the convergence is sublinear, and if 
-
-\[
-  \limsup_{n \to \infty} \frac{\|\theta_{n} - \theta_{\infty}\|}{\|\theta_{n-1} - \theta_{\infty}\|} = 0
-\]
-
-we say that the convergence is superlinear. There is also a refined 
-notion of convergence order for superlinearly convergent algorithms
-that more precisely describes the convergence. 
-
-For a contraction, $\theta_n = \Phi^{\circ n}(\theta_0)$ converges linearly 
-or superlinearly. If it converges linearly, the asymptotic rate is bounded by 
-$c$, but this is a global constant and may be pessimistic. The following 
-lemma provides a local upper bound on the asymptotic rate in terms of 
-the derivative of $\Phi$ in the limit $\theta_{\infty}$. 
-
-::: {.lemma #fixed-point-rate} 
-Let $\Phi : \mathbb{R}^p \to \mathbb{R}^p$ be twice continuously differentiable. If 
-$\theta_n = \Phi^{\circ n}(\theta_0)$ converges linearly toward a fixed point $\theta_{\infty}$ 
-of $\Phi$ then 
-
-\[
-  r_{\max} = \sup_{\gamma: \|\gamma \| = 1} \|D \Phi(\theta_{\infty}) \gamma\|
-\]
-
-is an upper bound on the asymptotic rate.
+for every $n \geq 1$.
 :::
 
 ::: {.proof .boxed}
-By Taylor's theorem, 
+Apply \@ref(eq:gd-descent-bound) at $\theta = \theta_i$ with $t = 1/L$ to get
+
+\[
+H(\theta_{i+1}) \leq H(\theta_i) - \frac{1}{2L} \|\nabla H(\theta_i)\|_2^2.
+\]
+
+By the first-order characterization of convexity (Section\ \@ref(convexity)),
+
+$$
+H(\theta^\star) \geq H(\theta_i) + \nabla H(\theta_i)^\top (\theta^\star - \theta_i),
+$$
+
+so
+
+$$
+H(\theta_i) - H(\theta^\star) \leq \nabla H(\theta_i)^\top (\theta_i - \theta^\star).
+$$
+
+Combining with the previous display,
 
 \begin{align*}
-\theta_{n} = \theta_{\infty} + D \Phi(\theta_{\infty})(\theta_{n-1} - \theta_{\infty}) +
-o(\|\theta_{n-1} - \theta_{\infty}\|_2).
+  H(\theta_{i+1}) - H(\theta^\star) & \leq \nabla H(\theta_i)^\top (\theta_i - \theta^\star) - \frac{1}{2L} \|\nabla H(\theta_i)\|_2^2 \\
+  & = \frac{L}{2} \left( \|\theta_i - \theta^\star\|_2^2 - \|\theta_i - \theta^\star - L^{-1} \nabla H(\theta_i)\|_2^2 \right) \\
+  & = \frac{L}{2} \left( \|\theta_i - \theta^\star\|_2^2 - \|\theta_{i+1} - \theta^\star\|_2^2 \right),
 \end{align*}
 
-Rearranging yields
+where the second line completes the square. Summing from $i = 0$ to $n - 1$
+gives us
+
+\[
+\sum_{i=0}^{n-1} \left( H(\theta_{i+1}) - H(\theta^\star) \right) \leq \frac{L}{2} \|\theta_0 - \theta^\star\|_2^2.
+\]
+
+The descent property ensures $H(\theta_n) - H(\theta^\star)$ is decreasing in
+$n$, so the left-hand side is at least $n (H(\theta_n) - H(\theta^\star))$.
+:::
+
+The suboptimality $H(\theta_n) - H(\theta^\star)$ thus decays like $1/n$. This
+is *sublinear* convergence: the number of correct digits in $H(\theta_n)$ grows
+like $\log n$. Doubling the accuracy requires doubling the iteration count, a
+slow rate when many digits are needed, but one that places remarkably weak
+demands on $H$ (just convexity and smoothness).
+
+Adding strong convexity sharpens the picture dramatically. If $H$ is
+$m$-strongly convex in addition to $L$-smooth, then
+Lemma\ \@ref(lem:strong-convex-suboptimality) gives the two-sided bound
+
+\[
+\frac{m}{2} \|\theta - \theta^\star\|_2^2 \leq H(\theta) - H(\theta^\star) \leq \frac{1}{2m} \|\nabla H(\theta)\|_2^2.
+\]
+
+The right inequality says that suboptimality is controlled by gradient norm,
+which combines with the per-step decrease of
+$(2L)^{-1} \|\nabla H(\theta_n)\|_2^2$ to yield a *contraction* in
+suboptimality.
+
+::: {.theorem #gd-linear}
+Let $H : \mathbb{R}^p \to \mathbb{R}$ be $m$-strongly convex and $L$-smooth with
+$0 < m \leq L$, and let $\theta^\star$ be its unique minimizer. The gradient
+descent iterates \@ref(eq:gd-step) satisfy
+
+\[
+H(\theta_{n+1}) - H(\theta^\star) \leq \left( 1 - \frac{m}{L} \right) \left( H(\theta_n) - H(\theta^\star) \right),
+\]
+
+and therefore
+
+\[
+H(\theta_n) - H(\theta^\star) \leq \left( 1 - \frac{1}{\kappa} \right)^n \left( H(\theta_0) - H(\theta^\star) \right),
+\]
+
+where $\kappa = L/m$ is the condition number from Section\ \@ref(smoothness).
+:::
+
+::: {.proof .boxed}
+The strong-convexity bound rearranges to
+
+$$
+\|\nabla H(\theta_n)\|_2^2 \geq 2m (H(\theta_n) - H(\theta^\star)).
+$$
+
+Substituting into the per-step decrease,
 
 \begin{align*}
-\limsup_{n \to \infty} 
-\frac{\| \theta_{n} - \theta_{\infty}\|}{\| \theta_{n-1} - \theta_{\infty}\|} 
-& = \limsup_{n \to \infty} 
-\frac{\| D \Phi(\theta_{\infty})(\theta_{n-1} - \theta_{\infty})\|}{\| \theta_{n-1} - \theta_{\infty}\|} \\
-& = \limsup_{n \to \infty} 
-\| D \Phi(\theta_{\infty})\left(\frac{\theta_{n-1} - \theta_{\infty}}{\| \theta_{n-1} - \theta_{\infty}\|} \right)\| \\
-& \leq r_{\max}.
-\end{align*}
-:::
-
-Note that it is possible that $r_{\max} \geq 1$ even if the convergence is linear, 
-in which case $r_{\max}$ is a useless upper bound. Moreover, the actual rate 
-can depend on the starting point $\theta_0$, and even when $r_{\max} < 1$ it 
-only quantifies the worst case convergence rate. 
-
-To estimate the actual convergence rate, note that linear 
-convergence with rate $r$ implies that for any $\delta > 0$
-
-\[
-\| \theta_n - \theta_{\infty} \| \leq (r + \delta) \| \theta_{n-1} - \theta_{\infty} \| \leq \ldots 
-\leq (r + \delta)^{n - n_0} \| \theta_{n_0} - \theta_{\infty} \|
-\]
-
-$n \geq n_0$ with $n_0$ sufficiently large (depending on $\delta$). That is, 
-
-\[
-  \log \|\theta_{n} - \theta_{\infty}\| \leq n \log(r + \delta) + d,
-\]
-
-for $n \geq n_0$. In practice, we run the algorithm for $M$ 
-iterations, so that $\theta_M = \theta_{\infty}$ up to computer precision, 
-and we plot $\log \|\theta_{n} - \theta_{M}\|$ as a function of $n$. 
-The decay should be approximately linear for $n \geq n_0$ for some $n_0$, in 
-which case the slope is about $\log(r) < 0$, which can then be estimated by least squares. 
-A slower-than-linear or faster-than-linear decay indicate that the 
-algorithm converges sublinearly or superlinearly, respectively.
-
-It is, of course, possible to quantify convergence 
-in terms of the sequences $H(\theta_n)$ and $\nabla H(\theta_n)$ instead.
-For a descent algorithm with $H(\theta_n) \rightarrow H(\theta_\infty)$ linearly for 
-$n \to \infty$, we can plot 
-
-\[
-  \log(H(\theta_n) - H(\theta_M))
-\]
-
-as a function of $n$, and use least squares to estimate the asymptotic rate of 
-convergence of $H(\theta_n)$.
-
-Using $\nabla H(\theta_n)$ to quantify convergence is particularly appealing 
-as we know that the limit is $0$. This also means that we can monitor 
-its convergence while the algorithm is running and not only after it has 
-converged. If $\nabla H(\theta_n)$ converges linearly in the norm $\|\cdot\|$, that is,
-
-\[
-  \limsup_{n \to \infty} \frac{\|\nabla H(\theta_n)\|}{\|\nabla H(\theta_{n-1})\|} = r,
-\]
-
-we have for any $\delta > 0$ that 
-
-\[
-  \log \|\nabla H(\theta_n)\| \leq n \log(r + \delta) + d
-\]
-
-for $n \geq n_0$ and $n_0$ sufficiently large. Again, least squares
-can be used to estimate the asymptotic rate of convergence of 
-$\|\nabla H(\theta_n)\|$. 
-
-The concepts of linear convergence and asymptotic rate are, unfortunately, not 
-independent of the norm used, nor does linear convergence of $\theta_n$ in $\|\cdot\|$
-imply linear convergence of $H(\theta_n)$ or $\|\nabla H(\theta_n)\|$. 
-We can show, though, that if $\theta_n$ converges linearly in the norm $\| \cdot \|$, the other two 
-sequences converge linearly along an arithmetic subsequence. Similarly, it can be shown 
-that in any other norm than $\| \cdot \|$, $\theta_n$ is also linearly convergent 
-along an arithmetic subsequence. 
-
-::: {.theorem #linear-convergence} 
-Suppose that $H$ is three times continuously 
-differentiable with $\nabla H (\theta_{\infty}) = 0$ and $D^2 H(\theta_{\infty})$
-positive definite. If $\theta_n$ converges linearly toward $\theta_{\infty}$ 
-in any norm then for some $k \geq 1$, the subsequences $H(\theta_{nk})$ and 
-$\|\nabla H(\theta_{nk})\|$ converge linearly toward $H(\theta_{\infty})$ 
-  and $0$, respectively.
-:::
-
-::: {.proof .boxed} 
-Let $G = D^2 H(\theta_{\infty})$ and $g_n = \theta_n - \theta_{\infty}$.
-Since $G$ is positive definite it defines a norm, and since all norms
-on $\mathbb{R}^p$ are equivalent there are constants $a, b > 0$ such that 
-
-\[
-  a \| x \|^2 \leq x^T G x \leq b \| x \|^2.
-\]
-
-By Taylor's theorem, 
-
-\[
-  H(\theta_{(n + 1)k}) - H(\theta_{\infty}) = g_{(n + 1)k}^T G  g_{(n + 1)k} + o(\|g_{(n + 1)k}\|^2).
-\]
-
-From this, 
-
-\begin{align*}
-\limsup_{n \to \infty} \frac{H(\theta_{(n + 1)k}) - H(\theta_{\infty})}{H(\theta_{nk}) - H(\theta_{\infty})}
-& = \limsup_{n \to \infty} \frac{g_{(n + 1)k}^T G  g_{(n + 1)k}}{g_{nk}^T G  g_{nk}} \\
-& \leq \limsup_{n \to \infty} \frac{b \| g_{(n + 1)k}\|^2}{a \| g_{nk}\|^2} 
-= \frac{b}{a} r^{2k}
+  H(\theta_{n+1}) & \leq H(\theta_n) - \frac{1}{2L} \|\nabla H(\theta_n)\|_2^2 \\
+  & \leq H(\theta_n) - \frac{m}{L} (H(\theta_n) - H(\theta^\star)).
 \end{align*}
 
-where $r \in (0, 1)$ is the asymptotic rate of $\theta_n \to \theta_{\infty}$.
-By choosing $k$ sufficiently large, the right hand side above is strictly 
-smaller than 1, which gives an upper bound on the rate along the 
-subsequence $H(\theta_{nk})$. A similar argument gives a lower bound strictly larger 
-than 0, which shows that the convergence is not superlinear. 
-
-Using Taylor's theorem on $\nabla H(\theta_{nk})$ yields a similar 
-proof for the subsequence $\|\nabla H(\theta_{nk})\|$---with $G$ replaced 
-by $G^2$ in the bounds.
+Subtracting $H(\theta^\star)$ from both sides gives the one-step contraction;
+iterating gives the geometric rate.
 :::
 
-The bounds in the proof are often pessimistic since $g_n$ and $g_{n+1}$ 
-can point in completely different directions. 
-Exercise ?? shows, however, that if $\theta_n$ approaches $\theta_{\infty}$ nicely 
-along a fixed direction (making $g_n$ and $g_{n+1}$ almost collinear), 
-$H(\theta_n)$ as well as $\|\nabla H(\theta_n)\|$
-inherit linear convergence from $\theta_n$ and even with the same rate. 
+Convergence at a geometric rate is called *linear* convergence in the
+numerical-optimization literature, because the number of correct digits in
+$H(\theta_n) - H(\theta^\star)$ grows linearly in $n$. The contraction factor
+$1 - 1/\kappa$ depends only on the condition number. Well-conditioned problems
+($\kappa$ close to $1$) converge in ewiterations. Ill-conditioned problems
+($\kappa$ large) crawl slowly towards convergence with the iterates tracing a
+long zigzag along the floor of a narrow ravine. In Section\ \@ref(smoothness),
+we provided the geometric interpretation: $\kappa$ is the aspect ratio of the
+level sets of $H$. Newton's method (Section\ \@ref(Newton)) corrects for the
+conditioning at the cost of solving a linear system per iteration.
 
-All rates discussed hithereto are *per iteration*,
-which is natural when investigating a single algorithm. However, different 
-algorithms may spend different amounts of time per iteration, and it does not 
-make sense to make a comparison of per iteration rates across different 
-algorithms. We therefore need to be able to convert between per iteration
-and per time unit rates. If one iteration takes $\delta$ time units (seconds, say) 
-the *per time unit* rate is 
+Both theorems assume $\Theta = \mathbb{R}^p$. The arguments go through on any
+open convex $\Theta$ provided the iterates remain in $\Theta$, but ensuring that
+under arbitrary constraints requires projection or barrier methods rather than
+the plain step\ \@ref(eq:gd-step).
+
+### Measuring convergence in practice
+
+The theoretical rates above are *worst case* bounds. The actual rate on any
+given problem can be much better. The standard way to estimate it empirically is
+to run the algorithm for $M$ iterations, such that
+$\theta_M \approx \theta^\star$ at machine precision and then plot
+$\log(H(\theta_n) - H(\theta_M))$ against $n$. Linear convergence with rate $r$
+means
 
 \[
-  r^{1/\delta}.
+\log(H(\theta_n) - H(\theta_M)) \approx n \log r + \text{const}
 \]
 
-If $t_n$ denotes the runtime of $n$ iterations, we could 
-estimate $\delta$ as $t_M / M$ for $M$ sufficiently large. 
+for sufficiently large $n$, so the slope of a linear fit to the late iterations
+estimates $\log r$. Sublinear convergence shows up as a decay slower than any
+straight line---superlinear convergence as a steepening slope.
 
-We will throughout systematically investigate convergence 
-as a function of time $t_n$ instead of iterations $n$, and we will estimate 
-rates per time unit directly by least squares regression on $t_n$ 
-instead of $n$. 
+The same idea can be applied to $\theta_n$ or to $\|\nabla H(\theta_n)\|$, the
+latter being especially convenient because the limit is known to be zero, so we
+can monitor it without waiting for the algorithm to finish.
+
+Per-iteration rates are useful for analyzing a single algorithm but not for
+comparing different algorithms, which may spend wildly different amounts of time
+per iteration. Throughout the chapter we will also report *per-second*
+convergence rates by plotting against measured runtime rather than iteration
+count. If one iteration takes $\delta$ seconds the per-second rate is
+$r^{1/\delta}$; in practice we estimate $\delta$ as $t_M / M$ for $M$ large.
+
+## Step size and stopping criteria
+
+The convergence theorems of Section\ \@ref(grad-descent) used the fixed step
+$t = 1/L$, which requires knowing the smoothness (Lipschitz) constant $L$. In
+practice $L$ is rarely available analytically, since it may vary across the
+parameter space, and a generic Lipschitz bound is often so pessimistic that
+fixed-step iterations slow to almost a stop. Practical implementations therefore
+often choose the step length adaptively at each iteration via a *line search*.
+The general step is
+
+\[
+\theta_{n+1} = \theta_n + \gamma_n \rho_n
+\]
+
+for a descent direction $\rho_n$ and a step length $\gamma_n > 0$ that is
+allowed to depend on $\theta_n$ and $\rho_n$. In this section we introduce
+backtracking line search, which we use throughout the rest of the chapter, and
+then turn to the question of when to terminate our algorithm.
+
+### Line search {#line-search}
+
+Given $\theta_n$ and a descent direction $\rho_n$, restrict $H$ to the ray
+emanating from $\theta_n$ in the direction $\rho_n$:
+
+\[
+h(\gamma) = H(\theta_n + \gamma \rho_n), \qquad \gamma \in [0, \infty).
+\]
+
+Then $h'(\gamma) = \nabla H(\theta_n + \gamma \rho_n)^\top \rho_n$ and the
+descent-direction property gives $h'(0) = \nabla H(\theta_n)^\top \rho_n < 0$,
+so $h$ is decreasing at $0$. The *exact line search* strategy picks
+$\gamma_n = \argmin_{\gamma > 0} h(\gamma)$, which delivers the maximal possible
+descent along the ray. It is rarely worth the compute unless the inner
+minimization admits a closed form.
+
+Inexact line search settles for *sufficient* descent. Fix $c \in (0, 1)$. The
+*Armijo condition*\index{Armijo condition}
+
+\[
+h(\gamma) \leq h(0) + c \gamma h'(0)
+\]
+
+requires $h$ to descend by at least the fraction $c$ of the linear prediction
+along the tangent at $0$. Since $h'(0) < 0$ the right-hand side sits below
+$h(0)$, and the condition reduces to one evaluation of $H$. For any
+$c \in (0, 1)$ the Armijo condition holds on some interval $[0, \varepsilon)$,
+so a small enough step always works. Figure\ \@ref(fig:armijo) shows the
+condition geometrically: $h$ must lie at or below the lower dashed line
+$h(0) + c \gamma h'(0)$ to be accepted, while the steeper tangent
+$h(0) + \gamma h'(0)$ is ceiling. Choosing $c$ close to $0$ asks for very little
+descent and admits most steps, whilst choosing $c$ close to $1$ asks fr a almost
+full linear prediction of descent and rules out most steps.
+
+```{r}
+#| label: armijo
+#| echo: false
+#| fig-width: 4
+#| fig-height: 3.2
+#| fig-align: "center"
+#| fig-cap: "The Armijo condition. Solid: the restriction $h(\\gamma) = H(\\theta + \\gamma \\rho)$ along a descent direction $\\rho$. Dashed orange: the tangent $h(0) + \\gamma h'(0)$, the linear prediction of descent at rate $h'(0)$. Dashed blue: the Armijo line $h(0) + c \\gamma h'(0)$ with $c = 0.35$. The shaded interval marks the values of $\\gamma$ for which the Armijo condition $h(\\gamma) \\leq h(0) + c \\gamma h'(0)$ holds."
+
+h_fun <- function(g) 0.5 * (g - 1.3)^2 - 0.4
+h0 <- h_fun(0)
+hp0 <- -1.3
+c_arm <- 0.35
+
+g_grid <- seq(-0.2, 2.4, length.out = 300)
+df_h <- data.frame(g = g_grid, y = h_fun(g_grid))
+df_tan <- data.frame(g = g_grid, y = h0 + g_grid * hp0)
+df_arm <- data.frame(g = g_grid, y = h0 + c_arm * g_grid * hp0)
+acc_max <- max(g_grid[df_h$y - df_arm$y <= 0])
+
+ggplot() +
+  annotate(
+    "rect",
+    xmin = 0,
+    xmax = acc_max,
+    ymin = -Inf,
+    ymax = Inf,
+    fill = "grey88",
+    alpha = 0.7
+  ) +
+  geom_line(data = df_h, aes(g, y), linewidth = 0.7) +
+  geom_line(
+    data = df_tan,
+    aes(g, y),
+    linetype = "dashed",
+    color = "darkorange",
+    linewidth = 0.6
+  ) +
+  geom_line(
+    data = df_arm,
+    aes(g, y),
+    linetype = "dashed",
+    color = "steelblue",
+    linewidth = 0.6
+  ) +
+  annotate("point", x = 0, y = h0, size = 2) +
+  annotate(
+    "text",
+    x = 0.05,
+    y = h0 + 0.18,
+    label = "h(0)",
+    hjust = 0,
+    size = 3.6
+  ) +
+  annotate(
+    "text",
+    x = 2.05,
+    y = h_fun(2.05) + 0.20,
+    label = "h(gamma)",
+    parse = TRUE,
+    hjust = 0.5,
+    size = 3.6
+  ) +
+  annotate(
+    "text",
+    x = 1.65,
+    y = h0 + 1.95 * hp0 - 0.15,
+    label = "h(0) + gamma * h*minute*(0)",
+    parse = TRUE,
+    hjust = 0.5,
+    vjust = 1,
+    size = 3.3,
+    color = "darkorange"
+  ) +
+  annotate(
+    "text",
+    x = 1.85,
+    y = h0 + c_arm * 1.95 * hp0 - 0.18,
+    label = "h(0) + c * gamma * h*minute*(0)",
+    parse = TRUE,
+    hjust = 0.5,
+    vjust = 1,
+    size = 3.3,
+    color = "steelblue"
+  ) +
+  annotate(
+    "text",
+    x = acc_max / 2,
+    y = -2.0,
+    label = "Armijo-acceptable",
+    size = 3.1,
+    color = "grey30"
+  ) +
+  coord_cartesian(xlim = c(-0.3, 2.4), ylim = c(-2.8, 0.9), expand = FALSE) +
+  labs(x = expression(gamma), y = NULL) +
+  theme_schematic()
+```
+
+The Armijo criterion alone can yield arbitrarily small step sizes, which can
+stall the algorithm venathough we are far from stationary point. The *curvature
+condition*
+
+\[
+h'(\gamma) \geq \tilde{c}\, h'(0)
+\]
+
+for some $\tilde{c} \in (c, 1)$ forces the slope at $\gamma$ to be less negative
+than at $0$, ruling out the smallest step sizes. Together the two requirements
+form the *Wolfe conditions*.\index{Wolfe conditions} They can always be
+satisfied when $h$ is bounded below, and under a mild angle condition on
+$\rho_n$ they ensure $\|\nabla H(\theta_n)\|_2 \to 0$.
+
+Most practical implementations replace the curvature condition with a geometric
+search. *Backtracking line search*\index{backtracking line search} (Algorithm 2)
+picks a starting step $\gamma_0 > 0$ and a shrinkage factor $d \in (0, 1)$, then
+tests the sequence
+
+\[
+\gamma_0, \, d \gamma_0, \, d^2 \gamma_0, \, d^3 \gamma_0, \ldots
+\]
+
+stopping at the first $\gamma = d^k \gamma_0$ satisfying the Armijo condition.
+The algorithm always tries $\gamma_0$ first and only shrinks when forced, so the
+smallest step sizes are excluded by design rather than by an explicit curvature
+bound.
+
+```{algorithm, backtracking}
+\begin{algorithm}
+  \caption{Backtracking line search}
+  \begin{algorithmic}
+    \Require descent direction $\rho$, initial step $\gamma_0 > 0$, shrinkage $d \in (0,1)$, Armijo constant $c \in (0,1)$
+    \State $\gamma \gets \gamma_0$
+    \While{$H(\theta + \gamma \rho) > H(\theta) + c \gamma \nabla H(\theta)^\top \rho$}
+        \State $\gamma \gets d \gamma$
+    \EndWhile
+    \Return $\gamma$
+  \end{algorithmic}
+\end{algorithm}
+```
+
+Three constants control the search: the initial step $\gamma_0$, the shrinkage
+factor $d$, and the Armijo slope $c$. Typical defaults are $d \in [0.5, 0.9]$
+and $c \in [10^{-4}, 0.1]$. For Newton's method (Section\ \@ref(Newton)) the
+choice $\gamma_0 = 1$ is a natural choice. For plain gradient descent there is
+no universal default and $\gamma_0$ has to be tuned to the scale of the problem.
 
 ### Stopping criteria {#stop-crit}
 
-One important practical question remains unanswered even 
-if we understand the theoretical convergence properties of an 
-algorithm well and have good methods for measuring its convergence rates. 
-No algorithm can run for an infinite number 
-of iterations, thus all algorithms need a criterion for when
-to stop, but the choice of an appropriate stopping criterion is 
-notoriously difficult. We present four of the most commonly used criteria and 
-discuss benefits and deficits for each of them. 
+No algorithm can run forever and every implementation needs a rule for when to
+terminate. But choosing an appropriate one is notoriously difficult. Next, we
+will provide four common stopping criter a, each of which is easy to implement
+and common in practice, but none of which actually guarantees convergence to a
+minimum. We also note that each should be combined with a *maximum iteration
+count* as a safeguard against infinite loops.
 
-::: {.boxed} 
-**Maximum number of iterations:** Stop when 
+::: {.boxed}
+*Maximum number of iterations.* Stop when
 
 \[
-  n = M
+n = M
 \]
 
-for a fixed maximum number of iterations $M$. 
-This is arguably the simplest criterion, but, obviously, 
-reaching a maximum number of iterations provides no evidence in 
-itself that $H(\theta_M)$ is sufficiently close to a (local) minimum. For 
-a specific problem we could from experience know of a sufficiently large
-$M$ so that the algorithm has typically converged after $M$ iterations, but
-the most important use of this criterion is in combination with another 
-criterion so that it works as a safeguard against an infinite loop.
+for a fixed maximum number of iterations $M$. The simplest criterion: it
+guarantees termination but says nothing about proximity to a minimum. Useful
+mainly as a safety net combined with one of the criteria below.
 :::
 
-The other three stopping criteria all depend on choosing a 
-*tolerance parameter* $\varepsilon > 0$, which will play different roles in the three 
-criteria. The three criteria can be used individually and in combinations, 
-but unfortunately neither of them nor their combination provide convergence 
-guarantees. It is nevertheless common say that an algorithm "has converged" 
-when the stopping criterion is satisfied, but since none of the criteria 
-are sufficient for convergence this can be a bit misleading. 
+The remaining three criteria depend on a *tolerance parameter* $\varepsilon > 0$
+that plays a different role in each. They can be used individually or in
+combination, but none of them (nor their combination) implies convergence. One
+nevertheless says that an algorithm "has converged" when its stopping criterion
+is met, with the understanding that this is shorthand.
 
-::: {.boxed} 
-**Small relative change:** Stop when 
+::: {.boxed}
+*Small relative change.* Stop when
 
 \[
-  \|\theta_n - \theta_{n-1}\| \leq \varepsilon(\|\theta_n\| + \varepsilon).
+\|\theta_n - \theta_{n-1}\| \leq \varepsilon (\|\theta_n\| + \varepsilon).
 \]
 
-The idea is that when $\theta_n \approx \theta_{n-1}$ the sequence has approximately
-reached the limit $\theta_{\infty}$ and we can stop. It is possible to use an
-absolute criterion such as $\|\theta_n - \theta_{n-1}\| < \varepsilon$, but then 
-the criterion would be sensitive to a rescaling of the parameters. Thus fixing a 
-reasonable tolerance parameter across many problems makes more sense for the 
-relative then the absolute criterion. The main reason for adding $\varepsilon$
-on the right hand size is to make the criterion well behaved even if 
-$\|\theta_n\|$ is close to zero. 
-
-The main benefit of this criterion is that it does not require evaluations 
-of the objective function. Some algorithms, such as the EM algorithm, do not
-need to evaluate the objective function, and it may even be difficult to do so. 
-In those cases this criterion can be used. The main deficit is that a 
-single iteration with little change in the parameter can happen for many 
-reasons besides convergence, and it does not imply that neither 
-$\|\theta_n - \theta_{\infty}\|$ nor $H(\theta_{n}) - H(\theta_{\infty})$ 
-are small.
+A step that barely moves $\theta_n$ suggests proximity to a fixed point of the
+step map. The relative form makes the criterion invariant to a global rescaling
+of the parameters, and the additive $\varepsilon$ keeps the right-hand side from
+collapsing when $\|\theta_n\|$ is near zero. Its main practical merit is that it
+does not require evaluating $H$, which makes it useful for algorithms where $H$
+is expensive or unavailable, such as the EM algorithm of Chapter\ \@ref(em). The
+deficit is that a small step has many causes besides convergence, and does not
+imply that either $\|\theta_n - \theta^\star\|$ or
+$H(\theta_n) - H(\theta^\star)$ is small.
 :::
 
-::: {.boxed} 
-**Small relative descent:** Stop when 
+::: {.boxed}
+*Small relative descent.* Stop when
 
 \[
-  H(\theta_{n-1}) - H(\theta_n) \leq \varepsilon (|H(\theta_n)| + \varepsilon).
+H(\theta_{n-1}) - H(\theta_n) \leq \varepsilon (|H(\theta_n)| + \varepsilon).
 \]
 
-This criterion only makes sense if the algorithm is a descent algorithm.
-As discussed above, an absolute criterion would be sensitive to rescaling of 
-the objective function, and the added $\varepsilon$ 
-on the right hand side is to ensure a reasonable behavior if $H(\theta_n)$
-is close to zero. 
-
-This criterion is natural for descent algorithms; we stop when the algorithm
-does not decrease the value of the objective function sufficiently. 
-The use of a relative criterion makes is possible to choose a tolerance 
-parameter that works reasonably well for many problems. A conventional choice 
-is $\varepsilon \approx 10^{-8}$ (and often chosen as the square root of the 
-[machine epsilon](https://en.wikipedia.org/wiki/Machine_epsilon)), though 
-the theoretical support for this choice is weak. The deficit of the 
-algorithm is as for the criterion above: a small descent does not imply that $H(\theta_{n}) - H(\theta_{\infty})$ is small, and it could happen if the 
-algorithm enters a part of $\Theta$ where $H$ is very flat, say. 
+Sensible only for descent algorithms. The relative form neutralizes a global
+rescaling of $H$, and the additive $\varepsilon$ handles
+$H(\theta_n) \approx 0$. A conventional choice is $\varepsilon \approx 10^{-8}$,
+often the square root of machine epsilon, a folk default with weak theoretical
+backing. The deficit mirrors that of the previous criterion: small descent can
+occur in flat regions of $\Theta$ without proximity to a minimizer.
 :::
 
-::: {.boxed} 
-**Small gradient:** Stop when 
+::: {.boxed}
+*Small gradient.* Stop when
 
 \[
-  \|\nabla H(\theta_n)\| \leq \varepsilon.
+\|\nabla H(\theta_n)\| \leq \varepsilon.
 \]
 
-This criterion directly measures if $\theta_n$ is close to being a stationary 
-point (and not if $\theta_n$ is close to a stationary point). 
-A small value of $\|\nabla H(\theta_n)\|$ is still no guarantee that
-$\|\theta_n - \theta_{\infty}\|$ or $H(\theta_{n}) - H(\theta_{\infty})$ are 
-small. The criterion also requires the computation of the gradient. In addition, 
-different norms can be used, and
-if different coordinates of the gradient are of different orders of 
-magnitude this should be reflected by the norm. Alternatively, the parameters
-should be rescaled.
+This criterion measures whether $\theta_n$ is close to being a stationary point,
+not whether it is close to a stationary point. A small gradient norm is no
+guarantee that $\|\theta_n - \theta^\star\|$ or $H(\theta_n) - H(\theta^\star)$
+is small. The criterion requires $\nabla H$ at each iteration. The choice of
+norm matters: when the gradient coordinates differ by orders of magnitude, a
+weighted norm (or a rescaling of the parameters) is more informative than the
+plain $\ell_2$ norm.
 :::
 
-Neither of the four criteria above gives a theoretical convergence guarantee 
-in terms of how close $H(\theta_{n})$ is to $H(\theta_{\infty})$ or 
-how close $\theta_n$ is to $\theta_{\infty}$. In some 
-special cases it is, however, possible to make stronger statements. If 
-$H$ is *strongly convex*, there is a constant $C$ such that 
+The picture improves under strong convexity. If $H$ is $m$-strongly convex,
+Lemma\ \@ref(lem:strong-convex-suboptimality) gives
 
 \[
-  \|\theta_n - \theta_{\infty}\| \leq C \|\nabla H(\theta_n)\|,
+\frac{m}{2} \|\theta_n - \theta^\star\|_2^2 \leq H(\theta_n) - H(\theta^\star) \leq \frac{1}{2m} \|\nabla H(\theta_n)\|_2^2,
 \]
 
-and the small gradient stopping criterion will, actually, imply 
-that $\theta_n$ is close to $\theta_{\infty}$---if $\varepsilon$ is 
-small relative to $C$. 
+so a small gradient norm does imply both proximity to $\theta^\star$ and small
+suboptimality, with constants in $m$. Strong convexity is the exception rather
+than the rule, but when it holds the small-gradient criterion comes with a
+rigorous interpretation.
 
-Another approach is based on a lower envelope. If there is a continuous function $\tilde{H}$ 
-satisfying $H(\theta_{\infty}) = \tilde{H}(\theta_{\infty})$ and 
+A more general option uses a *lower envelope*. Suppose a continuous
+$\tilde{H} : \Theta \to \mathbb{R}$ satisfies
+$H(\theta^\star) = \tilde{H}(\theta^\star)$ and
+$H(\theta^\star) \geq \tilde{H}(\theta)$ for all $\theta \in \Theta$ (or for all
+$\theta \in \mathrm{lev}(\theta_0)$ when the algorithm is a descent algorithm).
+Then
 
 \[
-  H(\theta_{\infty}) \geq \tilde{H}(\theta)
+0 \leq H(\theta_n) - H(\theta^\star) \leq H(\theta_n) - \tilde{H}(\theta_n),
 \]
 
-for all $\theta \in \Theta$ (or just in $\mathrm{lev}(\theta_0)$ for a descent
-algorithm)  then 
+and the right-hand side gives a computable upper bound on the suboptimality.
+Convex duality theory supplies such an envelope for many convex optimization
+problems; in those cases a *duality-gap* criterion can replace the *ad hoc*
+tolerances above with a quantitative one. Treating duality properly is beyond
+our scope, but it is worth knowing that better stopping rules exist when problem
+structure allows.
+
+### Implementing gradient descent
+
+We implement gradient descent with backtracking below as the function
+`grad_desc()`. For gradient descent, the sufficient descent condition amounts to
+choosing the smallest $k \geq 0$ such that
 
 \[
-  0 \leq H(\theta_{n}) - H(\theta_{\infty}) \leq 
-H(\theta_{n}) - \tilde{H}(\theta_{n}),
+H(\theta_{n} - d^k \gamma_0 \nabla H(\theta_{n})) \leq H(\theta_n) -  cd^k \gamma_0 \|\nabla H(\theta_{n})\|_2^2.
 \]
 
-and the right hand side directly quantifies convergence. Convex duality 
-theory gives for many convex optimization problems such a function, $\tilde{H}$,
-and in those cases a convergence criterion based on 
-$H(\theta_{n}) - \tilde{H}(\theta_{n})$ actually comes with a theoretical guarantee on
-how close we are to the minimum. We will not pursue 
-the necessary convex duality theory here, but it is useful to know 
-that in some cases we can do better than the *ad hoc* criteria above.
+The `grad_desc()` function takes the starting point, $\theta_0$, the objective
+function, $H$, and its gradient, $\nabla H$, as arguments. The four parameters
+$d$, $c$, $\gamma_0$ and $\varepsilon$ that control the algorithm can also be
+specified as additional arguments, but are given some reasonable default values.
+The implementation uses the *squared* norm of the gradient as a stopping
+criterion, but it also has a maximum number of iterations as a safeguard. If the
+maximum number is reached, a warning is printed.
 
-## Descent direction algorithms
+Finally, we include a callback argument (the `cb` argument). If a function is
+passed to this argument, it will be evaluated in each iteration of the
+algorithm. This gives us the possibility of logging or printing values of
+variables during evaluation, which can be highly useful for understanding the
+inner workings of the algorithm. Monitoring or logging intermediate values
+during the evaluation of code is referred to as *tracing*.
 
-The negative gradient of $H$ in $\theta$ is the direction of steepest descent.
-Since the goal is to minimize $H$, it is natural to move 
-away from $\theta$ in the direction of $-\nabla H(\theta)$. 
-However, other directions than the negative gradient can also be suitable
-descent directions.
+```{r}
+#| label: gd
 
-::: {.definition} 
-A *descent direction* in $\theta$ is a vector $\rho \in \mathbb{R}^p$ such that 
-
-\[
-\nabla H(\theta)^T \rho < 0.
-\]
-::: 
-
-When $\theta$ is not a stationary point,  
-
-\[
-\nabla H(\theta)^T(-\nabla H(\theta)) = - \| \nabla H(\theta)^T \|_2^2 < 0
-\]
-
-and $-\nabla H(\theta)^T$ is a descent direction in $\theta$ according to 
-the definition.
-
-Given $\theta_n$ and a descent direction $\rho_n$ in $\theta_n$ we can define 
-
-\[
-\theta_{n+1} = \theta_n + \gamma \rho_n
-\]
-
-for a suitably chosen $\gamma > 0$. By Taylor's theorem 
-
-\[
-H(\theta_{n+1}) = H(\theta_n) + \gamma \nabla H(\theta_n) \rho_n + o(\gamma),
-\]
-
-which means that
-
-\[
-H(\theta_{n+1}) < H(\theta_n)
-\]
-
-if $\gamma$ is small enough. 
-
-One strategy for choosing $\gamma$ is to minimize the univariate 
-function 
-
-\[
-\gamma \mapsto H(\theta_n + \gamma \rho_n),
-\]
-
-which is an example of a *line search* method. Such a minimization 
-would give the maximal possible descent in the direction $\rho_n$,
-and as we have argued, if $\rho_n$ is a descent direction, a minimizer $\gamma > 0$
-guarantees descent of $H$. However, unless the minimization can be 
-done analytically it is often computationally too expensive. 
-Less will also do, and as shown in Section \@ref(grad-descent),
-if the Hessian has uniformly bounded numerical radius it is possible to 
-fix one (sufficiently small) step length that will guarantee descent. 
-
-### Line search
-
-We consider algorithms of the form 
-
-\[
-\theta_{n+1} = \theta_n + \gamma_{n} \rho_n
-\]
-
-starting in $\theta_n$ and with $\rho_n$ a descent direction in $\theta_n$. 
-The step lengths, $\gamma_n$, should be chosen so as to give 
-sufficient descent in each iteration. 
-
-The function $h(\gamma) = H(\theta_{n} + \gamma \rho_{n})$ 
-is a univariate and differentiable function,
-
-\[
-h : [0,\infty) \to \mathbb{R},
-\]
-
-that gives the value of $H$ in the descent direction
-$\rho_n$. We find that 
-
-\[
-h'(\gamma) = \nabla H(\theta_{n} + \gamma \rho_{n})^T \rho_{n},
-\]
-
-and the maximal descent in direction $\rho_n$ can be found by solving
-$h'(\gamma) = 0$ for $\gamma$. As mentioned above, less will do. First note
-that 
-
-\[
-h'(0) = \nabla H(\theta_{n})^T \rho_{n} < 0,
-\]
-
-so $h$ has a negative slope in $0$. It descents in a sufficiently 
-small interval $[0, \varepsilon)$, and it is even true that for any $c \in (0, 1)$
-there is an $\varepsilon > 0$ such that
-
-\[
-h(\gamma) \leq h(0) + c \gamma h'(0)
-\]
-
-for $\gamma \in [0, \varepsilon)$. We note that this inequality can 
-be checked easily for any given $\gamma > 0$, and is known as the 
-*sufficient descent* condition. Sufficient descent is not enough 
-in itself as the step length could be arbitrarily small, and the algorithm 
-could effectively get stuck.  
-
-To prevent too small steps we can enforce another condition. Very close 
-to $0$, $h$ will have almost the same slope, $h'(0)$, as it has in $0$. If we 
-therefore require that the slope in $\gamma$ should be larger than $\tilde{c} h'(0)$
-for some $\tilde{c} \in (0, 1)$, $\gamma$ is forced away from $0$. This is 
-known as the *curvature condition*. 
-
-The combined conditions on $\gamma$, 
-
-\[
-h(\gamma) \leq h(0) + c \gamma h'(0)
-\]
-
-for a $c \in (0, 1)$ and 
-
-\[
-h'(\gamma) \geq \tilde{c} h'(0)
-\]
-
-for a $\tilde{c} \in (c, 1)$ are known collectively as 
-the *Wolfe conditions*. It can be shown that if $h$ is bounded below there 
-exists a step length satisfying the Wolfe conditions (Lemma 3.1 in @Nocedal:2006).
-
-Even when choosing $\gamma_{n}$ to fulfill
-the Wolfe conditions there is no guarantee that $\theta_n$
-will converge let alone converge toward a global minimizer. The best we
-can hope for in general is that 
-
-\[
-\|\nabla H(\theta_n)\|_2 \rightarrow 0
-\]
-
-for $n \to \infty$, and this will happen under some relatively weak 
-conditions on $H$ (Theorem 3.2 @Nocedal:2006) under the assumption 
-that
-
-\[
-\frac{\nabla H(\theta_n)^T \rho_n}{\|\nabla H(\theta_n)\|_2 \| \rho_n\|_2} \leq - \delta < 0.
-\]
-
-That is, the angle between the descent direction and the gradient should be 
-uniformly bounded away from $90^{\circ}$. 
-
-A practical way of searching for a step length is via *backtracking*. 
-Choosing a $\gamma_0$ and a constant $d \in (0, 1)$ we 
-can search through the sequence of step lengths 
-
-\[
-\gamma_0, d \gamma_0, d^2 \gamma_0, d^3 \gamma_0, \ldots
-\]
-
-and stop the first time we find a step length satisfying the Wolfe 
-conditions.
-
-Using backtracking, we can actually dispense of the curvature condition 
-and simply check the sufficient descent condition
-
-\[
-H(\theta_{n} + d^k \gamma_0 \rho_{n}) \leq H(\theta_n) + cd^k \gamma_0 \nabla H(\theta_{n})^T \rho_{n}
-\]
-
-for $c \in (0, 1)$. The implementation of backtracking requires the choice 
-of the three parameters: $\gamma_0 > 0$, $d \in (0, 1)$ and $c \in (0, 1)$.
-A good choice depends quite a lot on the algorithm used for choosing
-the descent direction, but choosing $c$ too close to 1 can make the algorithm 
-take too small steps, and taking $d$ too small can likewise 
-generate small step lengths. Thus $d = 0.8$ or $d = 0.9$ 
-and $c = 0.1$ or even smaller are sensible choices. For some algorithms, 
-like the Newton algorithm to be dealt with below, there is a natural 
-choice of $\gamma_0 = 1$. But for other algorithms a good choice depends 
-crucially on the scale of the parameters, and there is then no general 
-advice on choosing $\gamma_0$.
-
-### Gradient descent 
-
-We implement gradient descent with backtracking below as the function `grad_desc()`. 
-For gradient descent, the sufficient descent condition amounts to 
-choosing the smallest $k \geq 0$ such that 
-
-\[
-  H(\theta_{n} - d^k \gamma_0 \nabla H(\theta_{n})) \leq H(\theta_n) -  cd^k \gamma_0 \|\nabla H(\theta_{n})\|_2^2.
-\]
-
-The `grad_desc()` function takes the starting point, $\theta_0$, the objective function,
-$H$, and its gradient, $\nabla H$, as arguments. The four parameters $d$, $c$, $\gamma_0$ and 
-$\varepsilon$ that control the algorithm can also be specified as additional arguments, 
-but are given some reasonable default values. The implementation uses the *squared* norm of 
-the gradient as a stopping criterion, but it also has a maximum number of 
-iterations as a safeguard. If the maximum number is reached, a 
-warning is printed.
-
-Finally, we include a callback argument (the `cb` argument).
-If a function is passed to this argument, it will be evaluated in each iteration
-of the algorithm. This gives us the possibility of logging or 
-printing values of variables during evaluation, which can be highly useful 
-for understanding the inner workings of the algorithm. Monitoring or logging 
-intermediate values during the evaluation of code is referred to as 
-*tracing*. 
-
-```{r gd}
 grad_desc <- function(
-  par, 
+  par,
   H,
   gr,
-  d = 0.8, 
-  c = 0.1, 
-  gamma0 = 0.01, 
-  epsilon = 1e-4, 
+  d = 0.8,
+  c = 0.1,
+  gamma0 = 0.01,
+  epsilon = 1e-4,
   maxit = 1000,
   cb = NULL
 ) {
@@ -1039,64 +802,79 @@ grad_desc <- function(
     value <- H(par)
     grad <- gr(par)
     h_prime <- sum(grad^2)
-    if (!is.null(cb)) cb()
+
+    if (!is.null(cb)) {
+      cb()
+    }
+
     # Convergence criterion based on gradient norm
-    if (h_prime <= epsilon) break
+    if (h_prime <= epsilon) {
+      break
+    }
+
     gamma <- gamma0
+
     # Proposed descent step
     par1 <- par - gamma * grad
+
     # Backtracking while descent is insufficient
     while (H(par1) > value - c * gamma * h_prime) {
       gamma <- d * gamma
       par1 <- par - gamma * grad
     }
+
     par <- par1
   }
+
   if (n == maxit) {
     warning("Maximum number, ", maxit, ", of iterations reached")
   }
+
   par
 }
 ```
 
+We will use the Poisson regression example to illustrate the use of gradient
+descent and other optimization algorithms, and we need to implement functions in
+R for computing the negative log-likelihood and its gradient.
 
-We will use the Poisson regression example to illustrate the use of 
-gradient descent and other optimization algorithms, and we need to 
-implement functions in R for computing the negative log-likelihood and 
-its gradient.
+The implementation below uses a function factory to produce a list containing a
+parameter vector, the negative log-likelihood function and its gradient. We
+anticipate that for the Newton algorithm in Section \@ref(Newton) we also need
+an implementation of the Hessian, which is thus included here as well.
 
-The implementation below uses a function factory to produce a 
-list containing a parameter vector, the negative log-likelihood function 
-and its gradient. We anticipate that for the Newton algorithm in Section 
-\@ref(Newton) we also need an implementation of the Hessian, which is 
-thus included here as well. 
+We will exploit the `model.matrix()` function to construct the model matrix from
+the data via a formula, and the sufficient statistic is also computed. The
+implementations use linear algebra and vectorized computations relying on access
+to the model matrix and the sufficient statistics in their enclosing
+environment.
 
-We will exploit the `model.matrix()` function to construct the model matrix 
-from the data via a formula, and the sufficient statistic is also
-computed. The implementations use linear algebra and vectorized computations
-relying on access to the model matrix and the sufficient statistics in 
-their enclosing environment.
+```{r}
+#| label: Implement
 
-```{r Implement}
 poisson_model <- function(form, data, response) {
   X <- model.matrix(form, data)
   y <- data[[response]]
-  # The computation of t(X) %*% y is more efficiently done by 
-  # crossprod(X,y). Use the function drop() to drop the dim attribute 
+
+  # The computation of t(X) %*% y is more efficiently done by
+  # crossprod(X,y). Use the function drop() to drop the dim attribute
   # and turn a matrix with one column into a vector
-  t_map <- drop(crossprod(X, y)) 
+  t_map <- drop(crossprod(X, y))
   N <- nrow(X)
   p <- ncol(X)
-  
-  H <- function(beta) 
+
+  H <- function(beta) {
     drop(sum(exp(X %*% beta)) - beta %*% t_map) / N
-  
-  grad <- function(beta) 
+  }
+
+  grad <- function(beta) {
     (drop(crossprod(X, exp(X %*% beta))) - t_map) / N
-  
-  Hessian <- function(beta)
+  }
+
+  Hessian <- function(beta) {
     crossprod(X, drop(exp(X %*% beta)) * X) / N
-  
+  }
+
   list(par = rep(0, p), H = H, grad = grad, Hessian = Hessian)
 }
 ```
@@ -1109,121 +887,167 @@ numerical optimization algorithms. Gradient descent is very slow for the large
 Poisson model with individual store effects, so we consider only the simple
 model with two parameters.
 
-```{r veg-pois}
+```{r}
+#| label: veg-pois
+
 veg_pois <- poisson_model(
-  ~ log(normalSale), 
-  CSwR::vegetables, 
+  ~ log(normalSale),
+  CSwR::vegetables,
   response = "sale"
 )
 ```
 
-```{r gd-test, dependson=c("veg-pois", "gd")}
+```{r, dependson=c("veg-pois", "gd")}
+#| label: gd-test
+
 pois_gd <- grad_desc(veg_pois$par, veg_pois$H, veg_pois$grad)
 ```
 
-The gradient descent implementation is tested by comparing the minimizer to
-the estimated parameters as computed by `glm()`.
+The gradient descent implementation is tested by comparing the minimizer to the
+estimated parameters as computed by `glm()`.
 
-```{r gd-comp, dependson=c("gd-test", "pois-model-null"), results='hold'}
+```{r, dependson=c("gd-test", "pois-model-null")}
+#| label: gd-comp
+#| results: "hold"
+
 rbind(pois_glm = coefficients(pois_model_null), pois_gd)
 ```
 
-We get the same result up to the first two decimals. The convergence 
-criterion on our gradient descent algorithm was quite loose ($\varepsilon = 10^{-4}$,
-which means that the norm of the gradient is smaller than $10^{-2}$ when 
-the algorithm stops). This choice of $\varepsilon$ in combination with $\gamma_0 = 0.01$ 
-implies that the algorithm stops when the gradient is so small that the changes 
-are at most of norm $10^{-4}$. 
+We get the same result up to the first two decimals. The convergence criterion
+on our gradient descent algorithm was quite loose ($\varepsilon = 10^{-4}$,
+which means that the norm of the gradient is smaller than $10^{-2}$ when the
+algorithm stops). This choice of $\varepsilon$ in combination with
+$\gamma_0 = 0.01$ implies that the algorithm stops when the gradient is so small
+that the changes are at most of norm $10^{-4}$.
 
-Comparing the resulting values of the negative log-likelihood shows agreement
-up to the first five decimals, but we notice that the negative log-likelihood 
-for the parameters fitted using `glm()` is just slightly smaller. 
+Comparing the resulting values of the negative log-likelihood shows agreement up
+to the first five decimals, but we notice that the negative log-likelihood for
+the parameters fitted using `glm()` is just slightly smaller.
 
-```{r gd-object, dependson=c("veg-pois", "pois-model-null", "gd-test"), echo=2:3, results='hold'}
+```{r, dependson=c("veg-pois", "pois-model-null", "gd-test"), echo=2:3}
+#| label: gd-object
+#| results: "hold"
+
 old_options = options(digits = 15)
 veg_pois$H(coefficients(pois_model_null))
 veg_pois$H(pois_gd)
 options(digits = old_options$digits)
 ```
 
-To investigate what actually went on inside the gradient descent 
-algorithm we will use the callback argument to trace the internals 
-of a call to `grad_desc()`. The `tracer()` function from the [CSwR package](https://github.com/nielsrhansen/CSwR/tree/master/CSwR_package)
-can be used to construct a tracer object with a `tracer()` function that we can pass as the callback 
-argument.  The tracer object and its `tracer()` function work by storing 
-information in the enclosing environment of `tracer()`. When used as 
-the callback argument to, e.g., `grad_desc()` the `tracer()` function will look up 
-variables in the evaluation environment of `grad_desc()`, store them and 
-print them if requested, and store runtime information as well. 
+To investigate what actually went on inside the gradient descent algorithm we
+will use the callback argument to trace the internals of a call to
+`grad_desc()`. The `tracer()` function from the [CSwR
+package](https://github.com/nielsrhansen/CSwR/tree/master/CSwR_package) can be
+used to construct a tracer object with a `tracer()` function that we can pass as
+the callback argument. The tracer object and its `tracer()` function work by
+storing information in the enclosing environment of `tracer()`. When used as the
+callback argument to, e.g., `grad_desc()` the `tracer()` function will look up
+variables in the evaluation environment of `grad_desc()`, store them and print
+them if requested, and store runtime information as well.
 
-When `grad_desc()` has returned, the trace information can be accessed
-via the `summary()` method for the tracer object. The tracer objects 
-and their `tracer()` function should not be confused with the `trace()` 
-function from the R base package, but the tracer object's `tracer()` function
-can be passed as the `tracer` argument to `trace()` to interactively 
-inject tracing code into any R function. Here, the tracer objects will 
-only be used together with a callback argument.
+When `grad_desc()` has returned, the trace information can be accessed via the
+`summary()` method for the tracer object. The tracer objects and their
+`tracer()` function should not be confused with the `trace()` function from the
+R base package, but the tracer object's `tracer()` function can be passed as the
+`tracer` argument to `trace()` to interactively inject tracing code into any R
+function. Here, the tracer objects will only be used together with a callback
+argument.
 
-We use the tracer object with our gradient descent implementation
-and print trace information every 50th iteration. 
+We use the tracer object with our gradient descent implementation and print
+trace information every 50th iteration.
 
-```{r gd-trace, dependson=c("gd", "veg-pois")}
+```{r, dependson=c("gd", "veg-pois")}
+#| label: gd-trace
+
 gd_tracer <- CSwR::tracer(c("value", "h_prime", "gamma"), Delta = 50)
 pois_gd <- grad_desc(
-  veg_pois$par, 
-  veg_pois$H, 
-  veg_pois$grad, 
+  veg_pois$par,
+  veg_pois$H,
+  veg_pois$grad,
   cb = gd_tracer$tracer
 )
 ```
 
 We see that the gradient descent algorithm runs for a little more than 350
-iterations, and we can observe how the value of the negative log-likelihood is 
-descending. We can also see that the step length $\gamma$ bounces between 
-$0.004096 = 0.8^4 \times 0.01$ and 
-$0.00512 = 0.8^3 \times 0.01$, thus the backtracking 
-takes 3 to 4 iterations to find a step length with sufficient descent.
- 
-The printed trace does not reveal the runtime information. The 
-runtime is measured for each iteration of the algorithm and the 
-cumulative runtime is of greater interest. This information
-can be computed and inspected after the algorithm has converged,
-and it is returned by the summary method for tracer objects.
+iterations, and we can observe how the value of the negative log-likelihood is
+descending. We can also see that the step length $\gamma$ bounces between
+$0.004096 = 0.8^4 \times 0.01$ and $0.00512 = 0.8^3 \times 0.01$, thus the
+backtracking takes 3 to 4 iterations to find a step length with sufficient
+descent.
 
-```{r this-summary, dependson=c("gd-trace")}
+The printed trace does not reveal the runtime information. The runtime is
+measured for each iteration of the algorithm and the cumulative runtime is of
+greater interest. This information can be computed and inspected after the
+algorithm has converged, and it is returned by the summary method for tracer
+objects.
+
+```{r, dependson=c("gd-trace")}
+#| label: this-summary
+
 tail(summary(gd_tracer))
 ```
 
-The trace information is stored in a list. The summary method transforms 
-the trace information into a data frame with one row per iteration. We can also access 
-individual entries of the list of trace information via subsetting. 
+The trace information is stored in a list. The summary method transforms the
+trace information into a data frame with one row per iteration. We can also
+access individual entries of the list of trace information via subsetting.
 
-```{r gd-trace-sub, dependson=c("gd-trace")}
-gd_tracer[377] 
+```{r, dependson=c("gd-trace")}
+#| label: gd-trace-sub
+
+gd_tracer[377]
 ```
 
+```{r, dependson=c("gd-trace", "veg-pois")}
+#| label: gd-trace-plot
+#| echo: false
+#| fig-cap: "Gradient norm (left) and value of the negative log-likelihood (right) above the limit value $H(\\theta_{\\infty})$. The straight line is fitted to the data points except the first ten using least squares, and the rate is computed from this estimate and reported per ms."
+#| out-width: "100%"
+#| fig-width: 8
+#| fig-height: 3
+#| message: false
 
-```{r gd-trace-plot, echo=FALSE, fig.cap="Gradient norm (left) and value of the negative log-likelihood (right) above the limit value $H(\\theta_{\\infty})$. The straight line is fitted to the data points except the first ten using least squares, and the rate is computed from this estimate and reported per ms.", dependson=c("gd-trace", "veg-pois"), out.width="100%", fig.width=8, fig.height=3, message=FALSE}
 trace_gd <- summary(gd_tracer)
 
-rate1 <- exp(coef(lm(log(h_prime)/2 ~ I(1000 * .time), data = trace_gd, subset = 11:nrow(trace_gd))))[2]
+rate1 <- exp(coef(lm(
+  log(h_prime) / 2 ~ I(1000 * .time),
+  data = trace_gd,
+  subset = 11:nrow(trace_gd)
+)))[2]
 
 p1 <- ggplot(data = trace_gd, aes(x = 1000 * .time, y = sqrt(h_prime))) +
-  geom_point() + 
+  geom_point() +
   scale_y_log10("Gradient norm") +
-  xlab("Time (ms)") + 
-  geom_smooth(method = "lm", se = FALSE, method.args = list(subset = 11:nrow(trace_gd))) + 
-  geom_text(aes(x = 15, y = 10, label = paste("rate:", round(rate1, 3), "per ms")), data = data.frame())
+  xlab("Time (ms)") +
+  geom_smooth(
+    method = "lm",
+    se = FALSE,
+    method.args = list(subset = 11:nrow(trace_gd))
+  ) +
+  geom_text(
+    aes(x = 15, y = 10, label = paste("rate:", round(rate1, 3), "per ms")),
+    data = data.frame()
+  )
 
 value_Inf <- veg_pois$H(coefficients(pois_model_null))
-rate2 <- exp(coef(lm(log(value - value_Inf) ~ I(1000 * .time), data = trace_gd, subset = 11:nrow(trace_gd))))[2]
+rate2 <- exp(coef(lm(
+  log(value - value_Inf) ~ I(1000 * .time),
+  data = trace_gd,
+  subset = 11:nrow(trace_gd)
+)))[2]
 
 p2 <- ggplot(data = trace_gd, aes(x = 1000 * .time, y = value - value_Inf)) +
-  geom_point() + 
+  geom_point() +
   scale_y_log10(expression(Value - Value[infinity])) +
-  xlab("Time (ms)") + 
-  geom_smooth(method = "lm", se = FALSE, method.args = list(subset = 11:nrow(trace_gd))) + 
-  geom_text(aes(x = 15, y = 10, label = paste("rate:", round(rate2, 3), "per ms")), data = data.frame())
+  xlab("Time (ms)") +
+  geom_smooth(
+    method = "lm",
+    se = FALSE,
+    method.args = list(subset = 11:nrow(trace_gd))
+  ) +
+  geom_text(
+    aes(x = 15, y = 10, label = paste("rate:", round(rate2, 3), "per ms")),
+    data = data.frame()
+  )
 
 cc <- coord_cartesian(xlim = c(0, 20), ylim = c(1e-6, 1000))
 
@@ -1232,430 +1056,912 @@ library(patchwork)
 (p1 + cc) + (p2 + cc)
 ```
 
-```{r, echo=FALSE, eval=FALSE}
+```{r}
+#| label: gd-trace-plot-diff
+#| echo: false
+#| eval: false
 
-rate3 <- exp(coef(lm.fit(cbind(1, 11:nrow(trace_gd)), log(trace_gd$h_prime[11:nrow(trace_gd)])))[2])
+rate3 <- exp(coef(lm.fit(
+  cbind(1, 11:nrow(trace_gd)),
+  log(trace_gd$h_prime[11:nrow(trace_gd)])
+))[2])
 
 delta <- trace_gd$.time[nrow(trace_gd)] / nrow(trace_gd)
 
 plot(diff(trace_gd$.time), ylim = c(0, 0.0003))
 abline(h = delta, col = "red")
-rate3^(1/(1000 * delta))
+rate3^(1 / (1000 * delta))
 ```
 
+## Newton's method {#Newton}
 
-### Conjugate gradients
-
-The gradient direction is not the best descent direction. It is too 
-local, and convergence can be quite slow. One of the better algorithms that 
-is still a *first order algorithm* (using only gradient information) is the [nonlinear conjugate
-gradient](https://en.wikipedia.org/wiki/Nonlinear_conjugate_gradient_method) algorithm. 
-In the Fletcher--Reeves version of the algorithm
-the descent direction is initialized as the negative gradient
-$\rho_0 = - \nabla H(\theta_{0})$ and then updated as
+We can re-derive gradient descent from a different angle, and that derivation
+will lead us straight to Newton's method. Take the second-order Taylor expansion
+of $H$ around $\theta$,
 
 \[
-\rho_{n} = - \nabla H(\theta_{n}) + \frac{\|\nabla H(\theta_n)\|_2^2}{\|\nabla H(\theta_{n-1})\|_2^2} \rho_{n-1}.
+H(\theta + \rho) \approx H(\theta) + \nabla H(\theta)^\top \rho + \frac{1}{2} \rho^\top \nabla^2 H(\theta) \rho,
 \]
 
-That is, the descent direction, $\rho_{n}$, is the negative gradient but modified according to 
-the previous descent direction. There is plenty of opportunity to vary the prefactor 
-of $\rho_{n-1}$, and the one presented here is what makes it the Fletcher--Reeves
-version. Other versions go by the names of their inventors such as Polak–Ribière
-or Hestenes--Stiefel.
+and replace the Hessian $\nabla^2 H(\theta)$ with the conservative diagonal
+$(1/t) I$. Minimizing the resulting quadratic over $\rho$ recovers
+$\rho = -t \nabla H(\theta)$, the gradient descent direction. Substituting a
+scalar for the Hessian is what makes gradient descent both cheap (no Hessian to
+compute) and slow on ill-conditioned problems (it discards the geometry of the
+level sets). Figure\ \@ref(fig:gd-taylor-surrogate) shows the surrogate model
+for a one-dimensional objective, where the dashed quadratic surrogate uses
+curvature $1/t$ in place of the true Hessian, and its minimizer is the gradient
+descent step.
 
-In fact, $\rho_{n}$ need not be a descent direction unless we put some 
-restrictions on the step lengths. One possibility is to require that
-the step length $\gamma_{n}$ satisfies the *strong* curvature condition
+```{r}
+#| label: gd-taylor-surrogate
+#| echo: false
+#| fig-width: 4
+#| fig-height: 3
+#| fig-cap: "Gradient descent as surrogate minimization. The dashed quadratic, obtained from the second-order Taylor expansion of $H$ around $\\theta$ with the Hessian replaced by $(1/t)I$, has minimizer $\\theta^+ = \\theta - t \\nabla H(\\theta)$ (open circle). The filled dots mark $\\theta$ and the next iterate $\\theta^+$ on $H$. Newton's method instead keeps the true Hessian."
+#| warning: false
+
+H <- function(theta) (theta - 2)^2 + 1
+grad_H_1d <- function(theta) 2 * (theta - 2)
+
+theta <- 0
+t <- 0.2
+theta_p <- theta - t * grad_H_1d(theta)
+
+x_grid <- seq(theta - 0.5, theta + 1.7, length.out = 200)
+surrogate <- function(x) {
+  H(theta) + grad_H_1d(theta) * (x - theta) + (x - theta)^2 / (2 * t)
+}
+
+curve_df <- data.frame(
+  x = x_grid,
+  H_val = H(x_grid),
+  surr_val = surrogate(x_grid)
+)
+
+iterate_pts <- data.frame(
+  x = c(theta, theta_p),
+  y = c(H(theta), H(theta_p)),
+  label = c("theta", "theta^{`+`}")
+)
+
+surr_min <- data.frame(x = theta_p, y = surrogate(theta_p))
+
+ggplot(curve_df, aes(x)) +
+  geom_line(aes(y = H_val)) +
+  geom_line(aes(y = surr_val), linetype = "dashed", col = "steelblue") +
+  geom_segment(
+    aes(
+      x = theta_p,
+      xend = theta_p,
+      y = H(theta_p),
+      yend = surrogate(theta_p)
+    ),
+    linetype = "dotted"
+  ) +
+  geom_point(data = iterate_pts, aes(x = x, y = y)) +
+  geom_point(data = surr_min, aes(x = x, y = y), shape = 1) +
+  geom_text(
+    data = iterate_pts,
+    aes(x = x, y = y, label = label),
+    parse = TRUE,
+    nudge_y = -0.35
+  ) +
+  labs(x = expression(theta), y = expression(H(theta))) +
+  theme_schematic()
+```
+
+Newton's method does the opposite: it keeps the full Hessian and minimizes the
+second-order Taylor model exactly. When $\nabla^2 H(\theta)$ is positive
+definite, the minimizer of
+$\rho \mapsto \nabla H(\theta)^\top \rho + \frac{1}{2} \rho^\top \nabla^2 H(\theta) \rho$
+is
 
 \[
-|h'(\gamma)| = |\nabla H(\theta_n + \gamma \rho_n)^T \rho_n | \leq \tilde{c} |\nabla H(\theta_n)^T \rho_n| = \tilde{c} |h'(0)|
+\rho_{\mathrm{N}}(\theta) = -[\nabla^2 H(\theta)]^{-1} \nabla H(\theta),
 \]
 
-for a $\tilde{c} < \frac{1}{2}$. Then $\rho_{n + 1}$ can be shown to be a descent 
-direction if $\rho_{n}$ is. 
+the *Newton direction*.\index{Newton direction}
+Figure\ \@ref(fig:gd-vs-newton-surrogate) compares the two surrogates and their
+trajectories on the ill-conditioned OLS design from Section\ \@ref(smoothness)
+(Figure\ \@ref(fig:ols-condition-contour), right panel). The objective is
+quadratic, so its Hessian is constant and the Newton surrogate equals $H$
+exactly---its level sets coincide with the grey ellipses, and a single Newton
+step lands at $\hat{\beta}$. The gradient descent surrogate replaces that
+Hessian with $L \cdot I$ (where $L$ is the largest eigenvalue of
+$X^\top X$)---its level sets are circles aligned with neither axis of the true
+objective, and the resulting iterates zigzag across the narrow valley before
+drifting along it towards $\hat{\beta}$. This is the condition-number penalty
+paid by gradient descent in geometric form.
 
-We implement the conjugate gradient method in a slightly different way. Instead
-of introducing the more advanced curvature condition, we simply reset the 
-algorithm to use the gradient direction in any case where a non-descent direction
-has been chosen. Resets of descent direction every $p$-th iteration is recommended 
-anyway for the nonlinear conjugate gradient algorithm.
+```{r}
+#| label: gd-vs-newton-surrogate
+#| echo: false
+#| fig-width: 8
+#| fig-height: 4.5
+#| fig-cap: "Surrogate models and iterates for the OLS objective on the ill-conditioned design of Figure\\ \\@ref(fig:ols-condition-contour) (right panel). Both panels start from the filled dot $\\beta_0$. Solid grey contours are level sets of $H(\\beta) = \\tfrac{1}{2}\\lVert y - X\\beta \\rVert^2$; dashed blue contours are level sets of the surrogate built at $\\beta_0$, drawn at the same values. Left: gradient descent at step size $t = 1/L$. The surrogate is isotropic and misses the elongation of $H$, and the iterates trace a zigzag across the valley. Right: Newton's method. The surrogate coincides with $H$ (the dashed contours overlay the grey ones), and a single step reaches $\\hat{\\beta}$."
 
-```{r cg}
-conj_grad <- function(
-  par, 
+library(patchwork)
+
+set.seed(24)
+N_fig <- 100
+z1 <- rnorm(N_fig)
+z2 <- rnorm(N_fig)
+X <- cbind(z1, 0.8 * z1 + sqrt(1 - 0.8^2) * z2)
+beta_true <- c(1, 2)
+y <- X %*% beta_true
+
+XtX <- crossprod(X)
+Xty <- crossprod(X, y)
+beta_hat <- as.numeric(solve(XtX, Xty))
+eig <- eigen(XtX, symmetric = TRUE)
+L <- eig$values[1]
+flat_dir <- eig$vectors[, 2]
+steep_dir <- eig$vectors[, 1]
+grad_f <- function(b) drop(XtX %*% b - Xty)
+
+beta0 <- beta_hat + 1.8 * steep_dir + 0.6 * flat_dir
+g0 <- grad_f(beta0)
+f0 <- 0.5 * sum((beta0 - beta_hat) * (XtX %*% (beta0 - beta_hat)))
+t_gd <- 1 / L
+
+n_steps <- 30
+gd_path <- matrix(0, n_steps + 1, 2)
+gd_path[1, ] <- beta0
+for (i in seq_len(n_steps)) {
+  gd_path[i + 1, ] <- gd_path[i, ] - t_gd * grad_f(gd_path[i, ])
+}
+newton_path <- rbind(beta0, beta_hat)
+
+halfwidth <- 2.5
+
+grid <- expand.grid(
+  b1 = seq(beta_hat[1] - halfwidth, beta_hat[1] + halfwidth, length.out = 200),
+  b2 = seq(beta_hat[2] - halfwidth, beta_hat[2] + halfwidth, length.out = 200)
+)
+
+de1 <- grid$b1 - beta_hat[1]
+de2 <- grid$b2 - beta_hat[2]
+grid$H <- 0.5 *
+  (XtX[1, 1] * de1^2 + 2 * XtX[1, 2] * de1 * de2 + XtX[2, 2] * de2^2)
+
+d1 <- grid$b1 - beta0[1]
+d2 <- grid$b2 - beta0[2]
+grid$gd_surr <- f0 + g0[1] * d1 + g0[2] * d2 + (d1^2 + d2^2) / (2 * t_gd)
+grid$newton_surr <- f0 +
+  g0[1] * d1 +
+  g0[2] * d2 +
+  0.5 * (XtX[1, 1] * d1^2 + 2 * XtX[1, 2] * d1 * d2 + XtX[2, 2] * d2^2)
+
+start_pt <- data.frame(b1 = beta0[1], b2 = beta0[2])
+gd_df <- data.frame(b1 = gd_path[, 1], b2 = gd_path[, 2])
+newton_df <- data.frame(b1 = newton_path[, 1], b2 = newton_path[, 2])
+breaks <- c(10, 30, 80, 200, 400, 700)
+
+panel <- function(z_col, path_df, title) {
+  ggplot(grid, aes(b1, b2)) +
+    geom_contour(aes(z = H), color = "grey70", breaks = breaks) +
+    geom_contour(
+      aes(z = .data[[z_col]]),
+      color = "steelblue",
+      linetype = "dashed",
+      breaks = breaks
+    ) +
+    geom_path(data = path_df, linewidth = 0.4) +
+    geom_point(data = path_df, size = 0.8) +
+    geom_point(data = start_pt, size = 2) +
+    # coord_equal(
+    #   xlim = beta_hat[1] + c(-1, 1) * halfwidth,
+    #   ylim = beta_hat[2] + c(-1, 1) * halfwidth
+    # ) +
+    labs(
+      x = expression(beta[1]),
+      y = expression(beta[2]),
+      title = title
+    )
+}
+
+panel("gd_surr", gd_df, "Gradient descent") +
+  panel("newton_surr", newton_df, "Newton") +
+  plot_layout(axes = "collect")
+```
+
+The Newton iteration is then
+$\theta_{n+1} = \theta_n + \gamma_n \rho_{\mathrm{N}}(\theta_n)$. Pure Newton
+takes $\gamma_n = 1$, which is the right choice near a minimizer with
+positive-definite Hessian. Far from a minimizer, the model may be a poor guide
+and the natural unit step can overshoot, so the practical version combines the
+Newton direction with the backtracking line search of
+Section\ \@ref(line-search). This is called *damped
+Newton*.\index{Newton's method!damped}
+
+The Newton direction is automatically a descent direction whenever
+$\nabla^2 H(\theta_n)$ is positive definite:
+
+\[
+\rho_{\mathrm{N}}(\theta_n)^\top \nabla H(\theta_n) = -\nabla H(\theta_n)^\top [\nabla^2 H(\theta_n)]^{-1} \nabla H(\theta_n) < 0.
+\]
+
+When the Hessian is not positive definite, which can happen for non-convex $H$,
+we must either modify the Hessian by adding $\lambda I$ for some $\lambda > 0$
+or fall back to gradient descent for the offending iteration.
+
+Newton's method has two structural advantages over plain gradient descent.
+First, it is *affine invariant*: under a reparametrization $\theta = A\eta + b$
+for invertible $A$, the Newton iterates in $\eta$ are exact images of those in
+$\theta$, so the algorithm sees no difference between a well-conditioned and an
+ill-conditioned parametrization of the same underlying problem. The
+condition-number dependence that makes gradient descent slow
+(Section\ \@ref(smoothness)) is no longer an issue. Second, near a strict local
+minimizer where the Hessian is positive definite and Lipschitz continuous, pure
+Newton converges *quadratically*: there is a constant $M$ such that
+
+\[
+\|\theta_{n+1} - \theta^\star\|_2 \leq M \|\theta_n - \theta^\star\|_2^2,
+\]
+
+so the number of correct digits roughly doubles per iteration. We state this
+without proof, and refer the interested reader to @Boyd:2004; @Nocedal:2006. Far
+from the minimizer, damped Newton enters a *damped phase* with $\gamma_n < 1$
+and at least linear convergence. Once the iterates reach a neighborhood of
+$\theta^\star$, they transition to the pure-Newton phase, where quadratic
+convergence takes over.
+
+The cost of these advantages is an increase in the computational demands of
+every iteration. Each Newton step requires the Hessian $\nabla^2 H(\theta_n)$, a
+dense $p \times p$ matrix that costs $O(N p^2)$ to assemble for typical
+exponential-family models (Section\ \@ref(parametrization)), and the solution of
+a linear system in that Hessian, costing $O(p^3)$ by Cholesky factorization. For
+$p$ in the hundreds this is unproblematic; for $p$ in the millions it is
+prohibitive. The quasi-Newton methods of the next section cut the cost by
+replacing the Hessian inverse with a cheap surrogate.
+
+We implement damped Newton below as the function `newton()`, an immediate
+extension of `grad_desc()` from Section\ \@ref(stop-crit) with the Hessian added
+to the argument list and the gradient swapped for the Newton direction.
+
+```{r}
+#| label: Newton
+
+newton <- function(
+  par,
   H,
   gr,
-  d = 0.8, 
-  c = 0.1, 
-  gamma0 = 0.05, 
+  hess,
+  d = 0.8,
+  c = 0.1,
+  gamma0 = 1,
   epsilon = 1e-10,
-  maxit = 10000,
+  maxit = 50,
   cb = NULL
 ) {
-  p <- length(par)
-  m <- 1
-  rho0 <- numeric(p)
-  for(n in 1:maxit) {
+  for (n in 1:maxit) {
     value <- H(par)
     grad <- gr(par)
     grad_norm_sq <- sum(grad^2)
-    if(!is.null(cb)) cb()
-    if(grad_norm_sq <= epsilon) break
-    gamma <- gamma0
-    # Descent direction
-    rho <- - grad + grad_norm_sq * rho0
-    h_prime <- drop(t(grad) %*% rho)
-    # Reset to gradient if m > p or rho is not a descent direction
-    if(m > p || h_prime >= 0) {
-      rho <- - grad
-      h_prime <- - grad_norm_sq 
-      m <- 1
+
+    if (!is.null(cb)) {
+      cb()
     }
+
+    if (grad_norm_sq <= epsilon) {
+      break
+    }
+
+    Hessian <- hess(par)
+    rho <- -drop(solve(Hessian, grad))
+    gamma <- gamma0
     par1 <- par + gamma * rho
-    # Backtracking
-    while(H(par1) > value + c * gamma * h_prime) {
+    h_prime <- t(grad) %*% rho
+
+    while (H(par1) > value + c * gamma * h_prime) {
       gamma <- d * gamma
       par1 <- par + gamma * rho
     }
-    rho0 <- rho / grad_norm_sq
+
     par <- par1
-    m <- m + 1
   }
-  if(n == maxit)
+
+  if (n == maxit) {
     warning("Maximum number, ", maxit, ", of iterations reached")
+  }
+
   par
 }
 ```
 
+### Poisson regression
 
-```{r cg-test-null, echo=2:3, dependson=c("veg-pois", "cg")}
-old_options = options(digits = 5)
-cg_tracer <- CSwR::tracer(c("value", "gamma", "grad_norm_sq"), Delta = 25)
-pois_cg <- conj_grad(
-  veg_pois$par, 
-  veg_pois$H, 
-  veg_pois$grad, 
-  cb = cg_tracer$tracer
-)
-options(digits = old_options$digits)
-```
+We reconsider the Poisson regression model `pois_model` from
+Section\ \@ref(regression). The vegetables dataset has 352 stores, so a fit with
+store-level intercepts plus a slope on $\log(\mathrm{normalSale})$ gives 353
+parameters, a non-trivial size that exposes the differences between optimization
+algorithms.
 
-```{r gd-cg-trace-plot, echo=FALSE, fig.cap="Gradient norms (top) and negative log-likelihoods (bottom) for gradient descent (left) and conjugate gradient (right).", fig.height=6, fig.width=8, dependson=c("cg-test-null", "gd-trace-plot"), out.width="100%", message=FALSE}
-trace_cg <- summary(cg_tracer)
+```{r, dependson=c("Implement")}
+#| label: X-update
 
-rate3 <- exp(coef(lm(log(grad_norm_sq) / 2 ~ I(1000 * .time), data = trace_cg, subset = 11:nrow(trace_cg))))[2]
-
-p3 <- ggplot(data = trace_cg, aes(x = 1000 * .time, y = sqrt(grad_norm_sq))) +
-  geom_point() + 
-  scale_y_log10("Gradient norm") +
-  xlab("") + 
-  geom_smooth(method = "lm", se = FALSE, method.args = list(subset = 11:nrow(trace_cg))) + 
-  geom_text(aes(x = 15, y = 10, label = paste("rate:", round(rate3, 3), "per ms")), data = data.frame())
-
-rate4 <- exp(coef(lm(log(value - value_Inf) ~ I(1000 * .time), data = trace_cg, subset = 11:nrow(trace_cg))))[2]
-
-p4 <- ggplot(data = trace_cg, aes(x = 1000 * .time, y = value - value_Inf)) +
-  geom_point() + 
-  scale_y_log10(expression(Value - Value[infinity])) +
-  xlab("Time (ms)") + 
-  geom_smooth(method = "lm", se = FALSE, method.args = list(subset = 11:nrow(trace_cg))) + 
-  geom_text(aes(x = 15, y = 10, label = paste("rate:", round(rate4, 3), "per ms")), data = data.frame())
-
-cc1 <- coord_cartesian(xlim = c(0, 20), ylim = c(1e-5, 1000))
-cc2 <- coord_cartesian(xlim = c(0, 20), ylim = c(1e-12, 1000))
-gridExtra::grid.arrange(p1 + cc1 + ggtitle("Gradient descent") + xlab(""), 
-             p3 + cc1 + ggtitle("Conjugate gradient"), 
-             p2 + cc2, p4 + cc2, nrow = 2)
-```
-
-
-This algorithm is fast enough to fit the large Poisson regression model.
-
-```{r X-update, dependson=c("Implement")}
 veg_pois_large <- poisson_model(
-  ~ store + log(normalSale) - 1, 
-  CSwR::vegetables, 
+  ~ store + log(normalSale) - 1,
+  CSwR::vegetables,
   response = "sale"
 )
 ```
 
-```{r cg-test, echo=2:3, dependson=c("X-update", "cg")}
-old_options = options(digits = 5)
-cg_tracer <- CSwR::tracer(c("value", "gamma", "grad_norm_sq"), Delta = 400)
-pois_cg <- conj_grad(
-  veg_pois_large$par, 
-  veg_pois_large$H, 
-  veg_pois_large$grad, 
-  cb = cg_tracer$tracer
-)
-options(digits = old_options$digits)
-```
+The `veg_pois_large` list contains the negative log-likelihood $H$, the gradient
+$\nabla H$, and the Hessian $\nabla^2 H$ that the Newton iteration requires.
 
-```{r cg-tracer-summary, dependson = "cg-test"}
-tail(summary(cg_tracer))
-```
+```{r, dependson=c("X-update", "Newton")}
+#| label: Newton-test
 
-Using `optim()` with the conjugate gradient method.
-
-```{r cg-optim, dependson=c("X-update")}
-bench::bench_time(
-  pois_optim_cg <- optim(
-    veg_pois_large$par, 
-    veg_pois_large$H, 
-    veg_pois_large$grad, 
-    method = "CG", 
-    control = list(maxit = 10000)
-  )
-)
-```
-
-```{r cg-results, dependson="cg-optim"}
-pois_optim_cg[c("value", "counts")]
-```
-
-```{r cg-comparisons, echo = FALSE, eval = FALSE}
-old_options = options(digits = 15)
-veg_pois_large$H(pois_cg)
-veg_pois_large$H(pois_optim_cg$par)
-options(digits = old_options$digits)
-```
-
-## Newton-type algorithms {#Newton}
-
-The Newton algorithm is similar to gradient descent except that the gradient is 
-replaced by
-
-\[
-\rho_n = - D^2 H(\theta_n)^{-1} \nabla H(\theta_n)
-\]
-
-as a descent direction.
-
-The Newton algorithm is typically much more efficient than gradient 
-descent per iteration and will converge in few iterations. However, the storage of the 
-$p \times p$ Hessian, its computation, and the solution of the equation
-to compute $\rho_n$ all scale like $p^2$ and this can make the algorithm useless 
-for large $p$. 
-
-The standard Newton algorithm for a general objective function is implemented 
-in R via the function `nlm()`. Note that its interface differs from `optim()` 
-in terms of the order and type of the arguments, and the gradient 
-(and Hessian) are passed to `nlm()` as attributes to the objective function 
-rather than as arguments to `nlm()` itself. For non-linear least squares 
-problems the `nls()` function (with yet another interface) should be 
-considered. 
-
-We implement a standard Newton algorithm with backtracking below, which includes a
-callback option allowing us to trace the internals of the algorithm. It is a 
-straightforward modification of `grad_desc()` where we add the Hessian to the argument 
-list and change the descent direction.
-
-```{r Newton}
-newton <- function(
-  par, 
-  H,
-  gr,
-  hess,
-  d = 0.8, 
-  c = 0.1, 
-  gamma0 = 1, 
-  epsilon = 1e-10, 
-  maxit = 50,
-  cb = NULL
-) {
-  for(n in 1:maxit) {
-    value <- H(par)
-    grad <- gr(par)
-    grad_norm_sq <- sum(grad^2)
-    if(!is.null(cb)) cb()
-    if(grad_norm_sq <= epsilon) break
-    Hessian <- hess(par) 
-    rho <- - drop(solve(Hessian, grad)) 
-    gamma <- gamma0
-    par1 <- par + gamma * rho
-    h_prime <- t(grad) %*% rho 
-    while(H(par1) > value +  c * gamma * h_prime) { 
-      gamma <- d * gamma 
-      par1 <- par + gamma * rho
-    }
-    par <- par1 
-  }
-  if(n == maxit)
-    warning("Maximum number, ", maxit, ", of iterations reached")
-  par
-}
-```
-
-There exists a variety of alternatives to the Newton algorithm that replace
-the Hessian by another matrix that can be easier to compute and update. 
-That is, the descent directions are of the form 
-
-\[
-\rho_n = - B_n \nabla H(\theta_n)
-\]
-
-for a $p \times p$ matrix $B_n$. With $B_n = D^2 H(\theta_n)^{-1}$ we get 
-the standard Newton algorithm. Whether $\rho_n$ is actually a descent direction 
-depends on $B_n$. A sufficient condition is that $B_n$ is a positive 
-definite matrix. 
-
-### Poisson regression 
-
-We reconsider the Poisson regression model, `pois_model`, from Section 
-\@ref(regression), which was also considered in Section \@ref(conjugate-gradients).
-There we used conjugate gradient descent to estimate the 353 parameters. 
-Recall that the `veg_pois_large` list contains all the functions needed to 
-run the Newton algorithm---including the Hessian matrix. 
-
-```{r Newton-test, dependson=c("X-update", "Newton")}
 newton_tracer <- CSwR::tracer(
-  c("value", "gamma", "grad_norm_sq"), 
+  c("value", "gamma", "grad_norm_sq"),
   Delta = 0
 )
 pois_newton <- newton(
-  veg_pois_large$par, 
-  veg_pois_large$H, 
-  veg_pois_large$grad, 
-  veg_pois_large$Hessian, 
+  veg_pois_large$par,
+  veg_pois_large$H,
+  veg_pois_large$grad,
+  veg_pois_large$Hessian,
   cb = newton_tracer$tracer
 )
 ```
 
-We compare the resulting parameter estimates to those in `pois_model`, 
-computed using `glm.fit()`.
+We compare the resulting parameter estimates to those in `pois_model`, computed
+using `glm.fit()`.
 
-```{r Newton-comp, dependson=c("Newton-test", "pois-model")}
+```{r, dependson=c("Newton-test", "pois-model")}
+#| label: Newton-comp
+
 range(pois_newton - coefficients(pois_model))
 ```
 
-The differences between all parameters are very small. We can also compare the 
-corresponding values of the objective function, and we include in this comparison
-the value found using conjugate gradient.
+The differences are very small. The corresponding values of the negative
+log-likelihood agree to high precision as well:
 
-```{r Newton-object, dependson=c("X-update", "Newton-test", "pois-model"), echo=2}
+```{r, dependson=c("X-update", "Newton-test", "pois-model"), echo=2}
+#| label: Newton-object
+
 old_options = options(digits = 20)
 rbind(
-  pois_cg = veg_pois_large$H(pois_cg),
   pois_newton = veg_pois_large$H(pois_newton),
   pois_glm = veg_pois_large$H(coefficients(pois_model))
 )
 options(digits = old_options$digits)
 ```
 
-We see that these values are also extremely close with the first 12 digits 
-identical. 
+The trace information from the Newton run shows the algorithm reaching the
+stringent stopping criterion (squared gradient norm below $10^{-10}$) in only 10
+iterations.
 
-We finally study the trace information from running our Newton algorithm.
+```{r, dependson=c("Newton-test")}
+#| label: Newton-tracer-summary
 
-```{r Newton-tracer-summary, dependson=c("Newton-test")}
 summary(newton_tracer)
 ```
 
-We note the relatively few iterations used (10 in this case) to reach the 
-stringent stopping criterion that the squared gradient norm is less than $10^{-10}$. 
-This took less than $2$ seconds. Compare this to the $12$--$15$ seconds it took 
-the conjugate gradient algorithm to reach a similarly accurate value of 
-the minimizer. By inspecting the trace information (not shown) for 
-conjugate gradient it turns out that after the first $1$--$1.5$ second 
-(about 250 iterations) it reached roughly the same accuracy as Newton
-did in its first $7$ iterations. Thereafter, conjugate gradient spend
-the rest of the time improving the accuracy slowly while Newton in just 
-$3$ additional iterations converged to a very accurate minimizer. This 
-is a characteristic behavior of Newton, which has superlinear (in fact, quadratic)
-convergence.
+The whole run takes well under two seconds, and the per-iteration trace reveals
+the two-phase pattern: the first iterations are damped ($\gamma_n < 1$) while
+the iterates approach the basin of attraction; once inside, $\gamma_n = 1$ and
+the squared gradient norm drops by many orders of magnitude per step. This is
+the quadratic-convergence endgame in action.
 
-It is natural to ask if the R function `glm.fit()`, which also uses a Newton 
-algorithm (without backtracking), is faster than our implementation.
+R's built-in `glm.fit()` also uses a Newton iteration (without backtracking) and
+is a natural benchmark.
 
-```{r pois-glm.fit, dependson=c("X-update", "Newton-test")}
+```{r, dependson=c("X-update", "Newton-test")}
+#| label: pois-glm.fit
+
 env_pois <- environment(veg_pois_large$H)
 bench::bench_time(
   glm.fit(env_pois$X, env_pois$y, family = poisson())
 )
 ```
 
-Using `glm.fit()` is about a factor five faster on this example than 
-our Newton algorithm---but we should always be very careful when comparing 
-the runtimes of two different optimization algorithms. In this case they 
-have achieved about the same numerical precision, and by the comparison 
-above of the optimized value of the objective function, 
-the faster `glm.fit()` even obtained the smallest negative
-log-likelihood of the two.
+Using `glm.fit()` is about a factor five faster on this example than our Newton
+algorithm, but we should always be very careful when comparing the runtimes of
+two different optimization algorithms. In this case they have achieved about the
+same numerical precision, and by the comparison above of the optimized value of
+the objective function, the faster `glm.fit()` even obtained the smallest
+negative log-likelihood of the two.
 
-### Quasi-Newton algorithms
+## Quasi-Newton methods
 
-We turn to other descent direction algorithms that are more efficient 
-than gradient descent by choosing the descent direction in a more 
-clever way but less computationally demanding than the Newton 
-algorithm that requires the computation of the full Hessian in each 
-iteration. 
+Newton's method's per-iteration cost, $O(N p^2)$ to assemble the Hessian plus
+$O(p^3)$ for the linear solve, is fine for $p$ in the hundreds, as the Poisson
+regression example just demonstrated, but punitive for larger problems.
+*Quasi-Newton* methods keep the Newton update form
 
-We will only consider the application of the BFGS algorithm via the 
-implementation in the R function `optim()`.
+\[
+\rho_n = -B_n \nabla H(\theta_n)
+\]
 
-```{r BFGS, dependson=c("X-update")}
+but replace the inverse Hessian $[\nabla^2 H(\theta_n)]^{-1}$ with a cheaper
+positive-definite surrogate $B_n$ updated incrementally from gradient
+differences across iterations. Any positive-definite $B_n$ makes $\rho_n$ a
+descent direction, since
+$\rho_n^\top \nabla H(\theta_n) = -\nabla H(\theta_n)^\top B_n \nabla H(\theta_n) < 0$.
+
+The dominant quasi-Newton algorithm in practice is *BFGS*\index{BFGS}
+(Broyden--Fletcher--Goldfarb--Shanno), which maintains a rank-two update to
+$B_n$ satisfying a *secant condition*: $B_n$ maps the most recent gradient
+difference to the corresponding parameter difference, matching the true Hessian
+inverse along that direction. The update costs $O(p^2)$ per iteration without
+ever forming the Hessian. *L-BFGS*\index{L-BFGS} stores only the last few
+gradient and parameter differences, typically between five and twenty, and
+reconstructs $B_n$ on the fly. Its memory footprint is linear in $p$, and it is
+the de facto standard for problems with $p$ in the thousands or millions. We
+will not derive the BFGS update; @Nocedal:2006 has the details. R's `optim()`
+provides BFGS as one of its methods:
+
+```{r, dependson=c("X-update")}
+#| label: BFGS
+
 bench::bench_time(
   pois_bfgs <- optim(
-    veg_pois_large$par, 
-    veg_pois_large$H, 
-    veg_pois_large$grad, 
-    method = "BFGS", 
+    veg_pois_large$par,
+    veg_pois_large$H,
+    veg_pois_large$grad,
+    method = "BFGS",
     control = list(maxit = 10000)
   )
 )
 ```
 
-```{r BFGS-results, dependson="BFGS"}
+```{r, dependson=c("BFGS", "pois-model")}
+#| label: BFGS-results
+
 range(pois_bfgs$par - coefficients(pois_model))
 pois_bfgs[c("value", "counts")]
 ```
 
+BFGS reaches an estimate matching `pois_model` to high precision in seconds,
+without ever computing $\nabla^2 H$ explicitly. This is the default
+recommendation for general-purpose maximum-likelihood estimation in R when the
+gradient is available; both `optim()` and `nlminb()` use a quasi-Newton method
+underneath.
+
+### Nonlinear conjugate gradient
+
+A historical predecessor to BFGS, the *nonlinear conjugate
+gradient*\index{conjugate gradient} algorithm uses only gradient information but
+couples each step to the previous descent direction so as to escape the zig-zag
+pattern that slows plain gradient descent on ill-conditioned problems. In the
+Fletcher-- Reeves version the descent direction is
+
+\[
+\rho_n = -\nabla H(\theta_n) + \frac{\|\nabla H(\theta_n)\|_2^2}{\|\nabla H(\theta_{n-1})\|_2^2} \rho_{n-1},
+\]
+
+initialized at $\rho_0 = -\nabla H(\theta_0)$; the Polak--Ribière and
+Hestenes--Stiefel variants differ in the prefactor of $\rho_{n-1}$. Conjugate
+gradient uses only $O(p)$ memory and avoids matrix storage altogether, but needs
+many more iterations than BFGS to reach a given accuracy and is rarely the
+default choice today. R's `optim()` exposes the algorithm via `method = "CG"`:
+
+```{r, dependson=c("X-update")}
+#| label: cg-test
+
+bench::bench_time(
+  pois_cg <- optim(
+    veg_pois_large$par,
+    veg_pois_large$H,
+    veg_pois_large$grad,
+    method = "CG",
+    control = list(maxit = 10000)
+  )$par
+)
+```
+
+```{r, dependson="cg-test"}
+#| label: cg-objective
+
+veg_pois_large$H(pois_cg)
+```
+
+The CG run reaches the same minimizer as BFGS but spends substantially more
+wall-clock time on this problem. This is one reason BFGS, or L-BFGS for larger
+problems, is the better first choice.
+
+## Constrained optimization {#pep-moth-descent}
+
+Every algorithm in this chapter so far has assumed the parameter space is all of
+$\mathbb{R}^p$, but many statistical models are not so accommodating. The
+peppered-moth maximum-likelihood problem of Section\ \@ref(pep-moth) is
+\index{peppered moth!barrier method}\index{barrier method} inherently
+constrained: the allele frequencies $(p_C, p_I)$ must lie in the triangle
+$\{p_C \geq 0,\, p_I \geq 0,\, p_C + p_I \leq 1\}$. The implementation in
+Section\ \@ref(pep-moth) handled this by returning $+\infty$ at infeasible
+parameters, and Nelder--Mead's derivative-free search handles that gracefully,
+but the descent methods of Sections\ \@ref(grad-descent) and do not. A gradient
+step does not respect inequality constraints; a backtracking line search treats
+an infinite boundary as an arbitrarily steep wall but cannot see around it; and
+the gradient itself is undefined at $+\infty$. The right algorithm for the
+constrained problem is instead the *barrier method*, which is what we devote the
+sequel of this section to.
+
+Write the constrained problem in the standard form used by
+Theorem\ \@ref(thm:kkt):
+
+\[
+\operatorname*{minimize}_\theta H(\theta) \quad \text{subject to} \quad
+g_i(\theta) \leq 0, \quad i = 1, \ldots, r,
+\]
+
+with $H$ and the $g_i$ convex and differentiable. For peppered moths
+$\theta = (p_C, p_I)$, $H(\theta) = -\ell(\theta)$, and the three inequalities
+are
+
+\[
+g_1(\theta) = -p_C, \quad g_2(\theta) = -p_I, \quad g_3(\theta) = p_C + p_I - 1.
+\]
+
+The KKT conditions characterize the minimizer through stationarity, primal
+feasibility, and complementary slackness, but they presume one already *knows*
+which constraints are active at $\theta^\star$. A numerical algorithm cannot
+start from that knowledge; it has to discover the active set as it goes.
+
+The barrier method softens the hard inequalities into a smooth penalty that
+diverges at the boundary. The standard choice is the *logarithmic barrier*
+
+\begin{equation}
+\phi(\theta) = -\sum_{i=1}^r \log(-g_i(\theta)),
+(\#eq:log-barrier)
+\end{equation}
+
+defined on the strict interior
+$\{\theta : g_i(\theta) < 0,\ i = 1, \ldots, r\}$. For peppered moths,
+$\phi(\theta) = -\log p_C - \log p_I - \log(1 - p_C - p_I)$. Each term diverges
+as the corresponding constraint becomes tight, so $\phi$ acts as a one-sided
+wall pushing iterates away from the boundary. For each $t > 0$ consider the
+unconstrained *centering problem*
+
+\begin{equation}
+\operatorname*{minimize}_\theta \, t H(\theta) + \phi(\theta).
+(\#eq:centering)
+\end{equation}
+
+When $H$ is convex the centering objective is strictly convex on the interior,
+and its minimizer $\theta^\star(t)$, when it exists, lies strictly inside the
+feasible set. As $t$ grows the barrier matters less, iterates are allowed closer
+to the boundary, and $\theta^\star(t)$ approaches the constrained optimum
+$\theta^\star$. The map $t \mapsto \theta^\star(t)$ is the *central
+path*\index{central path}, and the gap between objective values along it admits
+a clean bound.
+
+::: {.theorem #barrier-suboptimality name="Barrier-method suboptimality"}
+Let $H$ and the $g_i$ be convex and differentiable, suppose the feasible set has
+nonempty interior, and suppose the constrained problem has a minimizer
+$\theta^\star$. For each $t > 0$ the centering problem \@ref(eq:centering) has a
+minimizer $\theta^\star(t)$, and
+
+\[
+H(\theta^\star(t)) - H(\theta^\star) \leq r / t.
+\]
+:::
+
+The proof, which we omith here, constructs an explicit dual-feasible point from
+$\theta^\star(t)$ via the KKT conditions for the centering problem and
+constructs the duality gap as $r/t$ (see @Boyd:2004, Section\ 11.2.2). The bound
+is essentially tight, so $r/t$ is the right tolerance to target: each
+multiplicative bump in $t$ shaves the suboptimality by the same factor, and
+reaching gap $\epsilon$ requires only $t \geq r / \epsilon$.
+
+The algorithm follows from the bound. Start from a strictly feasible
+$\theta^{(0)}$ and a modest $t_0 > 0$; minimize the centering problem to find
+$\theta^{(1)} = \theta^\star(t_0)$; multiply $t$ by some $\mu > 1$; re-minimize
+starting from $\theta^{(1)}$; iterate until $r / t < \epsilon$. Each inner
+subproblem is unconstrained and (for convex $H$) convex, so the descent
+algorithms of Sections\ \@ref(grad-descent)--\@ref(Newton) handle it. Warm
+starting from the previous central-path iterate keeps the inner solves cheap
+because consecutive points on the central path are close. Typical choices are
+$\mu \in [10, 100]$ with BFGS or damped Newton for the inner solve; @Boyd:2004
+(Section\ 11.3) discusses the tradeoff between aggressive $\mu$ (few outer
+iterations, each expensive) and gentle $\mu$ (many outer iterations, each
+cheap).
+
+Figure\ \@ref(fig:pep-central-path) plots the centering objective for the
+peppered-moth problem at four values of $t$. When $t$ is small the barrier
+dominates and the minimizer sits near the analytic center of the simplex; as $t$
+grows the iterate slides along the central path toward the maximum-likelihood
+estimate. Here the constrained optimum lies in the *interior* of the
+simplex---no constraint is active at $\theta^\star$---but the MLE is close
+enough to the $p_C = 0$ and $p_I = 0$ edges that the barrier visibly bends the
+contours away from them.
+
+```{r}
+#| label: pep-central-path
+#| echo: false
+#| warning: false
+#| fig-cap: "Contours of the centering objective $t H(\\theta) + \\phi(\\theta)$ for the peppered-moth problem at four values of $t$ (contour levels normalized within each panel). The dashed lines mark the simplex boundary, the white circle marks the constrained optimum $\\theta^\\star$, and the orange cross marks the minimizer of the centering problem at that $t$. As $t$ grows, the cross traces the central path from the analytic center of the simplex toward $\\theta^\\star$."
+#| fig-width: 6
+#| fig-height: 6.2
+
+ny_fig <- c(85, 196, 341)
+H_fig <- function(p) {
+  pT <- 1 - p[1] - p[2]
+  pD <- p[1]^2 + 2 * p[1] * p[2] + 2 * p[1] * pT
+  pM <- p[2]^2 + 2 * p[2] * pT
+  pL <- pT^2
+  -(ny_fig[1] * log(pD) + ny_fig[2] * log(pM) + ny_fig[3] * log(pL))
+}
+phi_fig <- function(p) -log(p[1]) - log(p[2]) - log(1 - p[1] - p[2])
+
+p1_grid <- seq(0.005, 0.995, length.out = 161)
+p2_grid <- seq(0.005, 0.995, length.out = 161)
+grid_df <- expand.grid(p1 = p1_grid, p2 = p2_grid)
+grid_df$pT <- 1 - grid_df$p1 - grid_df$p2
+grid_df <- subset(grid_df, pT > 0.001)
+grid_df$H <- -(ny_fig[1] *
+  log(
+    grid_df$p1^2 + 2 * grid_df$p1 * grid_df$p2 + 2 * grid_df$p1 * grid_df$pT
+  ) +
+  ny_fig[2] * log(grid_df$p2^2 + 2 * grid_df$p2 * grid_df$pT) +
+  ny_fig[3] * log(grid_df$pT^2))
+grid_df$phi <- -log(grid_df$p1) - log(grid_df$p2) - log(grid_df$pT)
+
+ts <- c(1e-4, 1e-3, 1e-2, 1)
+t_label <- function(t) paste0("t == ", formatC(t, format = "g", digits = 2))
+
+contour_df <- do.call(
+  rbind,
+  lapply(ts, function(t) {
+    z <- t * grid_df$H + grid_df$phi
+    data.frame(
+      p1 = grid_df$p1,
+      p2 = grid_df$p2,
+      z = (z - min(z)) / (max(z) - min(z)),
+      t = t
+    )
+  })
+)
+centering_df <- do.call(
+  rbind,
+  lapply(ts, function(t) {
+    star <- optim(
+      c(0.3, 0.3),
+      function(p) t * H_fig(p) + phi_fig(p),
+      method = "BFGS"
+    )$par
+    data.frame(p1 = star[1], p2 = star[2], t = t)
+  })
+)
+opt <- optim(c(0.3, 0.3), H_fig, method = "BFGS")$par
+opt_df <- data.frame(p1 = opt[1], p2 = opt[2], t = ts)
+
+contour_df$panel <- factor(t_label(contour_df$t), levels = t_label(ts))
+centering_df$panel <- factor(t_label(centering_df$t), levels = t_label(ts))
+opt_df$panel <- factor(t_label(opt_df$t), levels = t_label(ts))
+
+simplex_df <- data.frame(
+  x = c(0, 1, 0),
+  y = c(0, 0, 1),
+  xend = c(1, 0, 0),
+  yend = c(0, 1, 0)
+)
+
+ggplot() +
+  geom_contour(
+    data = contour_df,
+    aes(p1, p2, z = z, color = after_stat(level)),
+    breaks = seq(0, 0.4, length.out = 22),
+    linewidth = 0.3
+  ) +
+  geom_segment(
+    data = simplex_df,
+    aes(x = x, y = y, xend = xend, yend = yend),
+    linetype = "dashed",
+    color = "grey40"
+  ) +
+  geom_point(
+    data = opt_df,
+    aes(p1, p2),
+    shape = 21,
+    fill = "white",
+    color = "black",
+    size = 2.4,
+    stroke = 0.6
+  ) +
+  geom_point(
+    data = centering_df,
+    aes(p1, p2),
+    shape = 4,
+    color = "darkorange",
+    size = 2.8,
+    stroke = 1.3
+  ) +
+  facet_wrap(~panel, labeller = label_parsed) +
+  scale_color_viridis_c(guide = "none") +
+  coord_fixed(xlim = c(0, 1), ylim = c(0, 1), expand = FALSE) +
+  labs(x = expression(p[C]), y = expression(p[I])) +
+  theme_minimal()
+```
+
+For the peppered moths we re-implement the negative log-likelihood as a function
+of the allele frequencies, dropping the boundary check from
+Section\ \@ref(pep-moth) because the barrier will keep iterates in the interior:
+
+```{r}
+#| label: pep-neg-loglik
+
+neg_loglik_pep <- function(p, ny) {
+  p_T <- 1 - p[1] - p[2]
+  p_dark <- p[1]^2 + 2 * p[1] * p[2] + 2 * p[1] * p_T
+  p_mott <- p[2]^2 + 2 * p[2] * p_T
+  p_light <- p_T^2
+  -(ny[1] * log(p_dark) + ny[2] * log(p_mott) + ny[3] * log(p_light))
+}
+```
+
+The log-barrier is similarly direct:
+
+```{r}
+#| label: pep-barrier
+
+phi_pep <- function(p) {
+  -log(p[1]) - log(p[2]) - log(1 - p[1] - p[2])
+}
+```
+
+A straightforward implementation of the outer loop uses BFGS for each inner
+solve via `optim()`:
+
+```{r, dependson=c("pep-neg-loglik", "pep-barrier")}
+#| label: pep-barrier-loop
+#| warning: false
+
+ny <- c(85, 196, 341)
+r <- 3
+mu <- 10
+t <- 1
+theta <- c(0.3, 0.3)
+
+repeat {
+  centering <- function(p) t * neg_loglik_pep(p, ny) + phi_pep(p)
+  theta <- optim(theta, centering, method = "BFGS")$par
+
+  if (r / t < 1e-8) {
+    break
+  }
+
+  t <- mu * t
+}
+theta
+```
+
+R's `constrOptim()` packages this loop with an adaptive $\mu$ and its own
+stopping rule. It expects affine inequality constraints in the form
+$A\theta \succeq b$, supplied as a matrix `ui` and a vector `ci` with
+`ui %*% theta >= ci`. Rewriting $g_1, g_2, g_3 \leq 0$ in that form gives
+
+\[
+A = \begin{pmatrix} 1 & 0 \\ 0 & 1 \\ -1 & -1 \end{pmatrix},
+\quad b = \begin{pmatrix} \phantom{-}0 \\ \phantom{-}0 \\ -1 \end{pmatrix},
+\]
+
+so the same problem reduces to one call:
+
+```{r, dependson="pep-neg-loglik"}
+#| label: pep-constropt
+#| warning: false
+
+A <- rbind(c(1, 0), c(0, 1), c(-1, -1))
+b <- c(0, 0, -1)
+
+constrOptim(
+  c(0.3, 0.3),
+  neg_loglik_pep,
+  NULL,
+  ui = A,
+  ci = b,
+  ny = c(85, 196, 341)
+)$par
+```
+
+Both runs return the maximum-likelihood estimate found by Nelder--Mead in
+Section\ \@ref(pep-moth). The algorithms differ; the optimum does not.
+
+This example also illustrates the second strategy outlined in
+Section\ \@ref(constraints): keep the constraints and solve a sequence of smooth
+unconstrained problems. The first strategy, reparametrizing through the softmax
+to lift the simplex to all of $\mathbb{R}^K$, would also work here but it
+destroys convexity of the multinomial log-likelihood and forfeits the KKT-based
+suboptimality bound. A third approach: The EM algorithm (covered in
+Chapter\ \@ref(em)), exploits the latent-genotype structure specific to the
+peppered moths to sidestep the constraint problem entirely.
+
+## Algorithms in practice
+
+The previous sections introduced five algorithms: gradient descent, Newton's
+method, BFGS, nonlinear conjugate gradient, and the barrier method. We provided
+implementations in R that we one could inspect and modify. In an actual data
+analysis, R features a set of classical, well-tested algorithms through
+`optim()`, `constrOptim()`, and a handful other specialized interfaces, and
+these functions serve most basic use cases. This short section tries to link the
+algorithms to those interfaces, raises two common pitfalls, and revisits the
+Poisson-regression example to show what knowing the structure of the problem can
+sometimes gain us in terms of numerical performance.
+
+`optim()` is R's workhorse for general-purpose unconstrained minimization. Its
+`method` argument exposes Nelder--Mead (the default, derivative-free), `"BFGS"`,
+`"L-BFGS-B"` (box-constrained quasi-Newton), `"CG"` (Polak--Ribière conjugate
+gradient), and `"SANN"` (simulated annealing, not covered here). If you are able
+to supply a function to compute the gradient through `gr`, then you should
+typically opt for L-BFGS-B, which is a good off-the-shelf choice that also
+allows box constraints to be supplied through `lower` and `upper`. `nlminb()`
+and `nlm()` are alternatives that calls quasi-Newton routines and are sometimes
+faster on expensive objectives. For linear inequality constraints in the form
+$A\teta \succeq b$, we can use `constrOptim()`, which wraps `optim()` with the
+barrier method of Section\ \@ref(pep-moth-descent). If you are interested in an
+extensive guide to the optimization infrastructure R and other CRAN packages
+have to offer, we recommend @Nash:2014 and the [CRAN task view of optimization
+and mathematical programming](https://cran.r-project.org/view=Optimization).
+
+For canonical-link generalized linear models, `glm()` and `glm.fit()` implement
+iteratively reweighted least squares, which is exactly Newton's method on the
+negative log-likelihood specialized to the exponential family
+(Section\ \@ref(parametrization)). Bypassing `glm()` to call `optim()` directly
+is rarely worth it: the specialized implementation is both faster and more
+convenient to work with. The Poisson-regression code from
+Sections\ \@ref(grad-descent) and \@ref(Newton) was written by hand precisely to
+expose the descent algorithms. In practice, fitting the model comes down to a
+single line via `glm(..., family = "poisson")`.
+
+Here, we want to raise two common pitfalls. First, numerical gradients via
+finite differences are subject to a tradeoff between truncation and roundoff
+error. They work well in well-behaved regions of the optimization surface,but
+can stall a quasi-Newton method near an optimum. Supplying an analytic gradient
+is almost always worth the effort, both for speed and stability. Second, the
+default convergence tolerances assume $H \sim O(1)$---if the objective is far
+away from unity, the `parscale` and `fnscale` entries of `optim()`'s `control`
+argument may help by rescaling the parameters and the objective to a more
+typical range.
+
 ### Sparsity
 
-One of the benefits of the implementations of $H$ and its derivatives
-as well as of the descent algorithms is that they can exploit sparsity
-of $\mathbf{X}$ almost for free. The implementations have not done that in 
-previous computations, because $\mathbf{X}$ has been stored as a dense matrix. In 
-reality, $\mathbf{X}$ is a very sparse matrix (the vast majority of the matrix 
-entries are zero), 
-and if we convert it into a sparse matrix, all the matrix-vector products 
-will be more runtime efficient. Sparse matrices are implemented in the 
-R package Matrix. 
+The custom implementations of $H$ and its derivatives, like the descent
+algorithms that consume them, treat $\mathbf{X}$ as an abstract matrix and
+exploit sparsity essentially for free. The Poisson-regression implementations
+above used a dense $\mathbf{X}$ only because that is what `model.matrix()`
+faster. The Matrix package supplies the sparse class:
 
-```{r Matrix, cache=FALSE}
+```{r}
+#| label: Matrix
+#| cache: false
+
 library(Matrix)
 ```
 
-```{r sparse, dependson=c("pois-glm.fit", "X-update")}
+```{r, dependson=c("pois-glm.fit", "X-update")}
+#| label: sparse
+
 env_pois$X <- Matrix(env_pois$X)
 class(env_pois$X)
 ```
 
-Without changing any other code, we get an immediate 
-runtime improvement using, e.g., `optim()` and the BFGS algorithm.
+Without any other change, BFGS via `optim()` runs faster:
 
-```{r BFGS-sparse, dependson=c("X-update", "sparse")}
+```{r, dependson=c("X-update", "sparse")}
+#| label: BFGS-sparse
+
 bench::bench_time(
   pois_bfgs_sparse <- optim(
-    veg_pois_large$par, 
-    veg_pois_large$H, 
-    veg_pois_large$grad, 
-    method = "BFGS", 
+    veg_pois_large$par,
+    veg_pois_large$H,
+    veg_pois_large$grad,
+    method = "BFGS",
     control = list(maxit = 10000)
   )
 )
 ```
 
-We should in real applications avoid constructing a dense intermediate 
-model matrix as a step toward constructing a sparse model matrix. This 
-is possible by constructing the sparse model matrix directly using 
-a function from the R package MatrixModels. Ideally, we should reimplement
-`pois_model()` to support an option for using sparse matrices, but 
-to focus on the runtime benefits of sparse matrices, we simply 
-change the matrix in the appropriate environment directly.
+For real applications one should avoid constructing the dense matrix in the
+first place. `MatrixModels::model.Matrix()` builds a sparse model matrix
+directly from a formula:
 
-```{r sparse-model-matrix, dependson=c("pois-glm.fit"), echo=-1}
+```{r, dependson=c("pois-glm.fit"), echo=-1}
+#| label: sparse-model-matrix
+
 library(MatrixModels)
 env_pois$X <- MatrixModels::model.Matrix(
   ~ store + log(normalSale) - 1,
@@ -1665,7 +1971,11 @@ env_pois$X <- MatrixModels::model.Matrix(
 class(env_pois$X)
 ```
 
-```{r time-model.matrix, echo=FALSE, eval=FALSE}
+```{r}
+#| label: time-model.matrix
+#| echo: false
+#| eval: false
+
 library(MatrixModels)
 bench::mark(
   sparse = X_sparse <- model.Matrix(
@@ -1678,128 +1988,70 @@ bench::mark(
     data = CSwR::vegetables
   ),
   check = FALSE
-) %>%  autoplot()
+) %>%
+  autoplot()
+
 range(as.matrix(X_sparse) - X)
 ```
 
-The Newton implementation benefits enormously from using sparse matrices
-because the bottleneck is the computation of the Hessian. 
+Newton's method benefits the most. The bottleneck of the dense implementation is
+the per-iteration Hessian assembly; with a sparse $\mathbf{X}$, that assembly
+drops by orders of magnitude.
 
-```{r time-sparse-model-matrix, echo=2:4, dependson=c("X-update", "Newton", "sparse-model-matrix")}
-pois_newton <- newton( # Ensures more correct timings, perhaps due to lazy-loading?
+```{r, echo=2:4, dependson=c("X-update", "Newton", "sparse-model-matrix")}
+#| label: time-sparse-model-matrix
+
+pois_newton <- newton(
+  # warm up to avoid lazy-loading overhead in the timing
   veg_pois_large$par,
   veg_pois_large$H,
   veg_pois_large$grad,
   veg_pois_large$Hessian
 )
+
 newton_tracer <- CSwR::tracer(c("value", "h_prime", "gamma"), Delta = 0)
-  pois_newton <- newton(
+
+pois_newton <- newton(
   veg_pois_large$par,
   veg_pois_large$H,
   veg_pois_large$grad,
   veg_pois_large$Hessian,
   cb = newton_tracer$tracer
 )
+
 summary(newton_tracer)
 ```
 
-To summarize the runtimes we have measured for the Poisson regression example, 
-we found that the conjugate gradient algorithms took of the order of 10 seconds 
-to converge. The Newton-type algorithms in this section were faster and took 
-between 0.3 and 1.7 seconds to converge. The use of sparse matrices reduced the 
-runtime of the quasi-Newton algorithm BFGS by a factor 3, but it reduced the 
-runtime of the Newton algorithm by a factor 150 to about 0.009 seconds. One could
-be concerned that the construction of the sparse model matrix takes more time (which
-we did not measure), but if measured it turns out that for this example 
-it takes about the same time to construct the dense model matrix as it takes to 
-construct the sparse one. 
+Pulling the timings together: with a dense $\mathbf{X}$, the conjugate gradient
+algorithm took around 10 seconds on the 353-parameter Poisson problem, BFGS
+roughly 2--3 seconds, and Newton's method between 0.3 and 1.7 seconds. Switching
+to a sparse $\mathbf{X}$ cut BFGS's runtime by a factor of three and Newton's by
+a factor of roughly 150, to about 0.009 seconds. The construction of the sparse
+model matrix is no slower than the dense one. Memory tells a similar story:
 
-Runtime efficiency is not the only argument for using sparse matrices as they are 
-also more memory efficient. It is memory (and time) inefficient to use dense intermediates, 
-and for truly large scale problems impossible. Using sparse model matrices 
-for regression models allows us to work with larger models that have 
-more variables, more factor levels and more observations than if we use dense
-model matrices. For the Poisson regression model the memory used by either representation can be found. 
+```{r, dependson=c("pois-glm.fit", "sparse-model-matrix"), echo=c(2, 4)}
+#| label: X-size
+#| results: "hold"
 
-```{r X-size, dependson=c("pois-glm.fit", "sparse-model-matrix"), echo=c(2, 4), results='hold'}
 cat("Sparse matrix memory usage:\n")
 object.size(env_pois$X)
+
 cat("Dense matrix memory usage:\n")
 object.size(as.matrix(env_pois$X))
 ```
 
-We see that the dense matrix uses around a factor 30 more memory than the 
-sparse representation. In this case it means using around 3 MB for storing the 
-dense matrix instead of around 100 kB, which won't be a problem 
-on a contemporary computer. However, going from using 3 GB for
-storing a matrix to using 100 Mb could be the difference between 
-not being able to work with the matrix on a standard laptop to
-running the computations with no problems. Using `model.Matrix()` makes
-it possible to construct sparse model matrices directly and avoid 
-all dense intermediates. 
+The dense representation uses about thirty times more memory. At the
+353-parameter scale of this example, the absolute difference between 3\ MB and
+100\ kB is unimportant. At the scale where it *would* matter, say going from
+3\ GB to 100\ MB, the choice between dense and sparse can be the difference
+between fitting the model on a laptop and not being able to load the design at
+all.
 
-The function `glm4()` from the MatrixModels package for fitting regression models, 
-can exploit sparse model matrices directly, and can 
-thus be useful in cases where your model matrix becomes very large but sparse. 
-There are two main applications where the model matrix becomes sparse. 
-When you model the response using one or more factors, and possibly their 
-interactions, the model matrix will become particularly sparse if 
-the factors have many levels. Another case is when you model the response 
-via basis expansions of quantitative predictors and use basis functions 
-with local support. The B-splines form an important example of such a basis
-with local support that results in a sparse model matrix.  
-
-
-## Misc.
-
-If $\Phi$ is just *nonexpansive* (the 
-constant $c$ above is one), this is no longer true, but replacing $\Phi$ 
-by $\alpha \Phi + (1 - \alpha) I$ for $\alpha \in (0,1)$ we get 
-Krasnoselskii-Mann iterates of the form 
-
-\[
-  \theta_n = \alpha \Phi(\theta_{n-1}) + (1 - \alpha) \theta_{n-1}
-\]
-
-that will converge to a fixed point of $\Phi$ provided it has one. 
-
-Banach's fixed point theorem implies a convergence that is at least as fast as 
-linear convergence with asymptotic rate $c$. 
-Moreover, if $\Phi$ is just a contraction for $n \geq n_0$ for some $n_0$, 
-then for $n \geq n_0$
-
-\[
-  \|\theta_{n + 1} - \theta_{n}\| \leq c \| \theta_{n} - \theta_{n-1}\|.
-\]
-
-The convergence may be superlinear, but if it is linear, the rate is bounded by $c$.
-To indicate if $\Phi$ is asymptotically a contraction, we can introduce
-
-\[
-  R_n = \frac{\|\theta_{n + 1} - \theta_{n}\|}{\|\theta_{n} - \theta_{n- 1}\|}
-\]
-
-and monitor its behavior as $n \to \infty$. The constant
-
-\[
-  r = \limsup_{n \to \infty} R_n
-\]
-
-is then asymptotically the smallest possible contraction constant. 
-If convergence is sublinear and $R_n \to 1$ the sequence is 
-called logarithmically convergent (by definition), while $r \in (0,1)$ is an 
-indication of linear convergence with rate $r$, and $r = 0$ is an indication of 
-superlinear convergence.
-
-In practice, we can plot the ratio $R_n$ as the algorithm is running, and 
-use $R_n$ as an estimate of the rate $r$ for large $n$. However, 
-this can be a quite unstable method for estimating the rate.
-
-Finally, it is also possible to 
-estimate the order $q$ as well as the rate $r$ by using that 
-$$\log \|\theta_{n} - \theta_{N}\| \approx q \log \|\theta_{n-1} - \theta_{N}\| + \log(r)$$
-for $n \geq n_0$. We can estimate $q$ and $\log(r)$
-by fitting a linear function by least squares to these log-log transformed norms 
-of errors. 
-
-Iteration, fixed points, convergence criteria. Ref to [Nonlinear Parameter Optimization Using R Tools](http://onlinelibrary.wiley.com/book/10.1002/9781118884003).
+The `glm4()` function in MatrixModels accepts sparse model matrices directly and
+is the recommended choice when the design is large and sparse. Two common
+situations produce sparsity: high-cardinality factor predictors, especially
+their interactions, and basis expansions of quantitative predictors using
+locally supported bases such as B-splines. In either case, switching to a sparse
+model matrix is essentially free at the modeling level and pays substantial
+dividends in compute and memory for the algorithms developed in this chapter.
+dividends in compute and memory for the algorithms developed in this chapter.

--- a/22-Optimization.Rmd
+++ b/22-Optimization.Rmd
@@ -18,19 +18,19 @@ When $H$ is convex, every stationary point is a global minimizer
 (Section\ \@ref(opt-conditions)) and the algorithms considered in this section
 produce a certified optimum. When it is not, they produce a local minimizer or
 merely a stationary point. That does not, however, mean that the solutions are
-meaningless. @Kiefer:1978, for instance, showed that the Gaussian-mixture
-likelihood of Section\ \@ref(Gauss-mix-ex) is unbounded above, yet $\nabla
-H(\theta) = 0$ admits a consistent sequence of solutions as $N \to \infty$.
-Convexity is convenient but not essential.
+without value. The Gaussian-mixture likelihood is for instance unbounded
+above\ (Section\ \@ref(Gauss-mix-ex)), yet the EM algorithm still converges to a
+local maximum that is statistically consistent. Convexity is convenient but not
+essential.
 
-Throughout the rest of this chapter, two recurrent themes will emerge. First,
-our goal is typically not the minimizer of $H$ for a particular dataset---what
-matters is the statistical estimate it represents. Driving an optimizer to
-machine precision is rarely worth the computational effort when the statistical
-uncertainty of the estimate is orders of magnitude larger, and our budget is
-then better spent exploring many models and starting values and quantifying
-parameter uncertainty. Second, the runtime of every algorithm in this chapter is
-dominated by the cost of evaluating $H$ and its derivatives. For
+Throughout the rest of this chapter, two recurrent themes will emerge. First, we
+observe that our goal is typically not the minimizer of $H$ for a particular
+dataset---what matters is the statistical estimate it represents. Driving an
+optimizer to machine precision is rarely worth the computational effort when the
+statistical uncertainty of the estimate is orders of magnitude larger, and our
+budget is then better spent exploring many models and starting values and
+quantifying parameter uncertainty. Second, the runtime of every algorithm in
+this chapter is dominated by the cost of evaluating $H$ and its derivatives. For
 exponential-family models, that cost collapses to a one-time
 sufficient-statistic computation (Section\ \@ref(parametrization)), making each
 iteration $O(p)$ rather than $O(Np)$. We will exploit this structure repeatedly.
@@ -42,10 +42,10 @@ $\theta_0 \in \Theta$ they generate a sequence $\theta_1, \theta_2, \ldots$ via
 a step map $\Phi : \Theta \to \Theta$ with
 
 \[
-\theta_n = \Phi(\theta_{n-1}).
+  \theta_n = \Phi(\theta_{n - 1}).
 \]
 
-We hope that $\theta_n \to \theta^\star$ for some minimizer
+Our hope is that $\theta_n \to \theta^\star$ for some minimizer
 $\theta^\star \in \argmin_\theta H(\theta)$. When this happens, continuity of
 $\Phi$ forces $\Phi(\theta^\star) = \theta^\star$, so the limit is a *fixed
 point* of the step map. We thus specify $\Phi$ so that its fixed points are
@@ -64,36 +64,36 @@ step moves $\theta_n$ in a *descent direction* $\rho_n \in \mathbb{R}^p$ scaled
 by a *step size* $t_n > 0$:
 
 \[
-\theta_{n+1} = \theta_n + t_n \rho_n.
+  \theta_{n + 1} = \theta_n + t_n \rho_n.
 \]
 
 The direction $\rho_n$ is called a descent direction at $\theta_n$ when
 
 \[
-\rho_n^\top \nabla H(\theta_n) < 0
+  \rho_n^\top \nabla H(\theta_n) < 0
 \]
 
 whenever $\theta_n$ is not a stationary point. The first-order Taylor expansion
 
 \[
-H(\theta_n + t \rho_n) = H(\theta_n) + t \rho_n^\top \nabla H(\theta_n) + o(t)
+  H(\theta_n + t \rho_n) = H(\theta_n) + t \rho_n^\top \nabla H(\theta_n) + o(t)
 \]
 
 then guarantees $H(\theta_n + t \rho_n) < H(\theta_n)$ for sufficiently small
 $t > 0$. The algorithms in this chapter differ in how they choose $\rho_n$ and
-$t_n$. The simplest choice is gradient descent (Section\ \@ref(grad-descent)),
+$t_n$. The simplest choice is gradient descent\ (Section\ \@ref(grad-descent)),
 which moves opposite the gradient, taking $\rho_n = -\nabla H(\theta_n)$.
-Newton's method (Section\ \@ref(Newton)) uses the curvature of $H$ (the Hessian)
-to correct the gradient direction, resulting in
-$\rho_n = -\nabla^2 H(\theta_n)^{-1} \nabla H(\theta_n)$, provided the Hessian
-is positive definite. Quasi-Newton methods replace the Hessian inverse with a
+Newton's method\ (Section\ \@ref(Newton)) uses the curvature of $H$ (the
+Hessian) to correct the gradient direction, resulting in
+$\rho_n = -\nabla^2 H(\theta_n)^{-1} \nabla H(\theta_n)$ (provided the Hessian
+is positive definite). Quasi-Newton methods replace the Hessian inverse with a
 cheaper surrogate. Step sizes can be fixed, chosen by line search, or obtained
 by minimizing exactly along the ray $t \mapsto H(\theta_n + t \rho_n)$.
 
 A sequence generated this way is called a *descent sequence* if
 
 \[
-H(\theta_0) \geq H(\theta_1) \geq H(\theta_2) \geq \ldots,
+  H(\theta_0) \geq H(\theta_1) \geq H(\theta_2) \geq \ldots,
 \]
 
 and a *strict* descent sequence if the inequalities are sharp at every
@@ -104,16 +104,15 @@ which holds in particular when that level set is compact. But descent alone does
 not imply convergence to a stationary point---an algorithm can take ever-smaller
 steps and stall short of any minimizer. What we need is *sufficient* descent at
 each step, controlled by a quantitative lower bound on
-$H(\theta_n) - H(\theta_{n+1})$ in terms of the gradient. The rest of the
-chapter is largely devoted to establishing such bounds and deriving convergence
-rates from them.
+$H(\theta_n) - H(\theta_{n + 1})$ in terms of the gradient. The rest of the
+chapter is largely devoted to this.
 
 ## Gradient descent {#grad-descent}
 
 Gradient descent is the quintessential first-order optimization algorithm. At
 each iteration we take $\rho_n = -\nabla H(\theta_n)$, the steepest descent
 direction, pick a step size $t_n > 0$, and update our current best guess of
-$\theta$ (Algorithm\ 1).
+$\theta$\ (Algorithm\ 1).
 
 ```{algorithm, gd-basic}
 \begin{algorithm}
@@ -199,35 +198,39 @@ ggplot(curve_df, aes(x, y)) +
 ```
 
 But how do we set $t$? If we set it too large, then we risk overshooting the
-target, possibly even diverging. If we set it too small, then we might never
-reach the optimum within our time budget. The answer hinges on the *smoothness*
-of $H$. Recall from Section\ \@ref(smoothness) that $H$ is *$L$-smooth* on
-$\Theta$ when $\nabla^2 H(\theta) \preceq L I$ for all $\theta \in \Theta$, and
-that the descent lemma (Lemma\ \@ref(lem:descent-lemma)) then guarantees
+target, possibly even diverging. If we set it too small, then we might not reach
+the optimum within our time budget. The answer hinges on the *smoothness* of
+$H$. Recall from Section\ \@ref(smoothness) that $H$ is *$L$-smooth* on $\Theta$
+when $\nabla^2 H(\theta) \preceq L I$ for all $\theta \in \Theta$, and that the
+descent lemma (Lemma\ \@ref(lem:descent-lemma)) then guarantees
 
 \[
-H(\theta') \leq H(\theta) + \nabla H(\theta)^\top (\theta' - \theta) + \frac{L}{2} \|\theta' - \theta\|_2^2
+  H(\theta') \leq H(\theta)
+                  + \nabla H(\theta)^\top (\theta' - \theta)
+                  + \frac{L}{2} \|\theta'
+                  - \theta\|_2^2
 \]
 
 for all $\theta, \theta' \in \Theta$. Setting
 $\theta' = \theta - t \nabla H(\theta)$ in this inequality yields
 
 \begin{align}
-H(\theta - t \nabla H(\theta)) & \leq H(\theta) - t \left(1 - \frac{tL}{2}\right) \|\nabla H(\theta)\|_2^2.
-(\#eq:gd-descent-bound)
+  H(\theta - t \nabla H(\theta)) & \leq H(\theta) - t \left(1 - \frac{tL}{2}\right) \|\nabla H(\theta)\|_2^2.
+  (\#eq:gd-descent-bound)
 \end{align}
 
 The right-hand side is minimized over $t > 0$ at $t = 1/L$, where the bound
 collapses to
 
 \[
-H(\theta - L^{-1} \nabla H(\theta)) \leq H(\theta) - \frac{1}{2L} \|\nabla H(\theta)\|_2^2.
+  H(\theta - L^{-1} \nabla H(\theta)) \leq H(\theta)
+                                           - \frac{1}{2L} \|\nabla H(\theta)\|_2^2.
 \]
 
 The gradient descent step we will analyze in this section is correspondingly
 
 \begin{align}
-\theta_{n+1} & = \theta_n - \frac{1}{L} \nabla H(\theta_n).  (\#eq:gd-step)
+  \theta_{n + 1} & = \theta_n - \frac{1}{L} \nabla H(\theta_n). (\#eq:gd-step)
 \end{align}
 
 Every iteration decreases $H$ by at least
@@ -235,28 +238,30 @@ $(2L)^{-1} \|\nabla H(\theta_n)\|_2^2$, so $(\theta_n)$ is a strict descent
 sequence unless it hits a stationary point. The corresponding step map
 
 \[
-\Phi(\theta) = \theta - \frac{1}{L} \nabla H(\theta)
+  \Phi(\theta) = \theta - \frac{1}{L} \nabla H(\theta)
 \]
 
 has $\theta$ as a fixed point if and only if $\nabla H(\theta) = 0$, so the
-fixed points of $\Phi$ are exactly the stationary points of $H$. Knowing $L$ in
-advance is rarely realistic in practice, and Section\ \@ref(stop-crit) and the
-line-search material that follows show how a backtracking step size adapts the
-step length without requiring it explicitly.
-
-Figure\ \@ref(fig:gd-step-sizes) illustrates the three regimes on a simple step
-near $1/L$ converges in a handful of iterations; a step approaching the step
-near $1/L$ converges in a handful of iterations; a step approaching the
-stability boundary $2/L$ (where the descent inequality
-\@ref(eq:gd-descent-bound) becomes vacuous) oscillates across the steep
-direction. For $t > 2/L$ the iterates diverge.
+fixed points of $\Phi$ are exactly the stationary points of $H$. Unfortunately,
+knowing or computing $L$ in advance is rarely realistic in practice, which means
+that we often have to pick it adaptively. The problem is that doing so is not a
+trivial matter. Figure\ \@ref(fig:gd-step-sizes) illustrates the three step size
+choices on a simple quadratic problem. A step far below $1/L$ crawls slowly
+towards the optimum; a step at exactly $1/L$ converges in a handful of
+iterations; and a step just above the stability boundary $2/L$ (where the
+descent inequality \@ref(eq:gd-descent-bound) breaks) diverges.
 
 ```{r}
 #| label: gd-step-sizes
 #| echo: false
 #| fig-width: 7
 #| fig-height: 3
-#| fig-cap: "Gradient descent on $H(\\theta) = (\\theta_1^2 + 4\\theta_2^2)/2$ (so $L = 4$) for three step sizes, starting from $\\theta_0 = (-2.5, 1.5)$. Contours are level sets of $H$; dots are the iterates. A step much smaller than $1/L$ descends slowly; a step near $1/L$ converges efficiently; a step near the stability boundary $2/L = 0.5$ oscillates across the steep direction."
+#| fig-cap: >-
+#|   Gradient descent on $H(\theta) = (\theta_1^2 + 4\theta_2^2)/2$ (so $L = 4$)
+#|   for three step sizes, starting from $\theta_0 = (-2.5, 1.5)$. Contours are
+#|   level sets of $H$; dots are the iterates. A step much smaller than $1/L$
+#|   descends slowly; a step at $1/L$ converges efficiently; and a step above
+#|   the stability boundary $2/L = 0.5$ diverges.
 
 library(patchwork)
 
@@ -295,9 +300,13 @@ make_panel <- function(t, title) {
 
 make_panel(0.05, "t = 0.05") +
   make_panel(0.20, "t = 0.20") +
-  make_panel(0.45, "t = 0.45") +
+  make_panel(0.51, "t = 0.51") +
   plot_layout(axes = "collect")
 ```
+
+In Section\ \@ref(line-search) we will discuss how to choose $t_n$ adaptively at
+each iteration via a line search. For now, however, we will assume that $L$ is
+known and fixed, and analyze the convergence of the gradient descent iterates.
 
 ### Convergence rates
 
@@ -312,7 +321,7 @@ attains its minimum at some $\theta^\star$. The gradient descent iterates
 \@ref(eq:gd-step) starting from $\theta_0 \in \mathbb{R}^p$ satisfy
 
 \[
-H(\theta_n) - H(\theta^\star) \leq \frac{L \|\theta_0 - \theta^\star\|_2^2}{2n}
+  H(\theta_n) - H(\theta^\star) \leq \frac{L \|\theta_0 - \theta^\star\|_2^2}{2n}
 \]
 
 for every $n \geq 1$.
@@ -322,34 +331,36 @@ for every $n \geq 1$.
 Apply \@ref(eq:gd-descent-bound) at $\theta = \theta_i$ with $t = 1/L$ to get
 
 \[
-H(\theta_{i+1}) \leq H(\theta_i) - \frac{1}{2L} \|\nabla H(\theta_i)\|_2^2.
+  H(\theta_{i + 1}) \leq H(\theta_i) - \frac{1}{2L} \|\nabla H(\theta_i)\|_2^2.
 \]
 
 By the first-order characterization of convexity (Section\ \@ref(convexity)),
 
 $$
-H(\theta^\star) \geq H(\theta_i) + \nabla H(\theta_i)^\top (\theta^\star - \theta_i),
+  H(\theta^\star) \geq H(\theta_i)
+                       + \nabla H(\theta_i)^\top (\theta^\star - \theta_i),
 $$
 
 so
 
 $$
-H(\theta_i) - H(\theta^\star) \leq \nabla H(\theta_i)^\top (\theta_i - \theta^\star).
+  H(\theta_i) - H(\theta^\star) \leq \nabla H(\theta_i)^\top (\theta_i - \theta^\star).
 $$
 
 Combining with the previous display,
 
 \begin{align*}
-  H(\theta_{i+1}) - H(\theta^\star) & \leq \nabla H(\theta_i)^\top (\theta_i - \theta^\star) - \frac{1}{2L} \|\nabla H(\theta_i)\|_2^2 \\
-  & = \frac{L}{2} \left( \|\theta_i - \theta^\star\|_2^2 - \|\theta_i - \theta^\star - L^{-1} \nabla H(\theta_i)\|_2^2 \right) \\
-  & = \frac{L}{2} \left( \|\theta_i - \theta^\star\|_2^2 - \|\theta_{i+1} - \theta^\star\|_2^2 \right),
+  H(\theta_{i + 1}) - H(\theta^\star) & \leq \nabla H(\theta_i)^\top (\theta_i - \theta^\star) - \frac{1}{2L} \|\nabla H(\theta_i)\|_2^2                           \\
+                                      & = \frac{L}{2} \left( \|\theta_i - \theta^\star\|_2^2 - \|\theta_i - \theta^\star - L^{-1} \nabla H(\theta_i)\|_2^2 \right) \\
+                                      & = \frac{L}{2} \left( \|\theta_i - \theta^\star\|_2^2 - \|\theta_{i + 1} - \theta^\star\|_2^2 \right),
 \end{align*}
 
 where the second line completes the square. Summing from $i = 0$ to $n - 1$
 gives us
 
 \[
-\sum_{i=0}^{n-1} \left( H(\theta_{i+1}) - H(\theta^\star) \right) \leq \frac{L}{2} \|\theta_0 - \theta^\star\|_2^2.
+  \sum_{i = 0}^{n - 1} \left( H(\theta_{i + 1}) - H(\theta^\star) \right) \leq \frac{L}{2} \|\theta_0
+                                                                               - \theta^\star\|_2^2.
 \]
 
 The descent property ensures $H(\theta_n) - H(\theta^\star)$ is decreasing in
@@ -358,16 +369,17 @@ $n$, so the left-hand side is at least $n (H(\theta_n) - H(\theta^\star))$.
 
 The suboptimality $H(\theta_n) - H(\theta^\star)$ thus decays like $1/n$. This
 is *sublinear* convergence: the number of correct digits in $H(\theta_n)$ grows
-like $\log n$. Doubling the accuracy requires doubling the iteration count, a
-slow rate when many digits are needed, but one that places remarkably weak
-demands on $H$ (just convexity and smoothness).
+according to $\log n$. Doubling the accuracy requires doubling the iteration
+count, which is a slow rate when many digits are needed, but one that places
+remarkably weak demands on $H$ (just convexity and smoothness).
 
-Adding strong convexity sharpens the picture dramatically. If $H$ is
+Adding strong convexity improves the picture dramatically. If $H$ is
 $m$-strongly convex in addition to $L$-smooth, then
 Lemma\ \@ref(lem:strong-convex-suboptimality) gives the two-sided bound
 
 \[
-\frac{m}{2} \|\theta - \theta^\star\|_2^2 \leq H(\theta) - H(\theta^\star) \leq \frac{1}{2m} \|\nabla H(\theta)\|_2^2.
+  \frac{m}{2} \|\theta - \theta^\star\|_2^2 \leq H(\theta) - H(\theta^\star)
+                                            \leq \frac{1}{2m} \|\nabla H(\theta)\|_2^2.
 \]
 
 The right inequality says that suboptimality is controlled by gradient norm,
@@ -381,13 +393,13 @@ $0 < m \leq L$, and let $\theta^\star$ be its unique minimizer. The gradient
 descent iterates \@ref(eq:gd-step) satisfy
 
 \[
-H(\theta_{n+1}) - H(\theta^\star) \leq \left( 1 - \frac{m}{L} \right) \left( H(\theta_n) - H(\theta^\star) \right),
+  H(\theta_{n + 1}) H(\theta^\star) \leq \left( 1 - \frac{m}{L} \right) \left( H(\theta_n) - H(\theta^\star) \right),
 \]
 
 and therefore
 
 \[
-H(\theta_n) - H(\theta^\star) \leq \left( 1 - \frac{1}{\kappa} \right)^n \left( H(\theta_0) - H(\theta^\star) \right),
+  H(\theta_n) - H(\theta^\star) \leq \left( 1 - \frac{1}{\kappa} \right)^n \left( H(\theta_0) - H(\theta^\star) \right),
 \]
 
 where $\kappa = L/m$ is the condition number from Section\ \@ref(smoothness).
@@ -397,30 +409,31 @@ where $\kappa = L/m$ is the condition number from Section\ \@ref(smoothness).
 The strong-convexity bound rearranges to
 
 $$
-\|\nabla H(\theta_n)\|_2^2 \geq 2m (H(\theta_n) - H(\theta^\star)).
+  \|\nabla H(\theta_n)\|_2^2 \geq 2m (H(\theta_n) - H(\theta^\star)).
 $$
 
 Substituting into the per-step decrease,
 
 \begin{align*}
-  H(\theta_{n+1}) & \leq H(\theta_n) - \frac{1}{2L} \|\nabla H(\theta_n)\|_2^2 \\
-  & \leq H(\theta_n) - \frac{m}{L} (H(\theta_n) - H(\theta^\star)).
+  H(\theta_{n + 1}) & \leq H(\theta_n) - \frac{1}{2L} \|\nabla H(\theta_n)\|_2^2      \\
+                    & \leq H(\theta_n) - \frac{m}{L} (H(\theta_n) - H(\theta^\star)).
 \end{align*}
 
-Subtracting $H(\theta^\star)$ from both sides gives the one-step contraction;
-iterating gives the geometric rate.
+Subtracting $H(\theta^\star)$ from both sides gives the one-step contraction.
+Iterating gives the geometric rate.
 :::
 
 Convergence at a geometric rate is called *linear* convergence in the
 numerical-optimization literature, because the number of correct digits in
 $H(\theta_n) - H(\theta^\star)$ grows linearly in $n$. The contraction factor
 $1 - 1/\kappa$ depends only on the condition number. Well-conditioned problems
-($\kappa$ close to $1$) converge in ewiterations. Ill-conditioned problems
-($\kappa$ large) crawl slowly towards convergence with the iterates tracing a
+($\kappa$ close to $1$) converge in few iterations. Ill-conditioned problems
+($\kappa$ large) crawl slowly towards convergence, with the iterates tracing a
 long zigzag along the floor of a narrow ravine. In Section\ \@ref(smoothness),
-we provided the geometric interpretation: $\kappa$ is the aspect ratio of the
-level sets of $H$. Newton's method (Section\ \@ref(Newton)) corrects for the
-conditioning at the cost of solving a linear system per iteration.
+we provided the geometric interpretation for this: $\kappa$ is the aspect ratio
+of the level sets of $H$. The classical solution to this is to use Newton's
+method\ (Section\ \@ref(Newton)) instead, which corrects for the conditioning at
+the cost of solving a linear system per iteration.
 
 Both theorems assume $\Theta = \mathbb{R}^p$. The arguments go through on any
 open convex $\Theta$ provided the iterates remain in $\Theta$, but ensuring that
@@ -437,7 +450,7 @@ $\log(H(\theta_n) - H(\theta_M))$ against $n$. Linear convergence with rate $r$
 means
 
 \[
-\log(H(\theta_n) - H(\theta_M)) \approx n \log r + \text{const}
+  \log(H(\theta_n) - H(\theta_M)) \approx n \log r + \text{const}
 \]
 
 for sufficiently large $n$, so the slope of a linear fit to the late iterations
@@ -448,31 +461,34 @@ The same idea can be applied to $\theta_n$ or to $\|\nabla H(\theta_n)\|$, the
 latter being especially convenient because the limit is known to be zero, so we
 can monitor it without waiting for the algorithm to finish.
 
-Per-iteration rates are useful for analyzing a single algorithm but not for
-comparing different algorithms, which may spend wildly different amounts of time
-per iteration. Throughout the chapter we will also report *per-second*
-convergence rates by plotting against measured runtime rather than iteration
-count. If one iteration takes $\delta$ seconds the per-second rate is
-$r^{1/\delta}$; in practice we estimate $\delta$ as $t_M / M$ for $M$ large.
+Per-iteration rates are useful for analyzing a single algorithm but can be
+misleading when comparing different algorithms, which may spend varying amounts
+of time per iteration. Throughout the chapter we will therefore also report
+*per-second* convergence rates by plotting against measured runtime rather than
+iteration count. On the other hand, runtime also has downsides in that it is
+affected by both implementation and hardware, which for instance means that
+results that for an algorithm implemented in R may not hold for the same
+algorithm implemented in C++ or run on a different machine.
 
 ## Step size and stopping criteria
 
 The convergence theorems of Section\ \@ref(grad-descent) used the fixed step
 $t = 1/L$, which requires knowing the smoothness (Lipschitz) constant $L$. In
-practice $L$ is rarely available analytically, since it may vary across the
-parameter space, and a generic Lipschitz bound is often so pessimistic that
-fixed-step iterations slow to almost a stop. Practical implementations therefore
-often choose the step length adaptively at each iteration via a *line search*.
-The general step is
+practice, however, $L$ is often not available analytically or is so pessimistic
+(since it has to be a bound over the entire parameter space) that our
+algorithm's convergence speed suffers. It is therefore often more practical to
+choose the step length adaptively at each iteration via a *line search*. The
+general update in a line search method is
 
 \[
-\theta_{n+1} = \theta_n + \gamma_n \rho_n
+  \theta_{n + 1} = \theta_n + \gamma_n \rho_n
 \]
 
 for a descent direction $\rho_n$ and a step length $\gamma_n > 0$ that is
-allowed to depend on $\theta_n$ and $\rho_n$. In this section we introduce
-backtracking line search, which we use throughout the rest of the chapter, and
-then turn to the question of when to terminate our algorithm.
+allowed to depend on $\theta_n$ and $\rho_n$. One of the simplest and most
+common types of line searches is backtracking line search, which we will
+introduce next and use throughout the rest of the chapter. We will then turn to
+the question of when to terminate our algorithm.
 
 ### Line search {#line-search}
 
@@ -480,33 +496,35 @@ Given $\theta_n$ and a descent direction $\rho_n$, restrict $H$ to the ray
 emanating from $\theta_n$ in the direction $\rho_n$:
 
 \[
-h(\gamma) = H(\theta_n + \gamma \rho_n), \qquad \gamma \in [0, \infty).
+  h(\gamma) = H(\theta_n + \gamma \rho_n), \qquad \gamma \in [0, \infty).
 \]
 
 Then $h'(\gamma) = \nabla H(\theta_n + \gamma \rho_n)^\top \rho_n$ and the
-descent-direction property gives $h'(0) = \nabla H(\theta_n)^\top \rho_n < 0$,
-so $h$ is decreasing at $0$. The *exact line search* strategy picks
-$\gamma_n = \argmin_{\gamma > 0} h(\gamma)$, which delivers the maximal possible
-descent along the ray. It is rarely worth the compute unless the inner
-minimization admits a closed form.
+descent-direction property yields $h'(0) = \nabla H(\theta_n)^\top \rho_n < 0$,
+which means that $h$ is decreasing at $0$. Picking
+$\gamma_n = \argmin_{\gamma > 0} h(\gamma)$---an *exact line search*
+strategy---may seem like a good idea since it delivers the maximal possible
+descent for each step. In reality however, it is rarely worth the extra
+computational effort unless the inner minimization admits a closed form.
 
 Inexact line search settles for *sufficient* descent. Fix $c \in (0, 1)$. The
 *Armijo condition*\index{Armijo condition}
 
 \[
-h(\gamma) \leq h(0) + c \gamma h'(0)
+  h(\gamma) \leq h(0) + c \gamma h'(0)
 \]
 
 requires $h$ to descend by at least the fraction $c$ of the linear prediction
-along the tangent at $0$. Since $h'(0) < 0$ the right-hand side sits below
-$h(0)$, and the condition reduces to one evaluation of $H$. For any
+along the tangent at $0$. Since $h'(0) < 0$ the right-hand side is strictly less
+than $h(0)$, and the condition reduces to one evaluation of $H$. For any
 $c \in (0, 1)$ the Armijo condition holds on some interval $[0, \varepsilon)$,
 so a small enough step always works. Figure\ \@ref(fig:armijo) shows the
 condition geometrically: $h$ must lie at or below the lower dashed line
 $h(0) + c \gamma h'(0)$ to be accepted, while the steeper tangent
-$h(0) + \gamma h'(0)$ is ceiling. Choosing $c$ close to $0$ asks for very little
-descent and admits most steps, whilst choosing $c$ close to $1$ asks fr a almost
-full linear prediction of descent and rules out most steps.
+$h(0) + \gamma h'(0)$ is ceiling. Choosing $c$ close to $0$ requires little
+descent before holdings and therefore allows most steps, whilst choosing $c$
+close to $1$ requires an almost full linear prediction of descent and rules out
+most steps.
 
 ```{r}
 #| label: armijo
@@ -514,7 +532,13 @@ full linear prediction of descent and rules out most steps.
 #| fig-width: 4
 #| fig-height: 3.2
 #| fig-align: "center"
-#| fig-cap: "The Armijo condition. Solid: the restriction $h(\\gamma) = H(\\theta + \\gamma \\rho)$ along a descent direction $\\rho$. Dashed orange: the tangent $h(0) + \\gamma h'(0)$, the linear prediction of descent at rate $h'(0)$. Dashed blue: the Armijo line $h(0) + c \\gamma h'(0)$ with $c = 0.35$. The shaded interval marks the values of $\\gamma$ for which the Armijo condition $h(\\gamma) \\leq h(0) + c \\gamma h'(0)$ holds."
+#| fig-cap: >-
+#|   The Armijo condition. Solid: the restriction $h(\gamma) = H(\theta + \gamma
+#|   \rho)$ along a descent direction $\rho$. Dashed orange: the tangent $h(0) +
+#|   \gamma h'(0)$, the linear prediction of descent at rate $h'(0)$. Dashed
+#|   blue: the Armijo line $h(0) + c \gamma h'(0)$ with $c = 0.35$. The shaded
+#|   interval marks the values of $\gamma$ for which the Armijo condition
+#|   $h(\gamma) \leq h(0) + c \gamma h'(0)$ holds.
 
 h_fun <- function(g) 0.5 * (g - 1.3)^2 - 0.4
 h0 <- h_fun(0)
@@ -606,11 +630,11 @@ ggplot() +
 ```
 
 The Armijo criterion alone can yield arbitrarily small step sizes, which can
-stall the algorithm venathough we are far from stationary point. The *curvature
-condition*
+stall the algorithm even though we are far from a stationary point. The
+*curvature condition*
 
 \[
-h'(\gamma) \geq \tilde{c}\, h'(0)
+  h'(\gamma) \geq \tilde{c}\, h'(0)
 \]
 
 for some $\tilde{c} \in (c, 1)$ forces the slope at $\gamma$ to be less negative
@@ -625,7 +649,7 @@ picks a starting step $\gamma_0 > 0$ and a shrinkage factor $d \in (0, 1)$, then
 tests the sequence
 
 \[
-\gamma_0, \, d \gamma_0, \, d^2 \gamma_0, \, d^3 \gamma_0, \ldots
+  \gamma_0, \, d \gamma_0, \, d^2 \gamma_0, \, d^3 \gamma_0, \ldots
 \]
 
 stopping at the first $\gamma = d^k \gamma_0$ satisfying the Armijo condition.
@@ -647,26 +671,27 @@ bound.
 \end{algorithm}
 ```
 
-Three constants control the search: the initial step $\gamma_0$, the shrinkage
-factor $d$, and the Armijo slope $c$. Typical defaults are $d \in [0.5, 0.9]$
-and $c \in [10^{-4}, 0.1]$. For Newton's method (Section\ \@ref(Newton)) the
-choice $\gamma_0 = 1$ is a natural choice. For plain gradient descent there is
-no universal default and $\gamma_0$ has to be tuned to the scale of the problem.
+The search is controlled by three constants: the initial step $\gamma_0$, the
+shrinkage factor $d$, and the Armijo slope $c$. Typical defaults are
+$d \in [0.5, 0.9]$ and $c \in [10^{-4}, 0.1]$. For Newton's method
+(Section\ \@ref(Newton)) the choice $\gamma_0 = 1$ is a natural choice. For
+plain gradient descent there is no universal default and $\gamma_0$ has to be
+tuned to the scale of the problem.
 
 ### Stopping criteria {#stop-crit}
 
 No algorithm can run forever and every implementation needs a rule for when to
 terminate. But choosing an appropriate one is notoriously difficult. Next, we
-will provide four common stopping criter a, each of which is easy to implement
+will provide four common stopping criteria, each of which is easy to implement
 and common in practice, but none of which actually guarantees convergence to a
 minimum. We also note that each should be combined with a *maximum iteration
-count* as a safeguard against infinite loops.
+count* or time budget as a safeguard against infinite loops.
 
 ::: {.boxed}
 *Maximum number of iterations.* Stop when
 
 \[
-n = M
+  n = M
 \]
 
 for a fixed maximum number of iterations $M$. The simplest criterion: it
@@ -684,7 +709,7 @@ is met, with the understanding that this is shorthand.
 *Small relative change.* Stop when
 
 \[
-\|\theta_n - \theta_{n-1}\| \leq \varepsilon (\|\theta_n\| + \varepsilon).
+  \|\theta_n - \theta_{n - 1}\| \leq \varepsilon (\|\theta_n\| + \varepsilon).
 \]
 
 A step that barely moves $\theta_n$ suggests proximity to a fixed point of the
@@ -702,7 +727,8 @@ $H(\theta_n) - H(\theta^\star)$ is small.
 *Small relative descent.* Stop when
 
 \[
-H(\theta_{n-1}) - H(\theta_n) \leq \varepsilon (|H(\theta_n)| + \varepsilon).
+  H(\theta_{n - 1})
+                                       - H(\theta_n) \leq \varepsilon (|H(\theta_n)| + \varepsilon).
 \]
 
 Sensible only for descent algorithms. The relative form neutralizes a global
@@ -717,7 +743,7 @@ occur in flat regions of $\Theta$ without proximity to a minimizer.
 *Small gradient.* Stop when
 
 \[
-\|\nabla H(\theta_n)\| \leq \varepsilon.
+  \|\nabla H(\theta_n)\| \leq \varepsilon.
 \]
 
 This criterion measures whether $\theta_n$ is close to being a stationary point,
@@ -733,7 +759,8 @@ The picture improves under strong convexity. If $H$ is $m$-strongly convex,
 Lemma\ \@ref(lem:strong-convex-suboptimality) gives
 
 \[
-\frac{m}{2} \|\theta_n - \theta^\star\|_2^2 \leq H(\theta_n) - H(\theta^\star) \leq \frac{1}{2m} \|\nabla H(\theta_n)\|_2^2,
+  \frac{m}{2} \|\theta_n - \theta^\star\|_2^2 \leq H(\theta_n) - H(\theta^\star)
+                                              \leq \frac{1}{2m} \|\nabla H(\theta_n)\|_2^2,
 \]
 
 so a small gradient norm does imply both proximity to $\theta^\star$ and small
@@ -749,7 +776,7 @@ $\theta \in \mathrm{lev}(\theta_0)$ when the algorithm is a descent algorithm).
 Then
 
 \[
-0 \leq H(\theta_n) - H(\theta^\star) \leq H(\theta_n) - \tilde{H}(\theta_n),
+  0 \leq H(\theta_n) - H(\theta^\star) \leq H(\theta_n) - \tilde{H}(\theta_n),
 \]
 
 and the right-hand side gives a computable upper bound on the suboptimality.
@@ -766,7 +793,8 @@ We implement gradient descent with backtracking below as the function
 choosing the smallest $k \geq 0$ such that
 
 \[
-H(\theta_{n} - d^k \gamma_0 \nabla H(\theta_{n})) \leq H(\theta_n) -  cd^k \gamma_0 \|\nabla H(\theta_{n})\|_2^2.
+  H(\theta_{n} - d^k \gamma_0 \nabla H(\theta_{n})) \leq H(\theta_n)
+                                                         - cd^k \gamma_0 \|\nabla H(\theta_{n})\|_2^2.
 \]
 
 The `grad_desc()` function takes the starting point, $\theta_0$, the objective
@@ -928,7 +956,7 @@ the parameters fitted using `glm()` is just slightly smaller.
 #| label: gd-object
 #| results: "hold"
 
-old_options = options(digits = 15)
+old_options <- options(digits = 15)
 veg_pois$H(coefficients(pois_model_null))
 veg_pois$H(pois_gd)
 options(digits = old_options$digits)
@@ -1000,7 +1028,11 @@ gd_tracer[377]
 ```{r, dependson=c("gd-trace", "veg-pois")}
 #| label: gd-trace-plot
 #| echo: false
-#| fig-cap: "Gradient norm (left) and value of the negative log-likelihood (right) above the limit value $H(\\theta_{\\infty})$. The straight line is fitted to the data points except the first ten using least squares, and the rate is computed from this estimate and reported per ms."
+#| fig-cap: >-
+#|   Gradient norm (left) and value of the negative log-likelihood (right) above
+#|   the limit value $H(\theta_{\infty})$. The straight line is fitted to the
+#|   data points except the first ten using least squares, and the rate is
+#|   computed from this estimate and reported per ms.
 #| out-width: "100%"
 #| fig-width: 8
 #| fig-height: 3
@@ -1080,7 +1112,9 @@ will lead us straight to Newton's method. Take the second-order Taylor expansion
 of $H$ around $\theta$,
 
 \[
-H(\theta + \rho) \approx H(\theta) + \nabla H(\theta)^\top \rho + \frac{1}{2} \rho^\top \nabla^2 H(\theta) \rho,
+  H(\theta + \rho) \approx H(\theta)
+                           + \nabla H(\theta)^\top \rho
+                           + \frac{1}{2} \rho^\top \nabla^2 H(\theta) \rho,
 \]
 
 and replace the Hessian $\nabla^2 H(\theta)$ with the conservative diagonal
@@ -1098,7 +1132,12 @@ descent step.
 #| echo: false
 #| fig-width: 4
 #| fig-height: 3
-#| fig-cap: "Gradient descent as surrogate minimization. The dashed quadratic, obtained from the second-order Taylor expansion of $H$ around $\\theta$ with the Hessian replaced by $(1/t)I$, has minimizer $\\theta^+ = \\theta - t \\nabla H(\\theta)$ (open circle). The filled dots mark $\\theta$ and the next iterate $\\theta^+$ on $H$. Newton's method instead keeps the true Hessian."
+#| fig-cap: >-
+#|   Gradient descent as surrogate minimization. The dashed quadratic, obtained
+#|   from the second-order Taylor expansion of $H$ around $\theta$ with the
+#|   Hessian replaced by $(1/t)I$, has minimizer $\theta^+ = \theta - t \nabla
+#|   H(\theta)$ (open circle). The filled dots mark $\theta$ and the next
+#|   iterate $\theta^+$ on $H$. Newton's method instead keeps the true Hessian.
 #| warning: false
 
 H <- function(theta) (theta - 2)^2 + 1
@@ -1158,7 +1197,7 @@ $\rho \mapsto \nabla H(\theta)^\top \rho + \frac{1}{2} \rho^\top \nabla^2 H(\the
 is
 
 \[
-\rho_{\mathrm{N}}(\theta) = -[\nabla^2 H(\theta)]^{-1} \nabla H(\theta),
+  \rho_{\mathrm{N}}(\theta) = -[\nabla^2 H(\theta)]^{-1} \nabla H(\theta),
 \]
 
 the *Newton direction*.\index{Newton direction}
@@ -1179,7 +1218,17 @@ paid by gradient descent in geometric form.
 #| echo: false
 #| fig-width: 8
 #| fig-height: 4.5
-#| fig-cap: "Surrogate models and iterates for the OLS objective on the ill-conditioned design of Figure\\ \\@ref(fig:ols-condition-contour) (right panel). Both panels start from the filled dot $\\beta_0$. Solid grey contours are level sets of $H(\\beta) = \\tfrac{1}{2}\\lVert y - X\\beta \\rVert^2$; dashed blue contours are level sets of the surrogate built at $\\beta_0$, drawn at the same values. Left: gradient descent at step size $t = 1/L$. The surrogate is isotropic and misses the elongation of $H$, and the iterates trace a zigzag across the valley. Right: Newton's method. The surrogate coincides with $H$ (the dashed contours overlay the grey ones), and a single step reaches $\\hat{\\beta}$."
+#| fig-cap: >-
+#|   Surrogate models and iterates for the OLS objective on the ill-conditioned
+#|   design of Figure\ \@ref(fig:ols-condition-contour) (right panel). Both
+#|   panels start from the filled dot $\beta_0$. Solid grey contours are level
+#|   sets of $H(\beta) = \tfrac{1}{2}\lVert y - X\beta \rVert^2$; dashed blue
+#|   contours are level sets of the surrogate built at $\beta_0$, drawn at the
+#|   same values. Left: gradient descent at step size $t = 1/L$. The surrogate
+#|   is isotropic and misses the elongation of $H$, and the iterates trace a
+#|   zigzag across the valley. Right: Newton's method. The surrogate coincides
+#|   with $H$ (the dashed contours overlay the grey ones), and a single step
+#|   reaches $\hat{\beta}$.
 
 library(patchwork)
 
@@ -1267,7 +1316,7 @@ panel("gd_surr", gd_df, "Gradient descent") +
 ```
 
 The Newton iteration is then
-$\theta_{n+1} = \theta_n + \gamma_n \rho_{\mathrm{N}}(\theta_n)$. Pure Newton
+$\theta_{n + 1} = \theta_n + \gamma_n \rho_{\mathrm{N}}(\theta_n)$. Pure Newton
 takes $\gamma_n = 1$, which is the right choice near a minimizer with
 positive-definite Hessian. Far from a minimizer, the model may be a poor guide
 and the natural unit step can overshoot, so the practical version combines the
@@ -1279,7 +1328,8 @@ The Newton direction is automatically a descent direction whenever
 $\nabla^2 H(\theta_n)$ is positive definite:
 
 \[
-\rho_{\mathrm{N}}(\theta_n)^\top \nabla H(\theta_n) = -\nabla H(\theta_n)^\top [\nabla^2 H(\theta_n)]^{-1} \nabla H(\theta_n) < 0.
+  \rho_{\mathrm{N}}(\theta_n)^\top \nabla H(\theta_n) = -\nabla H(\theta_n)^\top [\nabla^2 H(\theta_n)]^{-1} \nabla H(\theta_n)
+                                                      < 0.
 \]
 
 When the Hessian is not positive definite, which can happen for non-convex $H$,
@@ -1297,7 +1347,7 @@ minimizer where the Hessian is positive definite and Lipschitz continuous, pure
 Newton converges *quadratically*: there is a constant $M$ such that
 
 \[
-\|\theta_{n+1} - \theta^\star\|_2 \leq M \|\theta_n - \theta^\star\|_2^2,
+  \|\theta_{n + 1} - \theta^\star\|_2 \leq M \|\theta_n - \theta^\star\|_2^2,
 \]
 
 so the number of correct digits roughly doubles per iteration. We state this
@@ -1422,7 +1472,7 @@ log-likelihood agree to high precision as well:
 ```{r, dependson=c("X-update", "Newton-test", "pois-model"), echo=2}
 #| label: Newton-object
 
-old_options = options(digits = 20)
+old_options <- options(digits = 20)
 rbind(
   pois_newton = veg_pois_large$H(pois_newton),
   pois_glm = veg_pois_large$H(coefficients(pois_model))
@@ -1473,7 +1523,7 @@ regression example just demonstrated, but punitive for larger problems.
 *Quasi-Newton* methods keep the Newton update form
 
 \[
-\rho_n = -B_n \nabla H(\theta_n)
+  \rho_n = -B_n \nabla H(\theta_n)
 \]
 
 but replace the inverse Hessian $[\nabla^2 H(\theta_n)]^{-1}$ with a cheaper
@@ -1530,11 +1580,12 @@ pattern that slows plain gradient descent on ill-conditioned problems. In the
 Fletcher-- Reeves version the descent direction is
 
 \[
-\rho_n = -\nabla H(\theta_n) + \frac{\|\nabla H(\theta_n)\|_2^2}{\|\nabla H(\theta_{n-1})\|_2^2} \rho_{n-1},
+  \rho_n = -\nabla H(\theta_n)
+           + \frac{\|\nabla H(\theta_n)\|_2^2}{\|\nabla H(\theta_{n - 1})\|_2^2} \rho_{n - 1},
 \]
 
 initialized at $\rho_0 = -\nabla H(\theta_0)$; the Polak--Ribière and
-Hestenes--Stiefel variants differ in the prefactor of $\rho_{n-1}$. Conjugate
+Hestenes--Stiefel variants differ in the prefactor of $\rho_{n - 1}$. Conjugate
 gradient uses only $O(p)$ memory and avoids matrix storage altogether, but needs
 many more iterations than BFGS to reach a given accuracy and is rarely the
 default choice today. R's `optim()` exposes the algorithm via `method = "CG"`:
@@ -1584,8 +1635,9 @@ Write the constrained problem in the standard form used by
 Theorem\ \@ref(thm:kkt):
 
 \[
-\operatorname*{minimize}_\theta H(\theta) \quad \text{subject to} \quad
-g_i(\theta) \leq 0, \quad i = 1, \ldots, r,
+  \operatorname
+                                                                                             * {minimize}_\theta H(\theta) \quad \text{subject to} \quad g_i(\theta) \leq 0, \quad i
+                                                                                        = 1, \ldots, r,
 \]
 
 with $H$ and the $g_i$ convex and differentiable. For peppered moths
@@ -1593,7 +1645,9 @@ $\theta = (p_C, p_I)$, $H(\theta) = -\ell(\theta)$, and the three inequalities
 are
 
 \[
-g_1(\theta) = -p_C, \quad g_2(\theta) = -p_I, \quad g_3(\theta) = p_C + p_I - 1.
+  g_1(\theta) = -p_C, \quad g_2(\theta)
+              = -p_I, \quad g_3(\theta)
+              = p_C + p_I - 1.
 \]
 
 The KKT conditions characterize the minimizer through stationarity, primal
@@ -1605,8 +1659,8 @@ The barrier method softens the hard inequalities into a smooth penalty that
 diverges at the boundary. The standard choice is the *logarithmic barrier*
 
 \begin{equation}
-\phi(\theta) = -\sum_{i=1}^r \log(-g_i(\theta)),
-(\#eq:log-barrier)
+  \phi(\theta) = -\sum_{i = 1}^r \log(-g_i(\theta)),
+  (\#eq:log-barrier)
 \end{equation}
 
 defined on the strict interior
@@ -1617,8 +1671,8 @@ wall pushing iterates away from the boundary. For each $t > 0$ consider the
 unconstrained *centering problem*
 
 \begin{equation}
-\operatorname*{minimize}_\theta \, t H(\theta) + \phi(\theta).
-(\#eq:centering)
+  \operatorname * {minimize}_\theta \, t H(\theta) + \phi(\theta).
+  (\#eq:centering)
 \end{equation}
 
 When $H$ is convex the centering objective is strictly convex on the interior,
@@ -1636,7 +1690,7 @@ $\theta^\star$. For each $t > 0$ the centering problem \@ref(eq:centering) has a
 minimizer $\theta^\star(t)$, and
 
 \[
-H(\theta^\star(t)) - H(\theta^\star) \leq r / t.
+  H(\theta^\star(t)) - H(\theta^\star) \leq r / t.
 \]
 :::
 
@@ -1673,7 +1727,14 @@ contours away from them.
 #| label: pep-central-path
 #| echo: false
 #| warning: false
-#| fig-cap: "Contours of the centering objective $t H(\\theta) + \\phi(\\theta)$ for the peppered-moth problem at four values of $t$ (contour levels normalized within each panel). The dashed lines mark the simplex boundary, the white circle marks the constrained optimum $\\theta^\\star$, and the orange cross marks the minimizer of the centering problem at that $t$. As $t$ grows, the cross traces the central path from the analytic center of the simplex toward $\\theta^\\star$."
+#| fig-cap: >-
+#|   Contours of the centering objective $t H(\theta) + \phi(\theta)$ for the
+#|   peppered-moth problem at four values of $t$ (contour levels normalized
+#|   within each panel). The dashed lines mark the simplex boundary, the white
+#|   circle marks the constrained optimum $\theta^\star$, and the orange cross
+#|   marks the minimizer of the centering problem at that $t$. As $t$ grows, the
+#|   cross traces the central path from the analytic center of the simplex
+#|   toward $\theta^\star$.
 #| fig-width: 6
 #| fig-height: 6.2
 
@@ -1834,10 +1895,19 @@ stopping rule. It expects affine inequality constraints in the form
 $A\theta \succeq b$, supplied as a matrix `ui` and a vector `ci` with
 `ui %*% theta >= ci`. Rewriting $g_1, g_2, g_3 \leq 0$ in that form gives
 
-\[
-A = \begin{pmatrix} 1 & 0 \\ 0 & 1 \\ -1 & -1 \end{pmatrix},
-\quad b = \begin{pmatrix} \phantom{-}0 \\ \phantom{-}0 \\ -1 \end{pmatrix},
-\]
+\[ A =
+\begin{pmatrix}
+  1  & 0  \\
+  0  & 1  \\
+  -1 & -1
+\end{pmatrix}
+, \quad b =
+\begin{pmatrix}
+  \phantom{-}0 \\
+  \phantom{-}0 \\
+  -1
+\end{pmatrix}
+, \]
 
 so the same problem reduces to one call:
 

--- a/22-Optimization.Rmd
+++ b/22-Optimization.Rmd
@@ -1635,9 +1635,7 @@ Write the constrained problem in the standard form used by
 Theorem\ \@ref(thm:kkt):
 
 \[
-  \operatorname
-                                                                                             * {minimize}_\theta H(\theta) \quad \text{subject to} \quad g_i(\theta) \leq 0, \quad i
-                                                                                        = 1, \ldots, r,
+  \operatorname*{minimize}_\theta H(\theta) \quad \text{subject to} \quad g_i(\theta) \leq 0, \quad i = 1, \ldots, r,
 \]
 
 with $H$ and the $g_i$ convex and differentiable. For peppered moths
@@ -1671,7 +1669,7 @@ wall pushing iterates away from the boundary. For each $t > 0$ consider the
 unconstrained *centering problem*
 
 \begin{equation}
-  \operatorname * {minimize}_\theta \, t H(\theta) + \phi(\theta).
+  \operatorname*{minimize}_\theta \, t H(\theta) + \phi(\theta).
   (\#eq:centering)
 \end{equation}
 

--- a/25-EM.Rmd
+++ b/25-EM.Rmd
@@ -397,9 +397,9 @@ is given as an exponential family Bayesian network
 and $x = M(\mathbf{y})$ is the observed transformation. 
 
 The complete data log-likelihood is 
-$$\theta \mapsto \theta^T t(\mathbf{y}) - \kappa(\theta)  = \theta^T \sum_{j=1}^m t_j(y_j) -  \kappa(\theta),$$
+$$\theta \mapsto \theta^\top t(\mathbf{y}) - \kappa(\theta)  = \theta^\top \sum_{j=1}^m t_j(y_j) -  \kappa(\theta),$$
 and we find that 
-$$Q(\theta \mid \theta') = \theta^T \sum_{j=1}^m E_{\theta'}(t_j(Y_j) \mid X = x)  - 
+$$Q(\theta \mid \theta') = \theta^\top \sum_{j=1}^m E_{\theta'}(t_j(Y_j) \mid X = x)  - 
 E_{\theta'}( \kappa(\theta) \mid X = x).$$
 
 To maximize $Q$ we differentiate $Q$ and equate the derivative equal to zero. We
@@ -578,7 +578,7 @@ and using the second Bartlett identity
 we see that 
 
 \[
-  \hat{\mathcal{I}}(\theta_0) =  \sum_{i=1}^N \big(\nabla_{\theta} Q_i(\theta_0 \mid \theta_0) - N^{-1} \nabla_{\theta} \ell(\theta_0)\big)\big(\nabla_{\theta} Q_i(\theta_0 \mid \theta_0) - N^{-1} \nabla_{\theta} \ell(\theta_0)\big)^T
+  \hat{\mathcal{I}}(\theta_0) =  \sum_{i=1}^N \big(\nabla_{\theta} Q_i(\theta_0 \mid \theta_0) - N^{-1} \nabla_{\theta} \ell(\theta_0)\big)\big(\nabla_{\theta} Q_i(\theta_0 \mid \theta_0) - N^{-1} \nabla_{\theta} \ell(\theta_0)\big)^\top
 \]
 
 is almost an unbiased estimator of the
@@ -587,7 +587,7 @@ estimator as $\theta_0$ is not known. Using a plug-in-estimator,
 $\hat{\theta}$, of $\theta_0$ we get a real estimator
 
 \[
-  \hat{\mathcal{I}} = \hat{\mathcal{I}}(\hat{\theta}) =  \sum_{i=1}^N \big(\nabla_{\theta} Q_i(\hat{\theta} \mid \hat{\theta}) - N^{-1} \nabla_{\theta} \ell(\hat{\theta})\big)\big(\nabla_{\theta} Q_i(\hat{\theta} \mid \hat{\theta}) - N^{-1} \nabla_{\theta} \ell(\hat{\theta})\big)^T,
+  \hat{\mathcal{I}} = \hat{\mathcal{I}}(\hat{\theta}) =  \sum_{i=1}^N \big(\nabla_{\theta} Q_i(\hat{\theta} \mid \hat{\theta}) - N^{-1} \nabla_{\theta} \ell(\hat{\theta})\big)\big(\nabla_{\theta} Q_i(\hat{\theta} \mid \hat{\theta}) - N^{-1} \nabla_{\theta} \ell(\hat{\theta})\big)^\top,
 \]
 
 though $\hat{\mathcal{I}}$ will no longer necessarily be unbiased. 
@@ -599,7 +599,7 @@ estimator, in which case $\nabla_{\theta} \ell(\hat{\theta}) = 0$ and the empiri
 Fisher information simplifies to 
 
 \[
-  \hat{\mathcal{I}} = \sum_{i=1}^N \nabla_{\theta} Q_i(\hat{\theta} \mid \hat{\theta}) \nabla_{\theta} Q_i(\hat{\theta} \mid \hat{\theta})^T.
+  \hat{\mathcal{I}} = \sum_{i=1}^N \nabla_{\theta} Q_i(\hat{\theta} \mid \hat{\theta}) \nabla_{\theta} Q_i(\hat{\theta} \mid \hat{\theta})^\top.
 \]
 
 However, $\nabla_{\theta} \ell(\hat{\theta})$ is in practice only approximately 
@@ -656,7 +656,7 @@ possible to get `optim()` to compute the Hessian numerically in the minimizer
 as a final step, but `optimHess()` does this computation separately). 
 
 
-```{r empFisher-pep, dependson=c("grad-loglik-pep", "moth-EM", "moth-likelihood", "moth-prob", "moth-M", "pep-jacobian")}
+```{r empFisher-pep, dependson=c("grad-loglik-pep-em", "moth-EM", "moth-likelihood", "moth-prob", "moth-M")}
 # The gradient of Q (equivalently the log-likelihood) is
 # implemented via 'grad_neg_loglik_mult'.
 grad_Q <- function(par, xx) {
@@ -673,11 +673,23 @@ estimates of the same quantity. Thus they are *not* supposed to be identical on
 a given data set, but they are supposed to estimate the same thing 
 and thus to be similar. 
 
-An alternative to the empirical Fisher information or a direct computation of 
-the observed Fisher information is supplemented EM (SEM). This is a general method 
-for computing the observed Fisher 
-information that relies only on EM steps and a numerical differentiation scheme. 
-Define the EM map $\Phi : \Theta \mapsto \Theta$ by 
+An alternative to the empirical Fisher information or a direct computation of
+the observed Fisher information is supplemented EM (SEM). This is a general method
+for computing the observed Fisher
+information that relies only on EM steps and a numerical differentiation scheme.
+
+Before introducing the SEM update, it is worth positioning EM within the
+iteration schema of Section\ \@ref(numopt). EM produces a sequence
+$\theta_n = \Phi(\theta_{n-1})$ for a step map $\Phi$ defined implicitly
+through the conditional expectation $Q$; the explicit formula is given
+below. Unlike the descent methods of Section\ \@ref(grad-descent), EM does
+not move along $-\nabla \ell$ at each step; monotonicity of the observed
+log-likelihood comes from Theorem\ \@ref(thm:EM-inequality) instead. Its
+convergence rate is governed by the spectrum of $D \Phi$ at a fixed point,
+and the SEM derivation below turns this fact into a recipe for computing
+observed Fisher information from EM steps alone.
+
+Define the EM map $\Phi : \Theta \mapsto \Theta$ by
 
 \[
 \Phi(\theta') = \argmax_{\theta} \ Q(\theta \mid \theta').
@@ -709,14 +721,14 @@ We want to compute $\hat{i}_Y$ but $\hat{i}_{X \mid Y} := \hat{i}_{X \mid Y}(\ha
 is not computable either. It can, however, be shown that 
 
 \[
-D_{\theta} \Phi(\hat{\theta})^T = \hat{i}_{X\mid Y} \left(\hat{i}_X\right)^{-1}.
+D_{\theta} \Phi(\hat{\theta})^\top = \hat{i}_{X\mid Y} \left(\hat{i}_X\right)^{-1}.
 \]
 
 Hence
 
 \begin{align}
 \hat{i}_Y & = \left(I - \hat{i}_{X \mid Y} \left(\hat{i}_X \right)^{-1}\right) \hat{i}_X \\
-& = \left(I - D_{\theta} \Phi(\hat{\theta})^T\right) \hat{i}_X.
+& = \left(I - D_{\theta} \Phi(\hat{\theta})^\top\right) \hat{i}_X.
 \end{align}
 
 Though the EM map $\Phi$ might not have a simple analytic expression, 
@@ -758,9 +770,9 @@ be computed by inverting $\hat{i}_Y$, but we also have the following
 interesting identity
 
 \begin{align}
-\hat{i}_Y^{-1} & = \hat{i}_Y^{-1} \left(I - D_{\theta} \Phi(\hat{\theta})^T\right)^{-1} \\
- & = \hat{i}_Y^{-1} \left(I + \sum_{n=1}^{\infty} \left(D_{\theta} \Phi(\hat{\theta})^T\right)^n \right) \\
- & = \hat{i}_Y^{-1} + \hat{i}_Y^{-1} D_{\theta} \Phi(\hat{\theta})^T \left(I - D_{\theta} \Phi(\hat{\theta})^T\right)^{-1}
+\hat{i}_Y^{-1} & = \hat{i}_Y^{-1} \left(I - D_{\theta} \Phi(\hat{\theta})^\top\right)^{-1} \\
+ & = \hat{i}_Y^{-1} \left(I + \sum_{n=1}^{\infty} \left(D_{\theta} \Phi(\hat{\theta})^\top\right)^n \right) \\
+ & = \hat{i}_Y^{-1} + \hat{i}_Y^{-1} D_{\theta} \Phi(\hat{\theta})^\top \left(I - D_{\theta} \Phi(\hat{\theta})^\top\right)^{-1}
 \end{align}
 
 where the second identity follows by the 
@@ -796,37 +808,247 @@ differentiation since this method ignores numerical errors, and when the algorit
 gets sufficiently close to the MLE, the numerical errors will dominate in 
 the difference quotients.
 
-## Revisiting Gaussian mixtures
+## Revisiting Gaussian mixtures {#Gauss-mix-ex}
 
-In a two-component Gaussian mixture model the marginal density of the 
-distribution of $Y$ is 
+To close this chapter, we develop the EM algorithm in full for a
+two-component Gaussian mixture. Mixture likelihoods are the textbook example
+of multimodal objectives, and the resulting fragility of direct maximization
+is exactly the regime where EM is most useful. We first set up the model and
+its canonical exponential-family parametrization, building on
+Section\ \@ref(parametrization); then simulate from it; then attempt
+direct maximization with `optim()`, which works for good initial guesses
+but gets stuck in local maxima for bad ones; and finally develop the EM
+algorithm itself.
+
+### Setting up the model
+
+A Gaussian mixture model is a mixture model where all the mixture
+distributions are Gaussian but potentially with different means and
+variances. We focus on the simplest case with $K = 2$ mixture components,
+parametrized by the five parameters: the mixture weight
+$p = \P(Z = 1) \in (0, 1)$, the two means $\mu_1, \mu_2 \in \mathbb{R}$, and
+the two standard deviations $\sigma_1, \sigma_2 > 0$.
+
+The marginal density of $Y$ in this parametrization is
 
 \[
-  f(y) = p \frac{1}{\sqrt{2 \pi \sigma_1^2}} e^{-\frac{(y - \mu_1)^2}{2 \sigma_1^2}} + 
+f(y) = p \frac{1}{\sqrt{2 \pi \sigma_1^2}} e^{-\frac{(y - \mu_1)^2}{2 \sigma_1^2}} +
 (1 - p)\frac{1}{\sqrt{2 \pi \sigma_2^2}}e^{-\frac{(y - \mu_2)^2}{2 \sigma_2^2}}.
 \]
 
-The following is a simulation of data from such a mixture model.
+It is also useful to express the model in canonical exponential-family form,
+following Section\ \@ref(parametrization). The canonical parameters are
 
-```{r gaus-mix-sim}
+\[
+\theta_1  = \log \frac{p}{1 - p}, \quad
+\theta_2  = \frac{\mu_1}{2\sigma_1^2}, \quad
+\theta_3  = \frac{1}{2\sigma_1^2}, \quad
+\theta_4  = \frac{\mu_2}{\sigma_2^2}, \quad
+\theta_5  = \frac{1}{2\sigma_2^2}.
+\]
+
+The joint density of $(Y, Z)$ in this parametrization is
+
+\[
+(y,k) \mapsto \left\{ \begin{array}{ll}
+\exp\left(\theta_1 + \theta_2 y - \theta_3 y^2 - \log (1 + e^{\theta_1}) - \frac{ \theta_2^2}{4\theta_3}+ \frac{1}{2} \log(\theta_3) \right) & \quad \text{if } k = 1 \\
+\exp\left(\theta_4 y - \theta_5 y^2 - \log (1 + e^{\theta_1}) - \frac{\theta_4^2}{4\theta_5} + \frac{1}{2}\log(\theta_5) \right) &  \quad \text{if } k = 2
+\end{array} \right.
+\]
+
+and the marginal density of $Y$ becomes
+
+\begin{align}
+f(y \mid \theta) & = \exp\left(\theta_1 + \theta_2 y - \theta_3 y^2 - \log (1 + e^{\theta_1}) - \frac{ \theta_2^2}{4\theta_3}+ \frac{1}{2} \log(\theta_3) \right) \\
+& + \exp\left(\theta_4 y - \theta_5 y^2 - \log (1 + e^{\theta_1}) - \frac{\theta_4^2}{4\theta_5} + \frac{1}{2}\log(\theta_5) \right).
+\end{align}
+
+There is no apparent benefit to the canonical parametrization for the
+marginal density itself, but it is useful when we need the logarithm of the
+joint density, as we will for the EM algorithm below.
+
+### Simulating from the mixture
+
+We simulate $N = 5000$ observations from the two-component Gaussian mixture
+model with mixture distributions $\mathcal{N}(-0.5, 1)$ and $\mathcal{N}(4, 4)$
+and equal mixture weights.
+
+```{r}
+#| label: mixture-gaus-sim
+
 sigma1 <- 1
 sigma2 <- 2
 mu1 <- -0.5
 mu2 <- 4
 p <- 0.5
-n <- 1000
-z <- sample(c(TRUE, FALSE), n, replace = TRUE, prob = c(p, 1 - p))
-y <- numeric(n)
-n1 <- sum(z)
-y[z] <- rnorm(n1, mu1, sigma1)
-y[!z] <- rnorm(n - n1, mu2, sigma2)
+N <- 5000
+z <- sample(c(TRUE, FALSE), N, replace = TRUE, prob = c(p, 1 - p))
+## Conditional simulation from the mixture components
+y <- numeric(N)
+N1 <- sum(z)
+y[z] <- rnorm(N1, mu1, sigma1)
+y[!z] <- rnorm(N - N1, mu2, sigma2)
 ```
 
-We implement the log-likelihood assuming that the variances are known. Note
-that the implementation takes just one single parameter argument, which is 
-then supposed to be a vector of all parameters in the model. Internally to 
-the function one has to decide for each entry in the parameter vector what
-parameter in the model it corresponds to.
+The resulting marginal distribution is bimodal, as the histogram in
+Figure\ \@ref(fig:mixture-gaus-histogram) shows.
+
+```{r, dependson="mixture-gaus-sim"}
+#| label: mixture-gaus-histogram
+#| fig-cap: "Histogram and density estimate (red) of data simulated from a two-component Gaussian mixture distribution. The true marginal density is in blue."
+
+yy <- seq(-3, 11, 0.1)
+dens <- p * dnorm(yy, mu1, sigma1) + (1 - p) * dnorm(yy, mu2, sigma2)
+ggplot(mapping = aes(y, after_stat(density))) +
+  geom_histogram(bins = 20) +
+  geom_line(aes(yy, dens), color = "blue", size = 1) +
+  stat_density(bw = "sj", geom = "line", color = "red", size = 1)
+```
+
+It is possible to give a mathematically different representation of the
+marginal distribution of $Y$ that is sometimes useful. Though it gives the
+same marginal distribution from the same components, it does provide a
+different interpretation of what a mixture model is a model of, and it does
+provide a different way of simulating from a mixture distribution.
+
+If we let $Y_1 \sim \mathcal{N}(\mu_1, \sigma_1^2)$ and
+$Y_2 \sim \mathcal{N}(\mu_2, \sigma_2^2)$ be independent, and independent of
+$Z$, we can define
+
+\begin{equation}
+Y = 1(Z = 1) Y_1 + 1(Z = 2) Y_2 = Y_{Z}.
+(\#eq:mixturerep)
+\end{equation}
+
+Clearly, the conditional distribution of $Y$ given $Z = k$ is $f_k$. From
+\@ref(eq:mixturerep) it follows directly that
+
+$$
+\E(Y^n) = \P(Z = 1) \E(Y_1^n) + \P(Z = 2) \E(Y_2^n) = p m_1(n) + (1 - p) m_2(n)
+$$
+
+where $m_k(n)$ denotes the $n$th non-central moment of the $k$th mixture
+component. In particular,
+
+$$
+\E(Y) = p \mu_1 + (1 - p) \mu_2.
+$$
+
+The variance can be found from the second moment as
+
+\begin{align}
+\V(Y) & = p(\mu_1^2 + \sigma_1^2) + (1-p)(\mu_2^2 + \sigma_2^2) -  (p \mu_1 + (1 - p) \mu_2)^2 \\
+& = p\sigma_1^2 + (1 - p) \sigma_2^2 + p(1-p)(\mu_1^2 + \mu_2^2 - 2 \mu_1 \mu_2).
+\end{align}
+
+While it is certainly possible to derive this formula by other means, using
+\@ref(eq:mixturerep) gives a simple argument based on elementary properties
+of expectation and independence of $(Y_1, Y_2)$ and $Z$.
+
+The construction via \@ref(eq:mixturerep) has an interpretation that differs
+from how a mixture model was defined in the first place. Though $(Y, Z)$
+has the correct joint distribution, $Y$ is by \@ref(eq:mixturerep) the
+result of $Z$ *selecting* one out of two possible observations. The
+difference is illustrated by the following example. Suppose that we have a
+population of twins with each pair of twins consisting of a male and a
+female. We can draw a sample of individuals (ignoring the relations between
+the twins) from this population and let $Z$ denote the sex and $Y$ the
+height of the individual. Then $Y$ follows a mixture distribution with two
+components corresponding to males and females according to the definition.
+We could then also draw a sample of twins, and for each pair of twins flip
+a coin to decide whether to report the male's or the female's height. This
+corresponds to the construction of $Y$ by \@ref(eq:mixturerep). We get the
+same marginal mixture distribution of heights though.
+
+Arguably the heights of two twins are not independent, but this is actually
+immaterial. Any dependence structure between $Y_1$ and $Y_2$ is lost in the
+transformation \@ref(eq:mixturerep), and we can just as well assume them
+independent for mathematical convenience. We will not be able to tell the
+difference from observing only $Y$ (and $Z$) anyway.
+
+We illustrate below how \@ref(eq:mixturerep) can be used for alternative
+implementations of ways to simulate from the mixture model. We compare
+empirical means and variances to the theoretical values to test if all the
+implementations actually simulate from the Gaussian mixture model.
+
+```{r, dependson="mixture-gaus-sim"}
+#| label: sim-gaus-mix
+
+## Mean
+mu <- p * mu1 + (1 - p) * mu2
+
+## Variance
+sigmasq <- p *
+  sigma1^2 +
+  (1 - p) * sigma2^2 +
+  p * (1 - p) * (mu1^2 + mu2^2 - 2 * mu1 * mu2)
+
+## Simulation using the selection formulation via 'ifelse'
+y2 <- ifelse(z, rnorm(N, mu1, sigma1), rnorm(N, mu2, sigma2))
+
+## Yet another way of simulating from a mixture model
+## using arithmetic instead of 'ifelse' for the selection
+## and with Y_1 and Y_2 actually being dependent
+y3 <- rnorm(N)
+y3 <- z * (sigma1 * y3 + mu1) + (!z) * (sigma2 * y3 + mu2)
+
+## Returning to the definition again, this last method simulates conditionally
+## from the mixture components via transformation of an underlying Gaussian
+## variable with mean 0 and variance 1
+y4 <- rnorm(N)
+y4[z] <- sigma1 * y4[z] + mu1
+y4[!z] <- sigma2 * y4[!z] + mu2
+
+## Tests
+data.frame(
+  mean = c(mu, mean(y), mean(y2), mean(y3), mean(y4)),
+  variance = c(sigmasq, var(y), var(y2), var(y3), var(y4)),
+  row.names = c("true", "conditional", "ifelse", "arithmetic", "conditional2")
+)
+```
+
+In terms of runtime there is not a big difference between three of the ways
+of simulating from a mixture model. A benchmark study (not shown) revealed
+that the first and third methods are comparable in terms of runtime and a
+bit faster than the fourth, while the second using `ifelse()` takes about
+twice as long as the two fastest. This is unsurprising as the `ifelse()`
+method takes \@ref(eq:mixturerep) very literally and generates twice the
+number of Gaussian variables actually needed.
+
+```{r}
+#| label: mix-sim-bench
+#| eval: false
+#| include: false
+
+N <- 10000
+z <- sample(c(TRUE, FALSE), N, replace = TRUE, prob = c(p, 1 - p))
+bench::mark(
+  {
+    x <- numeric(N)
+    N1 <- sum(z)
+    x[z] <- rnorm(N1, mu1, sigma1)
+    x[!z] <- rnorm(N - N1, mu2, sigma2)
+  },
+  x <- ifelse(z, rnorm(N, mu1, sigma1), rnorm(N, mu2, sigma2)),
+  {
+    x <- rnorm(N)
+    x <- z * (sigma1 * x + mu1) + (!z) * (sigma2 * x + mu2)
+  },
+  {
+    x <- rnorm(N)
+    x[z] <- sigma1 * x[z] + mu1
+    x[!z] <- sigma2 * x[!z] + mu2
+  },
+  check = FALSE
+)
+```
+
+### Optimization by direct MLE
+
+We implement the log-likelihood assuming that the variances are known. The
+implementation takes a single parameter argument, which is a vector of all
+parameters in the model; internally the function decides for each entry in
+the parameter vector what parameter in the model it corresponds to.
 
 ```{r gaus-mix-loglik}
 loglik <- function(par, y) {
@@ -841,34 +1063,36 @@ loglik <- function(par, y) {
 }
 ```
 
-Without further implementations, `optim()` can find the 
-maximum-likelihood estimate if we have a sensible initial parameter guess. 
-In this case we use the true parameters, which can be used when 
-algorithms are tested, but they are, of course, not available for 
-real applications. 
+Without further implementations, `optim()` can find the maximum-likelihood
+estimate if we have a sensible initial parameter guess. Here we use the true
+parameters, which can be used when algorithms are tested but are, of course,
+not available for real applications.
 
-```{r gaus-mix-example, dependson=c("gaus-mix-loglik", "gaus-mix-sim")}
+```{r gaus-mix-example, dependson=c("gaus-mix-loglik", "mixture-gaus-sim")}
 optim(c(0.5, -0.5, 4), loglik, y = y)[c(1, 2)]
 ```
 
-However, if we initialize the optimization badly, it does not find the maximum 
-but a local maximum instead.
+However, if we initialize the optimization badly, it does not find the
+maximum but a local maximum instead.
 
-```{r gaus-mix-example-bad, dependson=c("gaus-mix-loglik", "gaus-mix-sim")}
+```{r gaus-mix-example-bad, dependson=c("gaus-mix-loglik", "mixture-gaus-sim")}
 optim(c(0.9, 3, 1), loglik, y = y)[c(1, 2)]
 ```
 
-We will implement the EM algorithm for the Gaussian mixture model by 
-implementing and E-step and an M-step function. We know from Section 
-\@ref(Gauss-mix-ex) how the complete log-likelihood looks, and the E-step
-becomes a matter of computing 
-$$p_i(\mathbf{y}) = E(1(Z_i = 1) \mid \mathbf{Y} = \mathbf{y}) = P(Z_i = 1 \mid  \mathbf{Y} = \mathbf{y}).$$
+### EM algorithm
+
+We implement the EM algorithm for the Gaussian mixture model with an E-step
+and an M-step function. Using the canonical exponential-family parametrization
+set up above, the E-step amounts to computing
+
+$$p_i(\mathbf{y}) = \E(1(Z_i = 1) \mid \mathbf{Y} = \mathbf{y}) = \P(Z_i = 1 \mid  \mathbf{Y} = \mathbf{y}).$$
+
 The M-step becomes identical to the MLE, which can be found explicitly,
-but where the indicators $1(Z_i = 1)$ and $1(Z_i = 2) = 1 - 1(Z_i = 1)$ are 
-replaced by the conditional probabilities $p_i(\mathbf{y})$ and 
+but where the indicators $1(Z_i = 1)$ and $1(Z_i = 2) = 1 - 1(Z_i = 1)$ are
+replaced by the conditional probabilities $p_i(\mathbf{y})$ and
 $1 - p_i(\mathbf{y})$, respectively.
 
-```{r gaus-mix-EM, dependson=c("gaus-mix-loglik", "gaus-mix-sim")}
+```{r gaus-mix-EM, dependson=c("gaus-mix-loglik", "mixture-gaus-sim")}
 e_step_mix <- function(par, y) {
   p <- par[1]
   mu1 <- par[2]
@@ -879,10 +1103,10 @@ e_step_mix <- function(par, y) {
 }
 
 m_step_mix <- function(pz, y) {
-  n <- length(y)
+  N <- length(y)
   N2 <- sum(pz)
-  N1 <- n - N2
-  c(N1 / n, sum((1 - pz) * y) / N1, sum(pz * y) / N2)
+  N1 <- N - N2
+  c(N1 / N, sum((1 - pz) * y) / N1, sum(pz * y) / N2)
 }
 
 em_mix <- em_factory(e_step_mix, m_step_mix, eps = 1e-12)
@@ -890,10 +1114,10 @@ em_mix <- em_factory(e_step_mix, m_step_mix, eps = 1e-12)
 em_mix(c(0.5, -0.5, 4), y)
 ```
 
-The EM algorithm may, just as any other optimization algorithm, 
-end up in a *local* maximum, if it is started wrongly. 
+The EM algorithm may, just as any other optimization algorithm,
+end up in a *local* maximum, if it is started wrongly.
 
-```{r gauss-mix-EM-bad, dependson=c("gaus-mix-loglik", "gaus-mix-sim", "gaus-mix-EM")}
+```{r gauss-mix-EM-bad, dependson=c("gaus-mix-loglik", "mixture-gaus-sim", "gaus-mix-EM")}
 em_mix(c(0.9, 3, 1), y)
 ```
 

--- a/28-StochasticOptimization.Rmd
+++ b/28-StochasticOptimization.Rmd
@@ -1,6 +1,7 @@
 ```{r}
 #| label: stochopt-setup
 #| include: false
+
 library(tidyverse)
 library(patchwork)
 
@@ -11,63 +12,47 @@ knitr::opts_chunk$set(
 
 # Stochastic optimization {#stochopt}
 
-Numerical optimization involves different trade-offs such as an
-*exploration-exploitation* trade-off. On the one hand, the objective
-function must be thoroughly explored to build an adequate model of it.
-On the other hand, the model should be exploited so as to find the
-minimum quickly. Another trade-off is between the accuracy of the model
-and the time it takes to compute with it.
+The gradient descent and Newton methods of Chapter\ \@ref(numopt) take
+deterministic steps that use the *full* dataset at every iteration. For an
+empirical risk $H_N(\theta) = \frac{1}{N} \sum_{i=1}^N L(y_i, \theta)$ each
+gradient evaluation costs $O(Np)$, and when $N$ is in the millions this becomes
+the binding constraint, even though the per-iteration counts established in
+Theorems\ \@ref(thm:gd-linear) and \@ref(thm:gd-sublinear) look favourable.
 
-The optimization algorithms considered in Chapters \@ref(numopt) and
-\@ref(em) work on all available data and take deterministic steps in
-each iteration. The models are based on accurate local computations of
-derivatives that greedily exploit the local model obtained from
-derivatives, but they do little exploration.
+Stochastic gradient algorithms trade this picture for the opposite one. Each
+iteration uses only one or a few data points, costs $O(p)$ instead of $O(Np)$,
+and accepts a slower convergence rate measured in iterations. The deterministic
+algorithms win in the target accuracy $\epsilon$, the stochastic ones win in the
+sample size $N$, and for large $N$ at moderate accuracy, which is the regime of
+most statistical estimation problems, the crossover happens early enough that
+stochastic gradient comes out ahead. We will quantify the tradeoff as we go.
 
-By including randomness into optimization algorithms it is possible to
-lower the computational costs and make the algorithms more exploratory.
-This can be done in various ways. Examples of stochastic optimization
-algorithms include simulated annealing and evolutionary algorithms that
-incorporate randomness into the iterative steps with the purpose of
-exploring the objective function better than a deterministic algorithm
-is able to. In particular, to avoid getting stuck in saddle points and
-to escape local minima. Stochastic gradient algorithms form another
-example, where descent directions are approximated by gradients from
-random subsets of the data.
-
-The literature on stochastic optimization is huge, and this chapter will
-only cover some examples of particular relevance to statistics and
-machine learning. The most prominent applications are to large scale
-optimization, where stochastic gradient algorithms have become the
-standard solution. When the dimension of the optimization problem
-becomes very large, second order methods become prohibitively slow, and
-if the number of observations is also large, even one computation of the
-gradient for the entire data batch becomes time consuming. In those
-cases, stochastic gradient algorithms, that originate from online
-learning, can make progress more quickly while still using the entire
-batch of data.
+This chapter develops stochastic gradient algorithms for batch data, together
+with the variants that have proved useful in practice: mini-batches, momentum,
+and adaptive learning rates. The treatment is gradient-based throughout;
+gradient-free stochastic methods such as simulated annealing or evolutionary
+algorithms are outside the scope.
 
 ## Stochastic gradient algorithms {#sg-alg}
 
 Stochastic gradient algorithms have their origin in an online learning
-framework, where data arrives sequentially as a stream of data points
-and where the objective function is an expected loss. @Robbins:1951
-introduced in their seminal paper a variant of the online stochastic
-gradient algorithm that they called the *stochastic approximation
-method*, and they established the first convergence result for such
-algorithms. To understand what stochastic gradient algorithms are
-supposed to optimize, we introduce the general framework of a population
-model and give conditions that ensure that the basic online algorithm
-converges. Subsequently, the basic online algorithm is turned into an
-algorithm for batch data, which is the algorithm of primary interest. In
-the following sections, various beneficial extensions of the basic batch
-algorithm are explored.
+framework, where data arrives sequentially as a stream of data points and where
+the objective function is an expected loss. @Robbins:1951 introduced in their
+seminal paper a variant of the online stochastic gradient algorithm that they
+called the *stochastic approximation method*, and they established the first
+convergence result for such algorithms. To understand what stochastic gradient
+algorithms are supposed to optimize, we introduce the general framework of a
+population model and give conditions that ensure that the basic online algorithm
+converges. Subsequently, the basic online algorithm is turned into an algorithm
+for batch data, which is the algorithm of primary interest. In the following
+sections, various beneficial extensions of the basic batch algorithm are
+explored.
 
 ### Population models and loss functions {#Pop-model}
 
-We will consider observations from the sample space $\mathcal{Y}$, and
-we will be interested in estimating parameters from the parameter space
-$\Theta$. A loss function
+We will consider observations from the sample space $\mathcal{Y}$, and we will
+be interested in estimating parameters from the parameter space $\Theta$. A loss
+function
 
 \[
   L : \mathcal{Y} \times \Theta \to \mathbb{R}
@@ -80,13 +65,12 @@ is fixed throughout, and we want to minimize the expected loss also known as the
   H(\theta) = \E(L(Y, \theta)) = \int L(y, \theta) P(dy)
 \]
 
-with $Y \in \mathcal{Y}$ having distribution $P$. Of course, it is
-implicitly understood that the expectation has to be well defined for
-all $\theta$.
+with $Y \in \mathcal{Y}$ having distribution $P$. Of course, it is implicitly
+understood that the expectation has to be well defined for all $\theta$.
 
 ::: {#log-likelihood .example .boxed}
-Suppose that $f_{\theta}$ denotes a density on $\mathcal{Y}$
-parametrized by $\theta$. Then the log-likelihood loss is
+Suppose that $f_{\theta}$ denotes a density on $\mathcal{Y}$ parametrized by
+$\theta$. Then the log-likelihood loss is
 
 \[
   L(y, \theta) = - \log f_{\theta}(y).
@@ -112,15 +96,14 @@ finding a $\theta$ with $f_{\theta}$ being the optimal approximation of $f^0$ in
 a Kullback-Leibler sense.
 :::
 
-In many applications the observation is not just a single variable $y$ 
-but a pair of variables $(x, y)$, and the objective is often to predict
-$y$ from $x$. Thus the loss depends on both $x$ and $y$ and 
-reflects how well a prediction model given by the parameter $\theta$ 
-performs. 
+In many applications the observation is not just a single variable $y$ but a
+pair of variables $(x, y)$, and the objective is often to predict $y$ from $x$.
+Thus the loss depends on both $x$ and $y$ and reflects how well a prediction
+model given by the parameter $\theta$ performs.
 
 ::: {#least-squares .example .boxed}
-Suppose we observed $(X, Y)$ with $Y$ a real valued random variable, and
-that $\mu(x, \theta)$ denotes a parametrized mean value of $Y$ conditionally on
+Suppose we observed $(X, Y)$ with $Y$ a real valued random variable, and that
+$\mu(x, \theta)$ denotes a parametrized mean value of $Y$ conditionally on
 $X = x$. With the squared error loss,
 
 \[
@@ -133,68 +116,63 @@ the risk is the mean squared error
   \mathrm{MSE}(\theta) = \frac{1}{2} \E(Y - \mu(X, \theta))^2.
 \]
 
-From the definition of $\mathrm{MSE}(\theta)$ we see that 
+From the definition of $\mathrm{MSE}(\theta)$ we see that
 
 \[
-2 \mathrm{MSE}(\theta) =  \E(Y - \E(Y \mid X))^2 + \E(\E(Y \mid X) - \mu(X,
-\theta))^2,
+  2 \mathrm{MSE}(\theta) =  \E(Y - \E(Y \mid X))^2 + \E(\E(Y \mid X) - \mu(X,
+  \theta))^2,
 \]
 
-where the first term does not depend upon $\theta$. Thus
-minimizing the mean squared error is the same as finding $\theta_0$ such that
-$\mu(x, \theta_0)$ is the optimal approximation of $\E(Y \mid X = x)$ in a
-squared error sense.
+where the first term does not depend upon $\theta$. Thus minimizing the mean
+squared error is the same as finding $\theta_0$ such that $\mu(x, \theta_0)$ is
+the optimal approximation of $\E(Y \mid X = x)$ in a squared error sense.
 :::
 
-Note how the link between the distribution of $X$ and the parameter is
-defined in the example above by the choice of loss function. There is no
-upfront assumption that $\E(Y \mid X = x) = \mu(x, \theta_0)$ for any
-$\theta_0 \in \Theta$, but if there is such a $\theta_0$, it will
-clearly be a minimizer. In general, the optimal $\theta_0$ is simply the
-$\theta$ that minimizes the risk.
+Note how the link between the distribution of $X$ and the parameter is defined
+in the example above by the choice of loss function. There is no upfront
+assumption that $\E(Y \mid X = x) = \mu(x, \theta_0)$ for any
+$\theta_0 \in \Theta$, but if there is such a $\theta_0$, it will clearly be a
+minimizer. In general, the optimal $\theta_0$ is simply the $\theta$ that
+minimizes the risk.
 
-An alternative to the squared error loss is the log-likelihood loss,
-which can be used when we have a parametrized family of distributions.
+An alternative to the squared error loss is the log-likelihood loss, which can
+be used when we have a parametrized family of distributions.
 
 ::: {#log-likelihood-regress .example .boxed}
-We consider now the same regression setup as in Example
-\@ref(exm:least-squares) where we observe $(Y, X)$, but we let
+We consider now the same regression setup as in Example \@ref(exm:least-squares)
+where we observe $(Y, X)$, but we let
 
 \[
   f_{\theta}(y \mid x) = e^{- \mu(x, \theta)} \frac{y^{\mu(x, \theta)}}{y!}
 \]
 
-denote the Poisson point probabilities for the Poisson distribution with
-mean $\mu(x, \theta)$ conditionally on $X = x$. Then the log-likelihood
-loss is
+denote the Poisson point probabilities for the Poisson distribution with mean
+$\mu(x, \theta)$ conditionally on $X = x$. Then the log-likelihood loss is
 
-\[ 
+\[
   - \log f_{\theta}(y \mid x) = \mu(x, \theta) - y \log(\mu(x, \theta))
-\] 
+\]
 
-up to an additive constant not depending on $\theta$, and the
-cross-entropy is
+up to an additive constant not depending on $\theta$, and the cross-entropy is
 
 \[
   H(\theta) = \E\big(\mu(X, \theta) - \E(Y \mid X) \log(\mu(X, \theta))\big),
 \]
 
 again up to an additive constant. This risk function quantifies how
-$\mu(X, \theta)$ deviates from $\E(Y \mid X)$ in a different way than the
-risk based on the squared error loss. However, if
-$\E(Y \mid X = x) = \mu(x, \theta_0)$ for some $\theta_0$, it is still
-true that $\theta_0$ is a minimizer, cf. Exercise
-\@ref(exr:cross-entropy).
+$\mu(X, \theta)$ deviates from $\E(Y \mid X)$ in a different way than the risk
+based on the squared error loss. However, if
+$\E(Y \mid X = x) = \mu(x, \theta_0)$ for some $\theta_0$, it is still true that
+$\theta_0$ is a minimizer, cf. Exercise \@ref(exr:cross-entropy).
 :::
 
-The log-likelihood loss is an appropriate loss function if the
-parametrized family of distributions fits data well. For a Gaussian
-(conditional) mean value model the log-likelihood loss gives the same
-risk as the squared error loss---but the squared error loss can also be
-suitable even if data is not Gaussian. It is a suitable loss function
-whenever we just want to fit a model of the conditional mean of $Y$. If
-we want to fit the (conditional) median instead, we can use the absolute
-deviation 
+The log-likelihood loss is an appropriate loss function if the parametrized
+family of distributions fits data well. For a Gaussian (conditional) mean value
+model the log-likelihood loss gives the same risk as the squared error
+loss---but the squared error loss can also be suitable even if data is not
+Gaussian. It is a suitable loss function whenever we just want to fit a model of
+the conditional mean of $Y$. If we want to fit the (conditional) median instead,
+we can use the absolute deviation
 
 \[
   L(y,x, \theta) = |y - \mu(x, \theta)|.
@@ -203,52 +181,50 @@ deviation
 This is a special case of the so-called check loss functions used for [quantile
 regression](https://en.wikipedia.org/wiki/Quantile_regression#Quantiles). Thus
 by choosing the loss function we decide which aspects of the distribution we
-model. The log-likelihood loss leads to a good global fit, the squared error 
-loss leads to a good fit of the mean value specifically, and a check loss
-leads to a good fit of a particular quantile, such as the median.
+model. The log-likelihood loss leads to a good global fit, the squared error
+loss leads to a good fit of the mean value specifically, and a check loss leads
+to a good fit of a particular quantile, such as the median.
 
 ### Online stochastic gradient algorithm {#online-sg}
 
-The classical stochastic gradient algorithm is an example of an online
-learning algorithm. It is based on the simple observation that if we can
-interchange differentiation and expectation then
+The classical stochastic gradient algorithm is an example of an online learning
+algorithm. It is based on the simple observation that if we can interchange
+differentiation and expectation then
 
 \[
-\nabla H(\theta) = \E \left( \nabla_{\theta} L(Y, \theta) \right),
+  \nabla H(\theta) = \E \left( \nabla_{\theta} L(Y, \theta) \right),
 \]
 
 thus if $Y_1, Y_2, \ldots$ form an i.i.d. sequence then
-$\nabla_{\theta} L(Y_i, \theta)$ is unbiased as an estimate of the
-gradient of $H$ for any $\theta$ and any $i$. With inspiration from
-gradient descent algorithms it is natural to suggest stochastic
-parameter updates of the form
+$\nabla_{\theta} L(Y_i, \theta)$ is unbiased as an estimate of the gradient of
+$H$ for any $\theta$ and any $i$. With inspiration from gradient descent
+algorithms it is natural to suggest stochastic parameter updates of the form
 
 \[
-\theta_{n + 1} = \theta_n - \gamma_n \nabla_{\theta} L(Y_{n+1}, \theta_n)
+  \theta_{n + 1} = \theta_n - \gamma_n \nabla_{\theta} L(Y_{n+1}, \theta_n)
 \]
 
 starting from some initial value $\theta_0$. The direction,
-$\nabla_{\theta} L(Y_{n+1}, \theta_n)$, is, however, not guaranteed to
-be a descent direction for $H$, and even if it is, $\gamma_n$ is
-typically not chosen to guarantee descent.
+$\nabla_{\theta} L(Y_{n+1}, \theta_n)$, is, however, not guaranteed to be a
+descent direction for $H$, and even if it is, $\gamma_n$ is typically not chosen
+to guarantee descent.
 
-The sequence of step size parameters $\gamma_n \geq 0$ are known
-collectively as the *learning rate*. It can be a deterministic sequence,
-but $\gamma_n$ may also depend on $Y_1, \ldots, Y_{n}$ and
-$\theta_0, \ldots, \theta_{n}$. For stochastic gradient algorithms,
-convergence can be shown under global conditions on the decay of the
-learning rate rather than local conditions on the individual step
-lengths.
+The sequence of step size parameters $\gamma_n \geq 0$ are known collectively as
+the *learning rate*. It can be a deterministic sequence, but $\gamma_n$ may also
+depend on $Y_1, \ldots, Y_{n}$ and $\theta_0, \ldots, \theta_{n}$. For
+stochastic gradient algorithms, convergence can be shown under global conditions
+on the decay of the learning rate rather than local conditions on the individual
+step lengths.
 
 ::: {#sg-conv .theorem}
 Suppose $H$ is strongly convex and
 
 \[
-\E(\|\nabla_{\theta} L(Y, \theta))\|^2) \leq A + B \|\theta\|^2.
+  \E(\|\nabla_{\theta} L(Y, \theta))\|^2) \leq A + B \|\theta\|^2.
 \]
 
-If $\theta^*$ is the global minimizer of $H$ then $\theta_n$ converges
-almost surely toward $\theta^*$ if 
+If $\theta^*$ is the global minimizer of $H$ then $\theta_n$ converges almost
+surely toward $\theta^*$ if
 
 \begin{equation}
 \sum_{n=1}^{\infty} \gamma_n^2 < \infty \quad \text{and} \quad 
@@ -257,32 +233,39 @@ almost surely toward $\theta^*$ if
 :::
 
 From the above result, convergence of the algorithm is guaranteed if the
-learning rate, $\gamma_n$, converges to 0 but does so sufficiently
-slowly. Though formulated in a slightly different way, @Robbins:1951
-were the first to demonstrate convergence of an online learning
-algorithm under conditions as above on the learning rate. Following
-their terminology, much has since been written on online learning and
-adaptive control theory under the name *stochastic approximation*
-[@Lai:2003]. A proof of Theorem \@ref(thm:sg-conv) based on martingale 
-theory can be found [here](https://nrhstat.org/post/robbins_siegmund/).
+learning rate, $\gamma_n$, converges to 0 but does so sufficiently slowly.
+Though formulated in a slightly different way, @Robbins:1951 were the first to
+demonstrate convergence of an online learning algorithm under conditions as
+above on the learning rate. Following their terminology, much has since been
+written on online learning and adaptive control theory under the name
+*stochastic approximation* [@Lai:2003]. A proof of Theorem \@ref(thm:sg-conv)
+based on martingale theory can be found
+[here](https://nrhstat.org/post/robbins_siegmund/).
 
 A procedure for determining how the learning rate dacays is known as a *decay
-schedule*, and a flexible three-parameter power law family of decay
-schedules is given by
+schedule*, and a flexible three-parameter power law family of decay schedules is
+given by
 
 \[
-\gamma_n = \frac{\gamma_0  K}{K + n^a} = \frac{\gamma_0 }{1 + K^{-1} n^{a}}
+  \gamma_n = \frac{\gamma_0  K}{K + n^a} = \frac{\gamma_0 }{1 + K^{-1} n^{a}}
 \]
 
-for some initial learning rate $\gamma_0 > 0$ and constants $K, a > 0$.
-If $a \in (0.5, 1]$ the resulting learning rate satisfies the
-convergence conditions \@ref(eq:conv-cond).
+for some initial learning rate $\gamma_0 > 0$ and constants $K, a > 0$. If
+$a \in (0.5, 1]$ the resulting learning rate satisfies the convergence
+conditions \@ref(eq:conv-cond).
 
 (ref:decay-fig) Power law decay schedules as a function of $n$ for $\gamma_0 = 1$ and for different choices of $K$ and $a.$ The left figure shows decay schedules with $a$ chosen so that the convergence conditions are fulfilled, whereas the right figure shows decay schedules for which the convergence conditions are not fulfilled.
 
-```{r decay-fig, echo=FALSE, dependson="decay", fig.cap="(ref:decay-fig)", fig.height=4, fig.width=8, out.width="100%"}
+```{r, dependson="decay"}
+#| label: decay-fig
+#| echo: false
+#| fig-cap: "(ref:decay-fig)"
+#| fig-height: 4
+#| fig-width: 8
+#| out-width: "100%"
+
 grid_par <- expand.grid(
-#  n = 2^(seq(0, 20, 1)),
+  #  n = 2^(seq(0, 20, 1)),
   n = seq(0, 1000, 2),
   K = c(25, 50, 100),
   a = c(0.6, 1),
@@ -291,17 +274,21 @@ grid_par <- expand.grid(
 
 grid_par <- dplyr::mutate(grid_par, rate = gamma0 * K / (K + n^a))
 
-p1 <- ggplot(grid_par, aes(n, rate, color = factor(K), linetype = factor(a))) + 
+p1 <- ggplot(grid_par, aes(n, rate, color = factor(K), linetype = factor(a))) +
   geom_line() +
-#  geom_point(size = 2) +
-#  scale_x_log10() +
-#  scale_y_log10("Learning rate") +
-  theme(legend.position = "top", legend.box="vertical", legend.margin=margin()) +
+  #  geom_point(size = 2) +
+  #  scale_x_log10() +
+  #  scale_y_log10("Learning rate") +
+  theme(
+    legend.position = "top",
+    legend.box = "vertical",
+    legend.margin = margin()
+  ) +
   labs(y = "Rate", color = "K:", linetype = "a:") +
   guides(color = guide_legend(order = 1), linetype = guide_legend(order = 2))
 
 grid_par <- expand.grid(
-#  n = 2^(seq(0, 20, 1)),
+  #  n = 2^(seq(0, 20, 1)),
   n = seq(0, 1000, 2),
   K = c(1e4, 1e5, 1e6),
   a = c(2, 2.5),
@@ -310,61 +297,66 @@ grid_par <- expand.grid(
 
 grid_par <- dplyr::mutate(grid_par, rate = gamma0 * K / (K + n^a))
 
-p2 <- ggplot(grid_par, aes(n, rate, color = factor(K), linetype = factor(a))) + 
+p2 <- ggplot(grid_par, aes(n, rate, color = factor(K), linetype = factor(a))) +
   geom_line() +
-#  geom_point(size = 2) +
-#  scale_x_log10() +
-#  scale_y_log10("Learning rate") +
+  #  geom_point(size = 2) +
+  #  scale_x_log10() +
+  #  scale_y_log10("Learning rate") +
   ylab("") +
   scale_color_discrete(labels = c(quote(10^4), quote(10^5), quote(10^6))) +
   labs(y = "Rate", color = "K:", linetype = "a:") +
-  theme(legend.position = "top", legend.box="vertical", legend.margin=margin()) +
+  theme(
+    legend.position = "top",
+    legend.box = "vertical",
+    legend.margin = margin()
+  ) +
   guides(color = guide_legend(order = 1), linetype = guide_legend(order = 2))
 
 p1 + p2 + plot_layout(axes = "collect")
 ```
 
-The parameter $\gamma_0$ determines the initial baseline rate, and
-Figure \@ref(fig:decay-fig) illustrates the effect of the parameters $K$
-and $a$ on the decay. The parameter $a$ is the asymptotic exponent of
-$\gamma_n \sim \gamma_0 K n^{-a}$, and $K$ determines how quickly the
-rate will turn into a pure power law decay. Moreover, if we have a
-target rate, $\gamma_{1}$, that we want to hit after $n_{1}$ iterations,
-and we fix the exponent $a$, we can also solve for $K$ to find
+The parameter $\gamma_0$ determines the initial baseline rate, and Figure
+\@ref(fig:decay-fig) illustrates the effect of the parameters $K$ and $a$ on the
+decay. The parameter $a$ is the asymptotic exponent of
+$\gamma_n \sim \gamma_0 K n^{-a}$, and $K$ determines how quickly the rate will
+turn into a pure power law decay. Moreover, if we have a target rate,
+$\gamma_{1}$, that we want to hit after $n_{1}$ iterations, and we fix the
+exponent $a$, we can also solve for $K$ to find
 
 \[
   K = \frac{n_1^a \gamma_1}{\gamma_0 - \gamma_1}.
 \]
 
-This gives us a
-decay schedule that interpolates between $\gamma_0$ and $\gamma_1$ over
-the range $0, \ldots, n_1$ of iterations.
+This gives us a decay schedule that interpolates between $\gamma_0$ and
+$\gamma_1$ over the range $0, \ldots, n_1$ of iterations.
 
-We implement `decay_scheduler()` as a function that returns a particular
-decay schedule, with the possibility to determine $K$ automatically from
-a target rate.
+We implement `decay_scheduler()` as a function that returns a particular decay
+schedule, with the possibility to determine $K$ automatically from a target
+rate.
 
-```{r decay}
+```{r}
+#| label: decay
+
 decay_scheduler <- function(gamma0 = 1, a = 1, K = 1, gamma1, n1) {
   force(a)
-  if (!missing(gamma1) && !missing(n1))
+  if (!missing(gamma1) && !missing(n1)) {
     K <- n1^a * gamma1 / (gamma0 - gamma1)
+  }
   b <- gamma0 * K
   function(n) b / (K + n^a)
 }
 ```
 
-The following example of online Poisson regression illustrates the
-general ideas.
+The following example of online Poisson regression illustrates the general
+ideas.
 
 ::: {#online-pois-sg .example .boxed}
 In this example
-$Y_i \mid X_i = x_i \sim \mathrm{Pois}(\varphi(\beta_0 + \beta_1 x_i))$
-for $\beta = (\beta_0, \beta_1)^T$ the parameter vector and
-$\varphi: \mathbb{R} \to (0,\infty)$ a continuously differentiable
-function. We let the $X_i$-s be uniformly distributed in $(-1, 1)$, but
-this choice is not particularly important. The conditional mean of $Y_i$
-given $X_i = x_i$ is
+$Y_i \mid X_i = x_i \sim \mathrm{Pois}(\varphi(\beta_0 + \beta_1 x_i))$ for
+$\beta = (\beta_0, \beta_1)^\top$ the parameter vector and
+$\varphi: \mathbb{R} \to (0,\infty)$ a continuously differentiable function. We
+let the $X_i$-s be uniformly distributed in $(-1, 1)$, but this choice is not
+particularly important. The conditional mean of $Y_i$ given $X_i = x_i$ is
 
 \[
   \mu(x_i, \beta) = \varphi(\beta_0 + \beta_1 x_i)
@@ -374,167 +366,183 @@ and we will first consider the squared error loss. To this end, observe that
 
 \[
   \nabla_{\beta}  \mu(x_i, \beta) =  \varphi'(\beta_0 + \beta_1 x_i) 
-\left( \begin{array}{c} 1 \\ x_i \end{array} \right),
+  \left( \begin{array}{c} 1 \\ x_i \end{array} \right),
 \]
 
 which for the squared error loss results in the gradient
 
 \[
-\nabla_{\beta} \frac{1}{2} (y_i - \mu(x_i, \beta) )^2 = 
-  \varphi'(\beta_0 + \beta_1 x_i) (\mu(x_i, \beta) - y_i) \left( \begin{array}{c} 1 \\ x_i \end{array} \right).
+  \nabla_{\beta} \frac{1}{2} (y_i - \mu(x_i, \beta) )^2 = 
+    \varphi'(\beta_0 + \beta_1 x_i) (\mu(x_i, \beta) - y_i) \left( \begin{array}{c} 1 \\ x_i \end{array} \right).
 \]
 :::
 
-We simulate data and explore the learning algorithm in the special case
-with $\varphi = \exp$. To clearly emulate the online nature of the
-algorithm, the implementation below generates the observations
-sequentially in the loop.
+We simulate data and explore the learning algorithm in the special case with
+$\varphi = \exp$. To clearly emulate the online nature of the algorithm, the
+implementation below generates the observations sequentially in the loop.
 
-```{r online-poisson-sg-SE, echo=-1}
+```{r, echo=-1}
+#| label: online-poisson-sg-SE
+
 set.seed(13102020)
 N <- 5000
 beta_true = c(2, 3)
 mu <- function(x, beta) exp(beta[1] + beta[2] * x)
 beta <- vector("list", N)
 
-rate <- decay_scheduler(gamma0 = 0.0004, K = 100) 
+rate <- decay_scheduler(gamma0 = 0.0004, K = 100)
 beta[[1]] <- c(beta0 = 1, beta1 = 1)
 
-for(i in 2:N) {
+for (i in 2:N) {
   # Simulating a new data point
   x <- runif(1, -1, 1)
   y <- rpois(1, mu(x, beta_true))
-  # Update via squared error gradient 
+
+  # Update via squared error gradient
   mu_old <- mu(x, beta[[i - 1]])
-  beta[[i]] <- beta[[i - 1]]  - rate(i) * mu_old * (mu_old - y) * c(1, x)
+  beta[[i]] <- beta[[i - 1]] - rate(i) * mu_old * (mu_old - y) * c(1, x)
 }
-beta[[N]]  # This is close to beta_true; the algorithm appears to works.
+
+beta[[N]] # This is close to beta_true; the algorithm appears to works.
 ```
 
 For the log-likelihood loss we instead find the gradient
 
 \[
   \nabla_{\beta} \big( \mu(x_i, \beta) - y_i \log(\mu(x_i, \beta)) \big) = 
-  \frac{\varphi'(\beta_0 + \beta_1 x_i)}{\mu(x_i, \beta)} (\mu(x_i, \beta) - y_i) 
-\left( \begin{array}{c} 1 \\ x_i \end{array} \right),
+    \frac{\varphi'(\beta_0 + \beta_1 x_i)}{\mu(x_i, \beta)} (\mu(x_i, \beta) - y_i) 
+  \left( \begin{array}{c} 1 \\ x_i \end{array} \right),
 \]
 
-which leads to a
-slightly different but equally valid algorithm. In the special case with
-$\varphi = \exp$, the derivative is
+which leads to a slightly different but equally valid algorithm. In the special
+case with $\varphi = \exp$, the derivative is
 $\varphi'(\beta_0 + \beta_1 x_i) = \mu(x_i, \beta)$,
 
 \[
   \nabla_{\beta} \big( \mu(x_i, \beta) - y_i \log(\mu(x_i, \beta)) \big) = 
-  (\mu(x_i, \beta) - y_i) 
-\left( \begin{array}{c} 1 \\ x_i \end{array} \right),
+    (\mu(x_i, \beta) - y_i) 
+  \left( \begin{array}{c} 1 \\ x_i \end{array} \right),
 \]
 
-and the
-log-likelihood gradient differs from the squared error gradient by
+and the log-likelihood gradient differs from the squared error gradient by
 lacking the factor $\mu(x_i, \beta)$. With $X$ uniformly distributed on
 $(-1, 1$), the distribution of $\mu(X, (2, 3))$ has range between
-$e^{-1} \approx 0.3679$ and $e^5 \approx 148.4$ and is right skewed, that
-is, it is concentrated toward the smaller values but with a long right
-tail. Its median is $e^2 \approx 7.389$, while its mean is
-$(e^5 - e) / 6 \approx 24.67$.
+$e^{-1} \approx 0.3679$ and $e^5 \approx 148.4$ and is right skewed, that is, it
+is concentrated toward the smaller values but with a long right tail. Its median
+is $e^2 \approx 7.389$, while its mean is $(e^5 - e) / 6 \approx 24.67$.
 
 The squared error gradient is typically longer---and sometimes by a large
-factor---than the log-likelihood gradient due to the factor $\mu(x_i,
-\beta)$. In the implementation below with the gradient of the log-likelihood we
-therefore choose $\gamma_0$ a factor 25 larger than the $\gamma_0 = 0.0004$ that
-was used with the squared error gradient.
+factor---than the log-likelihood gradient due to the factor $\mu(x_i, \beta)$.
+In the implementation below with the gradient of the log-likelihood we therefore
+choose $\gamma_0$ a factor 25 larger than the $\gamma_0 = 0.0004$ that was used
+with the squared error gradient.
 
-```{r online-poisson-sg-LL, echo=-c(1, 2), dependson="online-poisson-sg-SE"}
+```{r, echo=-c(1, 2), dependson="online-poisson-sg-SE"}
+#| label: online-poisson-sg-LL
+
 set.seed(13102020)
-beta_SE <- cbind(as.data.frame(do.call(rbind, beta)),
-                 data.frame(iteration = 1:N, loss = "squared error"))
+beta_SE <- cbind(
+  as.data.frame(do.call(rbind, beta)),
+  data.frame(iteration = 1:N, loss = "squared error")
+)
 
-rate <- decay_scheduler(gamma0 = 0.01, K = 100) 
+rate <- decay_scheduler(gamma0 = 0.01, K = 100)
 beta[[1]] <- c(beta0 = 1, beta1 = 1)
 
-for(i in 2:N) {
+for (i in 2:N) {
   # Simulating a new data point
   x <- runif(1, -1, 1)
   y <- rpois(1, mu(x, beta_true))
-  # Update via log-likelihood gradient 
+
+  # Update via log-likelihood gradient
   mu_old <- mu(x, beta[[i - 1]])
-  beta[[i]] <- beta[[i - 1]]  - rate(i) * (mu_old - y) * c(1, x)
+  beta[[i]] <- beta[[i - 1]] - rate(i) * (mu_old - y) * c(1, x)
 }
-beta[[N]]  # This is close to beta_true; this algorithm also appears to works.
+beta[[N]] # This is close to beta_true; this algorithm also appears to works.
 ```
 
 (ref:pois-sgd) Estimated parameter values for the two parameters $\beta_0$ (true value $2$) and $\beta_1$ (true value $3$) in the Poisson regression model as a function of the number of data points in the online stochastic gradient algorithm.
 
-```{r pois-sgd, echo=FALSE, dependson="online_poisson_sg", fig.cap="(ref:pois-sgd)", warning=FALSE, fig.height=4, fig.width=8, out.width="100%"}
+```{r, dependson="online_poisson_sg"}
+#| label: pois-sgd
+#| echo: false
+#| fig-cap: "(ref:pois-sgd)"
+#| warning: false
+#| fig-height: 4
+#| fig-width: 8
+#| out-width: "100%"
+
 beta_all <- rbind(
-  cbind(as.data.frame(do.call(rbind, beta)),
-        data.frame(iteration = 1:N, loss = "log-likelihood")),
-  beta_SE) |> 
-  tidyr::pivot_longer(cols = c("beta0", "beta1"), names_to = "Parameter") |> 
+  cbind(
+    as.data.frame(do.call(rbind, beta)),
+    data.frame(iteration = 1:N, loss = "log-likelihood")
+  ),
+  beta_SE
+) |>
+  tidyr::pivot_longer(cols = c("beta0", "beta1"), names_to = "Parameter") |>
   dplyr::filter(iteration %% 50 == 0)
 
-ggplot(beta_all, aes(iteration, value, color = Parameter)) + 
-  geom_hline(yintercept = beta_true[1], color = "blue") + 
-  geom_hline(yintercept = beta_true[2], color = "red") + 
-  geom_point(alpha = 0.5, shape = 16, size = 2) + 
-  ylim(c(1.75, 3.25)) + 
+ggplot(beta_all, aes(iteration, value, color = Parameter)) +
+  geom_hline(yintercept = beta_true[1], color = "blue") +
+  geom_hline(yintercept = beta_true[2], color = "red") +
+  geom_point(alpha = 0.5, shape = 16, size = 2) +
+  ylim(c(1.75, 3.25)) +
   ylab("Parameter value") +
   xlab("Number of data points") +
   facet_wrap("loss") +
-  scale_color_manual(values = c("blue", "red"), labels = c(expression(beta[0]), expression(beta[1])))
+  scale_color_manual(
+    values = c("blue", "red"),
+    labels = c(expression(beta[0]), expression(beta[1]))
+  )
 ```
 
-Figure \@ref(fig:pois-sgd) shows how the estimates of $\beta_0$ and
-$\beta_1$ converge toward the true values for the two different choices
-of loss functions. With $\varphi = \exp$ and either loss function, the
-risk, $H(\beta)$, is strongly convex and attains its unique minimum in
-$\beta^* = (2, 3)^T$. Theorem \@ref(thm:sg-conv) suggests convergence
-for appropriate learning rates---except that the growth condition on
-the gradient is not fulfilled with $\varphi = \exp$. The growth
-condition *is* fulfilled if we replace the exponential function by
-softplus, $\varphi(w) = \log(1 + e^w)$, which for small values of $w$
-behaves like the exponential function, but grows linearly with $w$ for
-$w \to \infty$.
+Figure \@ref(fig:pois-sgd) shows how the estimates of $\beta_0$ and $\beta_1$
+converge toward the true values for the two different choices of loss functions.
+With $\varphi = \exp$ and either loss function, the risk, $H(\beta)$, is
+strongly convex and attains its unique minimum in $\beta^* = (2, 3)^\top$.
+Theorem \@ref(thm:sg-conv) suggests convergence for appropriate learning
+rates---except that the growth condition on the gradient is not fulfilled with
+$\varphi = \exp$. The growth condition *is* fulfilled if we replace the
+exponential function by softplus, $\varphi(w) = \log(1 + e^w)$, which for small
+values of $w$ behaves like the exponential function, but grows linearly with $w$
+for $w \to \infty$.
 
-The gradient from the squared error loss resulted in slower convergence
-and a more jagged sample path than the gradient from the log-likelihood.
-This is explained by the random factor $\mu(x_i, \beta)$ for the squared
-error gradient, which makes the step sizes somewhat irregular when data
-is from a Poisson distribution. It also makes choosing $\gamma_0$ a
-delicate balance. A small increase of $\gamma_0$ will make the algorithm
-unstable, while decreasing $\gamma_0$ will make the convergence even
-slower, though the fluctuations will also be damped. Making the right
-choice---or even a suitable choice---of decay schedule depends heavily
-on the problem considered and the gradient used. It is a problem
-specific challenge to find a good schedule, e.g., by choosing
-the three parameters if we use a power law schedule.
+The gradient from the squared error loss resulted in slower convergence and a
+more jagged sample path than the gradient from the log-likelihood. This is
+explained by the random factor $\mu(x_i, \beta)$ for the squared error gradient,
+which makes the step sizes somewhat irregular when data is from a Poisson
+distribution. It also makes choosing $\gamma_0$ a delicate balance. A small
+increase of $\gamma_0$ will make the algorithm unstable, while decreasing
+$\gamma_0$ will make the convergence even slower, though the fluctuations will
+also be damped. Making the right choice---or even a suitable choice---of decay
+schedule depends heavily on the problem considered and the gradient used. It is
+a problem specific challenge to find a good schedule, e.g., by choosing the
+three parameters if we use a power law schedule.
 
-The example illustrates that the loss function not only determines what
-we model, but also how well the learning algorithm works. Both loss
-functions are appropriate, but since the data is from the Poisson
-distribution, the log-likelihood loss leads to faster convergence.
-Exercise \@ref(exr:gauss-log-normal) explores the opposite situation
-where the data is from a Gaussian distribution.
+The example illustrates that the loss function not only determines what we
+model, but also how well the learning algorithm works. Both loss functions are
+appropriate, but since the data is from the Poisson distribution, the
+log-likelihood loss leads to faster convergence. Exercise
+\@ref(exr:gauss-log-normal) explores the opposite situation where the data is
+from a Gaussian distribution.
 
 ### Batch stochastic gradient algorithms
 
-The online algorithm does not store data, and once a data point is used
-it is forgotten. The online algorithm is working in a context where data
-arrives as a stream of data points and the model is updated continually.
-In statistics, we more frequently encounter batch algorithms, where an
-entire batch of data points is stored and processed by the algorithm,
-and where each data point in the batch can be accessed as many times as
-we like. However, when the batch is sufficiently large, many standard
-batch algorithms are slow, and some ideas from online algorithms can
-beneficially be transferred to batch processing of data.
+The online algorithm does not store data, and once a data point is used it is
+forgotten. The online algorithm is working in a context where data arrives as a
+stream of data points and the model is updated continually. In statistics, we
+more frequently encounter batch algorithms, where an entire batch of data points
+is stored and processed by the algorithm, and where each data point in the batch
+can be accessed as many times as we like. However, when the batch is
+sufficiently large, many standard batch algorithms are slow, and some ideas from
+online algorithms can beneficially be transferred to batch processing of data.
 
 Within the population model framework in Section \@ref(Pop-model) the objective
 is to minimize the population risk, $H(\theta)$, defined as the expected loss
-w.r.t. the probability distribution $P$. For the online algorithms we imagine
-an endless stream of data points from $P$, which can be used to ultimately
-minimize $H(\theta)$. Batch algorithms replace the population quantity by an
-empirical surrogate---the average loss on the batch
+w.r.t. the probability distribution $P$. For the online algorithms we imagine an
+endless stream of data points from $P$, which can be used to ultimately minimize
+$H(\theta)$. Batch algorithms replace the population quantity by an empirical
+surrogate, the average loss on the batch,
 
 \[
   H_N(\theta) = \frac{1}{N} \sum_{i=1}^N L(y_i, \theta).
@@ -543,253 +551,406 @@ empirical surrogate---the average loss on the batch
 Minimizing $H_N$ as a surrogate of minimizing $H$ is known as [empirical risk
 minimization](https://en.wikipedia.org/wiki/Empirical_risk_minimization).
 
-If data is i.i.d. the standard deviation of $H_N(\theta)$ decays as $N^{-1/2}$
-with $N$, while the runtime of its computation increases as $N$. Thus as we
-invest more computation time by using more data we get diminishing returns;
-doubling the runtime will only lower the precision of $H_N$ as an approximation
-of $H$ by a factor $1 / \sqrt{2} \approx 0.7$. The same is, of course, true if
-we look at the gradient, $\nabla H_N(\theta)$, or higher derivatives of $H_N$.
+If data is i.i.d. the standard deviation of $H_N(\theta)$ as an estimator of
+$H(\theta)$ decays as $N^{-1/2}$, while the runtime of its evaluation grows as
+$N$. Doubling the runtime improves precision only by a factor
+$1/\sqrt{2} \approx 0.7$. The same is true of $\nabla H_N(\theta)$ and higher
+derivatives. The cost of using the entire dataset for one gradient step is
+therefore poorly invested: the gradient from a random fraction of the data is
+already a noisy estimate of the population gradient $\nabla H(\theta)$, and
+using more data only sharpens the noise.
 
-It is not obvious that the computational costs of using the entire dataset to
-compute the gradient, say, is worth the effort compared to using only a fraction
-of the data. Thus we ask if there is a better trade-off between runtime and
-precision by using a fraction of data points each time we compute the gradient?
-Stochastic gradient algorithms are examples of such algorithms that "cycle through the
-data" and use only a random fraction of data points for each computation. The 
-most basic version of a stochastic gradient algorithm is presented first, 
-which uses only a single data point in each
-iteration, and it is really the same algorithm as presented in Section
-\@ref(online-sg) except that the population risk is replaced by the empirical
-risk defined in terms of the batch data.
+The basic stochastic gradient algorithm in the batch setting uses a single data
+point per iteration; it is the same as the online algorithm of
+Section\ \@ref(online-sg), with the population risk replaced by the empirical
+risk.
 
-With $P_N = \frac{1}{N}\sum_{i=1}^N \delta_{y_i}$ denoting the
-empirical distribution of the batch dataset, we see that
+With $P_N = \frac{1}{N}\sum_{i=1}^N \delta_{y_i}$ denoting the empirical
+distribution of the batch dataset, we see that
 
 \[
   H_N(\theta) = \int L(y, \theta) P_N(\mathrm{d}y),
 \]
 
-that is, the empirical risk is simply the expected loss with respect to the empirical
-distribution. Thus to minimize $H_N$ we can use the online approach by
-sampling observations from $P_N$. This leads to the following
-basic version of the stochastic gradient algorithm applied to a data
-batch.
+that is, the empirical risk is simply the expected loss with respect to the
+empirical distribution. Thus to minimize $H_N$ we can use the online approach by
+sampling observations from $P_N$. This leads to the following basic version of
+the stochastic gradient algorithm applied to a data batch.
 
-From an initial parameter value, $\theta_0$, we iteratively compute the
-parameters as follows: given $\theta_{n}$
+```{algorithm, sg-basic}
+\begin{algorithm}
+  \caption{Stochastic gradient descent}
+  \begin{algorithmic}
+    \Require learning rate $\gamma_n > 0$
+    \Repeat
+        \State sample an index $i$ uniformly from $\{1, \ldots, N\}$
+        \State $\theta \gets \theta - \gamma_n \nabla_{\theta} L(y_i, \theta)$
+    \Until{convergence}
+    \Return $\theta$
+  \end{algorithmic}
+\end{algorithm}
+```
 
--   sample an index $i$ uniformly from $\{1, \ldots, N\}$
--   compute $\rho_n = \nabla_{\theta} L(y_i, \theta_{n})$
--   update the parameter $\theta_{n+1} = \theta_{n} - \gamma_n \rho_n.$
+Sampling the index $i$ is equivalent to sampling an observation from the
+empirical distribution $P_N$, which in turn is the same as nonparametric
+bootstrapping. Just as in the online setting, the learning rate, $\gamma_n$, is
+a tuning parameter of the algorithm.
 
-Note that sampling the index $i$ is equivalent to sampling an
-observation from the empirical distribution $P_N$, which in turn is the same as
-nonparametric bootstrapping. Just as in the online setting, the
-learning rate, $\gamma_n$, is a tuning parameter of the algorithm.
+We implement the basic stochastic gradient algorithm below, allowing for a user
+defined decay schedule of the learning rate. However, instead of implementing
+one long loop, we divide the iterations into *epochs* with each epoch consisting
+of $N$ iterations. In the implementation, the maximum number of iterations is
+also given in terms of epochs, and the decay schedule is applied on a per epoch
+basis.
 
-We implement the basic stochastic gradient algorithm below, allowing for
-a user defined decay schedule of the learning rate. However, instead of
-implementing one long loop, we divide the iterations into *epochs* with
-each epoch consisting of $N$ iterations. In the implementation, the
-maximum number of iterations is also given in terms of epochs, and the
-decay schedule is applied on a per epoch basis.
+We also introduce a small twist on the sampling from the empirical distribution;
+instead of sampling with replacement (bootstrapping) we sample without
+replacement. Sampling $N$ indices from $\{1, \ldots, N\}$ without replacement is
+the same as sampling a permutation of the indices.
 
-We also introduce a small twist on the sampling from the empirical
-distribution; instead of sampling with replacement (bootstrapping) we
-sample without replacement. Sampling $N$ indices from $\{1, \ldots, N\}$
-without replacement is the same as sampling a permutation of the
-indices.
+```{r}
+#| label: sg
 
-```{r sg}
 stoch_grad <- function(
-  par, 
-  grad,              # Function of parameter and observation index
-  N,                 # Sample size
-  gamma,             # Decay schedule or a fixed learning rate
-  maxit = 100,       # Max epoch iterations
-  sampler = sample,  # Data resampler. Default is random permutation
-  cb = NULL, 
+  par,
+  grad, # Function of parameter and observation index
+  N, # Sample size
+  gamma, # Decay schedule or a fixed learning rate
+  maxit = 100, # Max epoch iterations
+  sampler = sample, # Data resampler. Default is random permutation
+  cb = NULL,
   ...
 ) {
-  if (is.function(gamma)) gamma <- gamma(1:maxit) 
-  gamma <- rep_len(gamma, maxit) 
-  for(n in 1:maxit) {
-    if(!is.null(cb)) cb()
-    samp <- sampler(N)   
-    for(j in 1:N) {
-      i <-  samp[j]
+  if (is.function(gamma)) {
+    gamma <- gamma(1:maxit)
+  }
+
+  gamma <- rep_len(gamma, maxit)
+
+  for (n in 1:maxit) {
+    if (!is.null(cb)) {
+      cb()
+    }
+
+    samp <- sampler(N)
+
+    for (j in 1:N) {
+      i <- samp[j]
       par <- par - gamma[n] * grad(par, i, ...)
     }
   }
+
   par
 }
 ```
 
-One epoch in the algorithm above is exactly one pass through the entire
-batch of data points, but in a random order. The default value of
-`sampler = sample` means that resampling is done without replacement. If
-we call `stoch_grad()` with `sampler = function(N) sample(N, replace = TRUE)` we
-would get sampling with replacement, in which case an epoch would be a
-pass through $N$ data points sampled independently from the batch.
-Sampling with replacement will feed the stochastic gradient algorithm
-with i.i.d. observations from the empirical distribution. Sampling without
-replacement introduces some dependence. Curiously, sampling without
-replacement has turned out to be empirically superior to sampling with
-replacement, and recent theoretical results, @Gurbuzbalaban:2019,
-support that it leads to a faster rate of convergence.
+One epoch in the algorithm above is exactly one pass through the entire batch of
+data points, but in a random order. The default value of `sampler = sample`
+means that resampling is done without replacement. If we call `stoch_grad()`
+with `sampler = function(N) sample(N, replace = TRUE)` we would get sampling
+with replacement, in which case an epoch would be a pass through $N$ data points
+sampled independently from the batch. Sampling with replacement will feed the
+stochastic gradient algorithm with i.i.d. observations from the empirical
+distribution. Sampling without replacement introduces some dependence.
+Curiously, sampling without replacement has turned out to be empirically
+superior to sampling with replacement, and recent theoretical results,
+@Gurbuzbalaban:2019, support that it leads to a faster rate of convergence.
 
 We may ask if the sampling actually matters, and whether we could just leave out
-that part of the algorithm? In practice, datasets may come in a "bad order",
-for instance in an unfortunate ordering according to one or more of its
-variables, and cycling through the data points in such an ordering can easily
-lead the algorithm astray. *It is therefore important to always randomize the
-order of the data points somehow*. A minimal amount of randomization in common
-use is to just do one initial random permutation, corresponding to moving the
-line `samp <- sampler(N)` outside of the outer for-loop in the implementation of
+that part of the algorithm? In practice, datasets may come in a "bad order", for
+instance in an unfortunate ordering according to one or more of its variables,
+and cycling through the data points in such an ordering can easily lead the
+algorithm astray. *It is therefore important to always randomize the order of
+the data points somehow*. A minimal amount of randomization in common use is to
+just do one initial random permutation, corresponding to moving the line
+`samp <- sampler(N)` outside of the outer for-loop in the implementation of
 `stoch_grad()`. This may be enough randomization for the algorithm to work in
 some cases, but the link to the convergence result for the online algorithm is
 broken.
 
 ::: {#batch-pois-sg .example .boxed}
-As a continuation of Example \@ref(exm:online-pois-sg) we consider the
-batch version of Poisson regression. We will only use the log-likelihood
-gradient, and we first simulate a small dataset with $N = 50$ data
-points.
+As a continuation of Example \@ref(exm:online-pois-sg) we consider the batch
+version of Poisson regression. We will only use the log-likelihood gradient, and
+we first simulate a small dataset with $N = 50$ data points.
 
-```{r pois-gradient, dependson="sg", echo=-1}
+```{r, dependson="sg", echo=-1}
+#| label: pois-gradient
+
 set.seed(17102020)
+
 N <- 50
 x <- runif(N, -1, 1)
 y <- rpois(N, mu(x, beta_true))
+
 grad_pois <- function(par, i) (mu(x[i], par) - y[i]) * c(1, x[i])
 ```
 
-Using the `grad_pois()` function above, we run the stochastic gradient
-algorithm for 1000 epochs with a decay schedule that interpolates
-between $\gamma_0 = 0.02$ and $\gamma_1 = 0.001$.
+Using the `grad_pois()` function above, we run the stochastic gradient algorithm
+for 1000 epochs with a decay schedule that interpolates between
+$\gamma_0 = 0.02$ and $\gamma_1 = 0.001$.
 
-```{r batch-poisson-sg, dependson="pois-gradient"}
+```{r, dependson="pois-gradient"}
+#| label: batch-poisson-sg
+
 pois_sg_tracer <- CSwR::tracer("par", Delta = 0)
+
 stoch_grad(
-  c(0, 0), 
-  grad_pois, 
-  N = N, 
-  gamma = decay_scheduler(gamma0 = 0.02, gamma1 = 0.001, n1 = 1000), 
-  maxit = 1000, 
+  c(0, 0),
+  grad_pois,
+  N = N,
+  gamma = decay_scheduler(gamma0 = 0.02, gamma1 = 0.001, n1 = 1000),
+  maxit = 1000,
   cb = pois_sg_tracer$tracer
 )
 ```
 
-The resulting parameter estimate should be compared to the
-maximum-likelihood estimate from an ordinary Poisson regression.
+The resulting parameter estimate should be compared to the maximum-likelihood
+estimate from an ordinary Poisson regression.
 
-```{r pois-beta-hat, dependson="pois-gradient", echo=1}
+```{r, dependson="pois-gradient", echo=1}
+#| label: pois-beta-hat
+
 beta_hat <- coefficients(glm(y ~ x, family = poisson))
 cat("beta_hat:", beta_hat)
 ```
 
-The batch version of stochastic gradient descent converges toward the
-minimizer, $(\hat{\beta}_0, \hat{\beta}_1)$, of the empirical risk. This
-is contrary to the online version that converges toward the minimizer of
-the theoretical risk, which in this case is
-$(\beta_0, \beta_1) = (2, 3)$. With a larger batch size,
+The batch version of stochastic gradient descent converges toward the minimizer,
+$(\hat{\beta}_0, \hat{\beta}_1)$, of the empirical risk. This is contrary to the
+online version that converges toward the minimizer of the theoretical risk,
+which in this case is $(\beta_0, \beta_1) = (2, 3)$. With a larger batch size,
 $(\hat{\beta}_0, \hat{\beta}_1)$ will come closer to $(2, 3)$. Figure
-\@ref(fig:batch-pois-sgd-fig) shows clearly how the algorithms converge
-toward a limit that depends on the batch size, and for $N = 500$, this
-limit is much closer to the theoretical minimizer.
+\@ref(fig:batch-pois-sgd-fig) shows clearly how the algorithms converge toward a
+limit that depends on the batch size, and for $N = 500$, this limit is much
+closer to the theoretical minimizer.
 
-```{r batch-poisson-sg-2, dependson="pois-gradient", echo=-1}
+```{r, dependson="pois-gradient", echo=-1}
+#| label: batch-poisson-sg-2
+
 set.seed(17102020)
 N <- 500
 x <- runif(N, -1, 1)
 y <- rpois(N, mu(x, beta_true))
 pois_sg_tracer_2 <- CSwR::tracer("par", Delta = 0)
 stoch_grad(
-  par = c(0, 0), 
-  grad = grad_pois, 
-  N = N, 
-  gamma = decay_scheduler(gamma0 = 0.02, gamma1 = 0.001, n1 = 100), 
+  par = c(0, 0),
+  grad = grad_pois,
+  N = N,
+  gamma = decay_scheduler(gamma0 = 0.02, gamma1 = 0.001, n1 = 100),
   cb = pois_sg_tracer_2$tracer
 )
 ```
 
-```{r pois-beta-hat-2, dependson="batch-poisson-sg-2", echo=1}
+```{r, dependson="batch-poisson-sg-2", echo=1}
+#| label: pois-beta-hat-2
+
 beta_hat_2 <- coefficients(glm(y ~ x, family = poisson))
 cat("beta_hat_2:", beta_hat_2)
 ```
 
 (ref:batch-pois-sgd) Estimated parameter values for the two parameters $\beta_0 =2$ and $\beta_1 = 3$ in the Poisson regression model as a function of the number of iterations in the stochastic gradient algorithm. For batch size $N = 50$, the algorithm converges to a parameter clearly different from the theoretically optimal one (gray dashed lines), while for batch size $N = 500$ the limit is closer to $(2, 3).$
 
-```{r batch-pois-sgd-fig, echo=FALSE, dependson="online_poisson_sg", fig.cap="(ref:batch-pois-sgd)", warning=FALSE, fig.height=4, fig.width=8, out.width="100%"}
+```{r, dependson="online_poisson_sg"}
+#| label: batch-pois-sgd-fig
+#| echo: false
+#| fig-cap: "(ref:batch-pois-sgd)"
+#| warning: false
+#| fig-height: 4
+#| fig-width: 8
+#| out-width: "100%"
+
 hline_data <- data.frame(
-  beta0 = c(beta_hat[1], beta_hat_2[1]), 
+  beta0 = c(beta_hat[1], beta_hat_2[1]),
   beta1 = c(beta_hat[2], beta_hat_2[2]),
   N = c("N = 50", "N = 500")
 )
 
 dplyr::bind_rows(
-  small = summary(pois_sg_tracer)[seq(10, 1000, 10), ], 
-  large = summary(pois_sg_tracer_2), 
+  small = summary(pois_sg_tracer)[seq(10, 1000, 10), ],
+  large = summary(pois_sg_tracer_2),
   .id = "N"
-) |> 
-  dplyr::mutate(N = ifelse(N == "small", "N = 50", "N = 500"), n = rep(5 * seq(10, 1000, 10), 2)) |> 
-  dplyr::rename(beta0 = par.1, beta1 = par.2) |> 
-  tidyr::pivot_longer(cols = c("beta0", "beta1"), names_to = "Parameter") |> 
-ggplot(aes(n, value, color = Parameter)) + 
-  geom_hline(data = hline_data, aes(yintercept = beta0), color = "blue") + 
-  geom_hline(data = hline_data, aes(yintercept = beta1), color = "red") + 
-  geom_hline(yintercept = beta_true[1], linetype = 2, alpha = 0.5) + 
-  geom_hline(yintercept = beta_true[2], linetype = 2, alpha = 0.5) + 
-  geom_point(alpha = 0.5, shape = 16, size = 2) + 
+) |>
+  dplyr::mutate(
+    N = ifelse(N == "small", "N = 50", "N = 500"),
+    n = rep(5 * seq(10, 1000, 10), 2)
+  ) |>
+  dplyr::rename(beta0 = par.1, beta1 = par.2) |>
+  tidyr::pivot_longer(cols = c("beta0", "beta1"), names_to = "Parameter") |>
+  ggplot(aes(n, value, color = Parameter)) +
+  geom_hline(data = hline_data, aes(yintercept = beta0), color = "blue") +
+  geom_hline(data = hline_data, aes(yintercept = beta1), color = "red") +
+  geom_hline(yintercept = beta_true[1], linetype = 2, alpha = 0.5) +
+  geom_hline(yintercept = beta_true[2], linetype = 2, alpha = 0.5) +
+  geom_point(alpha = 0.5, shape = 16, size = 2) +
   ylim(c(1.5, 3.5)) +
   ylab("Parameter value") +
   facet_wrap("N") +
-  scale_color_manual(values = c("blue", "red"), labels = c(expression(beta[0]), expression(beta[1])))
+  scale_color_manual(
+    values = c("blue", "red"),
+    labels = c(expression(beta[0]), expression(beta[1]))
+  )
 ```
+
+The per-epoch view in Figure \@ref(fig:batch-pois-sgd-fig) smooths over what
+each individual update looks like. Figure \@ref(fig:pois-sgd-traj) tracks the
+parameter after every single-point update on the $N = 50$ dataset, with gradient
+descent on the full batch overlaid for reference. The gradient descent iterates
+trace a smooth curve along the negative gradient, while the stochastic iterates
+wander noticeably around it; each step uses the gradient at a single data point,
+so the direction varies from step to step and the path becomes irregular.
 :::
 
+```{r, dependson=c("pois-gradient", "pois-beta-hat")}
+#| label: pois-sgd-traj
+#| echo: false
+#| fig-cap: >-
+#|   Stochastic gradient descent (5 epochs, 250 updates) and full-batch gradient
+#|   descent (40 iterations) on the negative log-likelihood contours of the
+#|   Poisson regression model with $N = 50$, both starting from $(0, 0)$. The
+#|   left panel shows the SGD trajectory at every single update; the right panel
+#|   shows it only at the end of each epoch. The cross marks the
+#|   maximum-likelihood estimate.
+#| fig-width: 8
+#| fig-height: 4
+#| out-width: "100%"
 
+library(patchwork)
 
-Example \@ref(exm:batch-pois-sg) and Figure
-\@ref(fig:batch-pois-sgd-fig), in particular, illustrate that if the
-dataset is relatively small, the algorithm quickly attains a precision
-smaller than the statistical uncertainty, and further optimization is
-therefore futile. However, for larger datasets, optimization to a
-greater precision can be beneficial.
+set.seed(23)
+
+# Per-step SGD trace
+sgd_gamma <- decay_scheduler(gamma0 = 0.02, gamma1 = 0.005, n1 = 5)(1:5)
+sgd_par <- c(0, 0)
+n_sgd <- 5 * N
+sgd_path <- matrix(0, nrow = n_sgd + 1, ncol = 2)
+sgd_path[1, ] <- sgd_par
+k <- 1
+
+for (epoch in 1:5) {
+  for (i in sample(N)) {
+    sgd_par <- sgd_par - sgd_gamma[epoch] * grad_pois(sgd_par, i)
+    k <- k + 1
+    sgd_path[k, ] <- sgd_par
+  }
+}
+
+# Full-batch gradient descent with averaged gradient
+grad_full <- function(par) colSums((mu(x, par) - y) * cbind(1, x)) / N
+
+gd_par <- c(0, 0)
+n_gd <- 50
+gd_path <- matrix(0, nrow = n_gd + 1, ncol = 2)
+gd_path[1, ] <- gd_par
+
+for (n in 1:n_gd) {
+  gd_par <- gd_par - 0.02 * grad_full(gd_par)
+  gd_path[n + 1, ] <- gd_par
+}
+
+nll <- function(b0, b1) {
+  eta <- b0 + b1 * x
+  sum(exp(eta) - y * eta) / N
+}
+
+b0_grid <- seq(-0.2, 3.2, length.out = 80)
+b1_grid <- seq(-0.2, 3.6, length.out = 80)
+nll_grid <- expand.grid(beta0 = b0_grid, beta1 = b1_grid)
+nll_grid$z <- mapply(nll, nll_grid$beta0, nll_grid$beta1)
+
+gd_df <- data.frame(
+  beta0 = gd_path[, 1],
+  beta1 = gd_path[, 2],
+  Algorithm = "GD"
+)
+sgd_step_df <- data.frame(
+  beta0 = sgd_path[, 1],
+  beta1 = sgd_path[, 2],
+  Algorithm = "SGD"
+)
+epoch_idx <- 1 + (0:5) * N
+sgd_epoch_df <- data.frame(
+  beta0 = sgd_path[epoch_idx, 1],
+  beta1 = sgd_path[epoch_idx, 2],
+  Algorithm = "SGD"
+)
+
+xlab <- expression(beta[0])
+ylab <- expression(beta[1])
+
+make_panel <- function(sgd_df, subtitle, sgd_size = 0.6) {
+  paths <- dplyr::bind_rows(sgd_df, gd_df)
+  ggplot() +
+    geom_contour(
+      data = nll_grid,
+      aes(beta0, beta1, z = z),
+      color = "grey85",
+      bins = 18
+    ) +
+    geom_path(data = paths, alpha = 0.5, aes(beta0, beta1, color = Algorithm)) +
+    geom_point(
+      data = gd_df,
+      aes(beta0, beta1, color = Algorithm),
+      size = 0.6
+    ) +
+    geom_point(
+      data = sgd_df,
+      aes(beta0, beta1, color = Algorithm),
+      size = sgd_size
+    ) +
+    annotate(
+      "point",
+      x = beta_hat[1],
+      y = beta_hat[2],
+      shape = 4,
+      size = 3,
+      stroke = 1
+    ) +
+    scale_color_manual(values = c("steelblue", "dark orange")) +
+    labs(x = xlab, y = ylab, subtitle = subtitle)
+}
+
+make_panel(sgd_step_df, "Per step") +
+  make_panel(sgd_epoch_df, "Per epoch") +
+  plot_layout(guides = "collect", axes = "collect")
+```
+
+Example \@ref(exm:batch-pois-sg) and Figure \@ref(fig:batch-pois-sgd-fig), in
+particular, illustrate that if the dataset is relatively small, the algorithm
+quickly attains a precision smaller than the statistical uncertainty, and
+further optimization is therefore futile. However, for larger datasets,
+optimization to a greater precision can be beneficial.
 
 ### Predicting news article sharing on social media {#news}
 
-In this section we will illustrate the use of the basic stochastic
-gradient algorithm for learning a model that predicts how many times a
-news article is shared on social media. We will use a simple linear 
-model and the squared error loss function. 
+In this section we will illustrate the use of the basic stochastic gradient
+algorithm for learning a model that predicts how many times a news article is
+shared on social media. We will use a simple linear model and the squared error
+loss function.
 
-The basic stochastic gradient algorithm for the linear model was
-introduced to the early machine learning community in 1960 via ADALINE
-(Adaptive Linear Neuron) by @Widrow:1960. ADALINE was
-[implemented as a physical
+The basic stochastic gradient algorithm for the linear model was introduced to
+the early machine learning community in 1960 via ADALINE (Adaptive Linear
+Neuron) by @Widrow:1960. ADALINE was [implemented as a physical
 device](https://www.youtube.com/watch?v=hc2Zj55j1zU) capable of learning
-patterns via stochastic gradient updates. The math is the same today,
-but the implementation has fortunately become somewhat easier.
+patterns via stochastic gradient updates. The math is the same today, but the
+implementation has fortunately become somewhat easier.
 
 With a linear model and the squared error loss,
-$L(y, x, \beta) = \frac{1}{2} (y - \beta^T x)^2$, the gradient becomes
+$L(y, x, \beta) = \frac{1}{2} (y - \beta^\top x)^2$, the gradient becomes
 
 \[
-\nabla_{\beta} L(y, x, \beta) = - x (y - \beta^T x) = x (\beta^T x - y),
+  \nabla_{\beta} L(y, x, \beta) = - x (y - \beta^\top x) = x (\beta^\top x - y),
 \]
 
 which results in updates of the form
 
 \[
-\beta_{n+1} = \beta_n - \gamma_n x_i (\beta_n^T x_i - y_i).
+  \beta_{n+1} = \beta_n - \gamma_n x_i (\beta_n^\top x_i - y_i).
 \]
 
-That is, the parameter moves in the direction of $x_i$ if $\beta_n^T x_i < y_i$
-and in the direction of $-x_i$ if $\beta_n^T x_i > y_i$. The amount by
-which it moves is controlled partly by the learning rate, $\gamma_n$,
-and partly by the size of the residual, $y_i - \beta_n^T x_i$. A larger
-residual gives a larger move.
+That is, the parameter moves in the direction of $x_i$ if
+$\beta_n^\top x_i < y_i$ and in the direction of $-x_i$ if
+$\beta_n^\top x_i > y_i$. The amount by which it moves is controlled partly by
+the learning rate, $\gamma_n$, and partly by the size of the residual,
+$y_i - \beta_n^\top x_i$. A larger residual gives a larger move.
 
 The following function factory for linear models takes a model matrix and a
 response vector for the complete data batch as arguments and implements the
@@ -799,21 +960,25 @@ and the gradient as well as additional variables including a parameter vector of
 the correct dimension, which can be used for initialization of optimization
 algorithms.
 
-```{r ls-model}
+```{r}
+#| label: ls-model
+
 ls_model <- function(X, y) {
   N <- length(y)
   X <- unname(X) # Strips X of names
+
   list(
     N = N,
-    X = X, 
-    y = y, 
+    X = X,
+    y = y,
     # Initial parameter value
     par0 = rep(0, ncol(X)),
     # Objective function
-    H = function(beta)
-      drop(crossprod(y - X %*% beta)) / (2 * N),
+    H = function(beta) {
+      drop(crossprod(y - X %*% beta)) / (2 * N)
+    },
     # Gradient for the (sub)batch indexed by i
-    grad = function(beta, i, ...) {               
+    grad = function(beta, i, ...) {
       xi <- X[i, , drop = FALSE]
       res <- xi %*% beta - y[i]
       drop(crossprod(xi, res)) / length(res)
@@ -822,159 +987,207 @@ ls_model <- function(X, y) {
 }
 ```
 
-Note that the gradient implementation works for `i` a single index as well 
-as for `i` a vector of indices, in which case it returns the  
-average gradient over the corresponding data points. Note also that if `i` 
-is missing, the subsetting with a missing argument will return the entire 
-matrix/vector, and `grad()` returns the gradient of `H()`. It is possible to 
-implement a slightly more efficient computation if `i` is always a single 
-number, but the more general implementation will be needed in subsequent 
-sections. 
+Note that the gradient implementation works for `i` a single index as well as
+for `i` a vector of indices, in which case it returns the\
+average gradient over the corresponding data points. Note also that if `i` is
+missing, the subsetting with a missing argument will return the entire
+matrix/vector, and `grad()` returns the gradient of `H()`. It is possible to
+implement a slightly more efficient computation if `i` is always a single
+number, but the more general implementation will be needed in subsequent
+sections.
 
-We will use the data included in the CSwR package as the data frame `news` with 
-39,644 observations and 53 variables. One variable is the
-integer valued `shares`, which is the target variable of our
-predictions. The data was originally collected by @Fernandes:2015, and is 
-also available from the
-[UCI Machine Learning
+We will use the data included in the CSwR package as the data frame `news` with
+39,644 observations and 53 variables. One variable is the integer valued
+`shares`, which is the target variable of our predictions. The data was
+originally collected by @Fernandes:2015, and is also available from the [UCI
+Machine Learning
 Repository](https://archive.ics.uci.edu/ml/datasets/online+news+popularity)
-[@News:2015]. 
+[@News:2015].
 
-We construct a model matrix without an explicit intercept from all
-the variables in the dataset but the target variable `shares`. We 
-then use it to compute the least squares fit for predicting the 
-logarithm of the number of shares.
+We construct a model matrix without an explicit intercept from all the variables
+in the dataset but the target variable `shares`. We then use it to compute the
+least squares fit for predicting the logarithm of the number of shares.
 
-```{r news-X-y, dependson="news-data"}
-X <- model.matrix(shares ~ . - 1, data = CSwR::news)  
+```{r, dependson="news-data"}
+#| label: news-X-y
+
+X <- model.matrix(shares ~ . - 1, data = CSwR::news)
 lm_news <- lm.fit(X, log(CSwR::news$shares))
 ```
 
-This dataset is by current standards not a large dataset---the dense
-model matrix takes only about 20 MB of memory---and the linear model
-(with the target variable `shares` log-transformed) can easily be fitted
-by simply solving the least squares problem. It takes about 0.2 seconds
-on a standard laptop to compute the solution. The residual plot in
-Figure \@ref(fig:fig-res-lm-news) shows that the model is actually not a
-poor fit to data, though there is a considerable unexplained residual
-variance.
+This dataset is by current standards not a large dataset---the dense model
+matrix takes only about 20 MB of memory---and the linear model (with the target
+variable `shares` log-transformed) can easily be fitted by simply solving the
+least squares problem. It takes about 0.2 seconds on a standard laptop to
+compute the solution. The residual plot in Figure \@ref(fig:fig-res-lm-news)
+shows that the model is actually not a poor fit to data, though there is a
+considerable unexplained residual variance.
 
-```{r fig-res-lm-news, message = FALSE, warning = FALSE, echo=FALSE, fig.cap="Residual plot for the linear model of the logarithm of news article shares.", dependson="news-X-y"}
-ggplot(mapping = aes(x = exp(lm_news$fitted.values), y = lm_news$residuals)) + 
-  geom_point(alpha = 0.1) + 
+```{r, dependson="news-X-y"}
+#| label: fig-res-lm-news
+#| message: false
+#| warning: false
+#| echo: false
+#| fig-cap: "Residual plot for the linear model of the logarithm of news article shares."
+
+ggplot(mapping = aes(x = exp(lm_news$fitted.values), y = lm_news$residuals)) +
+  geom_point(alpha = 0.1) +
   geom_smooth() +
   xlab("Fitted values (number of shares)") +
   ylab("Residuals (log-scale)") +
-  #scale_y_log10(limits = exp(c(-8, 8)), breaks = c(10^(-2), 0, 10^2), labels = c("0.01", "0", "100")) + 
-  coord_cartesian(ylim = c(-5, 5)) + 
+  #scale_y_log10(limits = exp(c(-8, 8)), breaks = c(10^(-2), 0, 10^2), labels = c("0.01", "0", "100")) +
+  coord_cartesian(ylim = c(-5, 5)) +
   scale_x_log10(limits = exp(c(6, 10)))
 ```
 
-```{r news-cor, eval=FALSE, echo=FALSE}
+```{r}
+#| label: news-cor
+#| eval: false
+#| echo: false
+
 cp <- cor(X, method = "spearman")
 ord <- rev(hclust(as.dist(1 - abs(cp)))$order)
 colPal <- colorRampPalette(c("blue", "yellow"), space = "rgb")(100)
-lattice::levelplot(cp[ord, ord], xlab = "",
-          ylab = "",
-          col.regions = colPal,
-          at = seq(-1, 1, length.out = 100),
-          colorkey = list(space = "top", labels = list(cex = 1.5)), 
-          scales = list(x = list(rot = 45), y = list(draw = FALSE), cex = 0.5) 
+lattice::levelplot(
+  cp[ord, ord],
+  xlab = "",
+  ylab = "",
+  col.regions = colPal,
+  at = seq(-1, 1, length.out = 100),
+  colorkey = list(space = "top", labels = list(cex = 1.5)),
+  scales = list(x = list(rot = 45), y = list(draw = FALSE), cex = 0.5)
 )
-
 ```
 
-```{r news-cor-order, eval=FALSE, echo=FALSE}
-cor_long <- as_tibble(cp) |> 
-  dplyr::mutate(var1 = row.names(cp)) |> 
-  tidyr::pivot_longer(- var1, names_to = "var2") 
+```{r}
+#| label: news-cor-order
+#| eval: false
+#| echo: false
+
+cor_long <- as_tibble(cp) |>
+  dplyr::mutate(var1 = row.names(cp)) |>
+  tidyr::pivot_longer(-var1, names_to = "var2")
 View(cor_long)
 svd(X)$d
 ```
 
-```{r news-cor-scatter, eval=FALSE, echo=FALSE}
-cor.print <- function(x, y) { panel.text(mean(range(x)), mean(range(y)),
-round(cor(x, y, method = "spearman"), digits = 2))
+```{r}
+#| label: news-cor-scatter
+#| eval: false
+#| echo: false
+
+cor.print <- function(x, y) {
+  panel.text(
+    mean(range(x)),
+    mean(range(y)),
+    round(cor(x, y, method = "spearman"), digits = 2)
+  )
 }
 
-contVar <- c("kw_max_min", "kw_avg_min",  "kw_min_min", "kw_max_max", "kw_avg_max", 
-             "kw_min_avg", "kw_max_avg", "kw_avg_avg") 
+contVar <- c(
+  "kw_max_min",
+  "kw_avg_min",
+  "kw_min_min",
+  "kw_max_max",
+  "kw_avg_max",
+  "kw_min_avg",
+  "kw_max_avg",
+  "kw_avg_avg"
+)
 
-contVar <- c("kw_max_min", "kw_max_avg",  "kw_max_max", "kw_avg_min", "kw_avg_avg", "kw_avg_max", 
-             "kw_min_min", "kw_min_avg") 
+contVar <- c(
+  "kw_max_min",
+  "kw_max_avg",
+  "kw_max_max",
+  "kw_avg_min",
+  "kw_avg_avg",
+  "kw_avg_max",
+  "kw_min_min",
+  "kw_min_avg"
+)
 
-splom(log(X[, contVar] + 2), xlab = "",
-upper.panel = hexbin::panel.hexbinplot,
-pscales = 0, xbins = 20,
-lower.panel = cor.print)
+splom(
+  log(X[, contVar] + 2),
+  xlab = "",
+  upper.panel = hexbin::panel.hexbinplot,
+  pscales = 0,
+  xbins = 20,
+  lower.panel = cor.print
+)
 ```
 
-Optimization of the squared error loss using this dataset will be used
-to illustrate a number of stochastic gradient algorithms even though we
-can compute the optimizer easily by other means. The real practical
-benefit of stochastic gradient algorithms comes when applied to large
-scale problems that are difficult to treat as textbook examples. But
-using a toy problem makes it easier to investigate the behaviors of the 
-different algorithms.
+Optimization of the squared error loss using this dataset will be used to
+illustrate a number of stochastic gradient algorithms even though we can compute
+the optimizer easily by other means. The real practical benefit of stochastic
+gradient algorithms comes when applied to large scale problems that are
+difficult to treat as textbook examples. But using a toy problem makes it easier
+to investigate the behaviors of the different algorithms.
 
-We will standardize all the columns of $X$ to have the same norm.
-Specifically to have non-central second moment 1. This does not change
-the optimization problem but corresponds to a reparametrization where
-all parameters are rescaled. The rescaling brings the parameters on a
-comparable scale, which is typically a good idea for optimization
-algorithms based on gradients only, see also Exercise
-\@ref(exr:news-cond-number). After rescaling we initialize the linear
-model with a call to `ls_model()` and refit the model using the new
+We will standardize all the columns of $X$ to have the same norm. Specifically
+to have non-central second moment 1. This does not change the optimization
+problem but corresponds to a reparametrization where all parameters are
+rescaled. The rescaling brings the parameters on a comparable scale, which is
+typically a good idea for optimization algorithms based on gradients only, see
+also Exercise \@ref(exr:news-cond-number). After rescaling we initialize the
+linear model with a call to `ls_model()` and refit the model using the new
 parametrization.
 
-```{r LS-model, dependson=c("ls-model", "news-X-y")}
+```{r, dependson=c("ls-model", "news-X-y")}
+#| label: LS-model
+
 # Standardization and log-transforming the target variable
 X <- scale(X, center = FALSE)
 ls_news <- ls_model(X, log(CSwR::news$shares))
 lm_news <- lm.fit(ls_news$X, ls_news$y)
 ```
 
-We first run the stochastic gradient algorithm with a fixed learning
-rate of $\gamma = 10^{-5}$ for 50 epochs with a tracer that computes and
-stores the value of the objective function at each epoch.
+We first run the stochastic gradient algorithm with a fixed learning rate of
+$\gamma = 10^{-5}$ for 50 epochs with a tracer that computes and stores the
+value of the objective function at each epoch.
 
-```{r sg-tracer, results="hide", dependson="LS-model"}
+```{r, dependson="LS-model"}
+#| label: sg-tracer
+#| results: "hide"
+
 expr <- quote(value <- ls_news$H(par))
 sg_tracer <- CSwR::tracer("value", expr = expr)
 stoch_grad(
-  par = ls_news$par0, 
-  grad = ls_news$grad, 
-  N = ls_news$N, 
-  gamma = 1e-5, 
-  maxit = 50, 
+  par = ls_news$par0,
+  grad = ls_news$grad,
+  N = ls_news$N,
+  gamma = 1e-5,
+  maxit = 50,
   cb = sg_tracer$tracer
 )
 ```
 
-Using the trace from the last epochs, we can compare the objective
-function values to the minimum found using `lm.fit()` above. The minimum
-was not reached completely after the 50 epochs that also took some time to
-compute.
+Using the trace from the last epochs, we can compare the objective function
+values to the minimum found using `lm.fit()` above. The minimum was not reached
+completely after the 50 epochs that also took some time to compute.
 
-```{r sg-tracer-sum, dependson="sg-tracer"}
+```{r, dependson="sg-tracer"}
+#| label: sg-tracer-sum
+
 sg_trace_low <- summary(sg_tracer)
 tail(sg_trace_low)
 ls_news$H(lm_news$coefficients)
 ```
 
-We will use profiling to investigate what most of the time was spent on
-in the stochastic gradient algorithm.
+We will use profiling to investigate what most of the time was spent on in the
+stochastic gradient algorithm.
 
-```{r sg-profiling, echo = 3, dependson="LS-model"}
+```{r, echo=3, dependson="LS-model"}
+#| label: sg-profiling
+
 source("scripts/SG_profile.R", keep.source = TRUE)
 ls_news <- ls_model(ls_news$X, ls_news$y)
 p <- profvis::profvis(
   stoch_grad(
-    par = ls_news$par0, 
-    grad = ls_news$grad, 
-    N = ls_news$N, 
-    gamma = 1e-5, 
-    maxit = 50, 
+    par = ls_news$par0,
+    grad = ls_news$grad,
+    N = ls_news$N,
+    gamma = 1e-5,
+    maxit = 50,
   )
 )
 setwd("./figures/") # Hack to make saveWidget() clean up
@@ -982,223 +1195,279 @@ htmlwidgets::saveWidget(p, "sg_profile.html")
 setwd("..")
 ```
 
-```{r sg-profivis-image, out.width="100%", echo=FALSE, dependson="sg-profiling"}
+```{r, dependson="sg-profiling"}
+#| label: sg-profivis-image
+#| out-width: "100%"
+#| echo: false
+
 pagedown::chrome_print(
-  "./figures/sg_profile.html", 
+  "./figures/sg_profile.html",
   format = "png",
   wait = 10,
-  options = list(clip = list(x = 0L, y=0L, width = 725L, height = 520L, scale = 4)),
+  options = list(
+    clip = list(x = 0L, y = 0L, width = 725L, height = 520L, scale = 4)
+  ),
   extra_args = c("--window-size=700,1150")
 )
 knitr::include_graphics("figures/sg_profile.png")
 ```
 
-The [profiling result](figures/sg_profile.html) shows, unsurprisingly,
-that the computation of the gradient and the update of the parameter
-vector takes up most of the runtime. But if we look closer at the
-implementation of the gradient, we see that the innocuously looking
-subsetting `X[i, , drop = FALSE]` to the $i$-th row in line 25 is 
-actually responsible for a large
-fraction of the runtime. We also see a substantial allocation and
-deallocation of memory associated with this line. It is a bottleneck of
-the R implementation that slicing out rows from a bigger matrix cannot
-be done without creating a copy of those rows, and this is why this
-particular line takes up so much time.
+The [profiling result](figures/sg_profile.html) shows, unsurprisingly, that the
+computation of the gradient and the update of the parameter vector takes up most
+of the runtime. But if we look closer at the implementation of the gradient, we
+see that the innocuously looking subsetting `X[i, , drop = FALSE]` to the $i$-th
+row in line 25 is actually responsible for a large fraction of the runtime. We
+also see a substantial allocation and deallocation of memory associated with
+this line. It is a bottleneck of the R implementation that slicing out rows from
+a bigger matrix cannot be done without creating a copy of those rows, and this
+is why this particular line takes up so much time.
 
-A possible objection to the implementation by slicing out rows is that 
-R stores matrices in [column-major order](https://en.wikipedia.org/wiki/Row-_and_column-major_order), so 
-slicing out rows is not as efficient as slicing out columns. This is true, 
-and we could rewrite the gradient computation in `ls_model()` to 
-use a transposed model matrix. Exercise \@ref(exr:grad-transpose) 
-explores the runtime benefits of this approach. For the basic stochastic
-gradient algorithm above, the benefits are minor, but for the mini-batch 
-algorithms in Section \@ref(beyond) the transposition can lead to 
-some reduction of runtime. Slicing in R will, however, always result in a copy 
-of data, irrespectively of whether we slice out rows or columns.
+A possible objection to the implementation by slicing out rows is that R stores
+matrices in [column-major
+order](https://en.wikipedia.org/wiki/Row-_and_column-major_order), so slicing
+out rows is not as efficient as slicing out columns. This is true, and we could
+rewrite the gradient computation in `ls_model()` to use a transposed model
+matrix. Exercise \@ref(exr:grad-transpose) explores the runtime benefits of this
+approach. For the basic stochastic gradient algorithm above, the benefits are
+minor, but for the mini-batch algorithms in Section \@ref(beyond) the
+transposition can lead to some reduction of runtime. Slicing in R will, however,
+always result in a copy of data, irrespectively of whether we slice out rows or
+columns.
 
 To further investigate the convergence of the basic stochastic gradient
-algorithm we run it with a larger learning rate of
-$\gamma = 5 \times 10^{-5}$ and then with a power law decay schedule,
-which interpolates from an initial learning rate of $10^{-3}$ to a
-learning rate of $10^{-5}$ after 50 epochs.
+algorithm we run it with a larger learning rate of $\gamma = 5 \times 10^{-5}$
+and then with a power law decay schedule, which interpolates from an initial
+learning rate of $10^{-3}$ to a learning rate of $10^{-5}$ after 50 epochs.
 
-```{r sg-tracer-2, results="hide", dependson=c("sg-tracer", "LS-model")}
+```{r, dependson=c("sg-tracer", "LS-model")}
+#| label: sg-tracer-2
+#| results: "hide"
+
 sg_tracer$clear()
+
 stoch_grad(
-  par = ls_news$par0, 
-  grad = ls_news$grad, 
-  N = ls_news$N, 
-  gamma = 5e-5, 
-  maxit= 50, 
+  par = ls_news$par0,
+  grad = ls_news$grad,
+  N = ls_news$N,
+  gamma = 5e-5,
+  maxit = 50,
   cb = sg_tracer$tracer
 )
+
 sg_trace_high <- summary(sg_tracer)
 sg_tracer$clear()
+
 stoch_grad(
-  par = ls_news$par0, 
-  grad = ls_news$grad, 
+  par = ls_news$par0,
+  grad = ls_news$grad,
   N = ls_news$N,
-  gamma = decay_scheduler(gamma0 = 7e-5, gamma1 = 4e-5, a = 0.5, n1 = 50), 
-  maxit= 50, 
+  gamma = decay_scheduler(gamma0 = 7e-5, gamma1 = 4e-5, a = 0.5, n1 = 50),
+  maxit = 50,
   cb = sg_tracer$tracer
 )
+
 sg_trace_decay <- summary(sg_tracer)
 ```
 
-We will compare the convergence of the three stochastic gradient
-algorithms with the convergence of gradient descent with backtracking.
-For gradient descent we choose $\gamma = 8 \times 10^{-2}$, which
-results in only a few initial backtracking steps and then all subsequent
-steps will use the step length $\gamma = 8 \times 10^{-2}$. Choosing a
-larger $\gamma$ for this particular optimization resulted in
-backtracking until a step length around $8 \times 10^{-2}$ was reached,
-thus this choice of $\gamma$ will use a minimal amount of time on the
-backtracking step of the algorithm.
+We will compare the convergence of the three stochastic gradient algorithms with
+the convergence of gradient descent with backtracking. For gradient descent we
+choose $\gamma = 8 \times 10^{-2}$, which results in only a few initial
+backtracking steps and then all subsequent steps will use the step length
+$\gamma = 8 \times 10^{-2}$. Choosing a larger $\gamma$ for this particular
+optimization resulted in backtracking until a step length around
+$8 \times 10^{-2}$ was reached, thus this choice of $\gamma$ will use a minimal
+amount of time on the backtracking step of the algorithm.
 
-```{r news-gd, warning=FALSE, results='hide', dependson="LS-model"}
+```{r, dependson="LS-model"}
+#| label: news-gd
+#| warning: false
+#| results: "hide"
+
 gd_tracer <- CSwR::tracer("value", Delta = 10)
+
 grad_desc(
-  par = ls_news$par0, 
-  H = ls_news$H, 
-  gr = ls_news$grad, 
-  gamma = 8e-2, 
-  maxit = 800, 
+  par = ls_news$par0,
+  H = ls_news$H,
+  gr = ls_news$grad,
+  gamma = 8e-2,
+  maxit = 800,
   cb = gd_tracer$tracer
 )
+
 gd_trace <- summary(gd_tracer)
 ```
 
-Figure \@ref(fig:news-trace-plot) shows how the four algorithms
-converge. The gradient descent algorithm converges faster than the
-stochastic gradient algorithm with the low learning rate
-$\gamma = 10^{-5}$, but with the high learning rate
-$\gamma = 5 \times 10^{-5}$ and the power law decay schedule the
-stochastic gradient algorithm converges about as fast as gradient
-descent. For this particular run, the power law decay schedule shows
-marginally faster convergence than the fixed high learning rate, and
-this was ensured after some tuning of the decay schedule parameters.
-Despite theoretical guarantees of convergence with the power law decay schedule,
-the practical choice of a suitable learning rate or decay schedule is
-really an empirical art. With very large data, the tuning of learning
-rate parameters can be done on a small subset of data before the
-algorithms are run using the full dataset.
+Figure \@ref(fig:news-trace-plot) shows how the four algorithms converge. The
+gradient descent algorithm converges faster than the stochastic gradient
+algorithm with the low learning rate $\gamma = 10^{-5}$, but with the high
+learning rate $\gamma = 5 \times 10^{-5}$ and the power law decay schedule the
+stochastic gradient algorithm converges about as fast as gradient descent. For
+this particular run, the power law decay schedule shows marginally faster
+convergence than the fixed high learning rate, and this was ensured after some
+tuning of the decay schedule parameters. Despite theoretical guarantees of
+convergence with the power law decay schedule, the practical choice of a
+suitable learning rate or decay schedule is really an empirical art. With very
+large data, the tuning of learning rate parameters can be done on a small subset
+of data before the algorithms are run using the full dataset.
 
-```{r news-trace-plot, echo=FALSE, dependson=c("news-gd", "sg-tracer-2", "sg-tracer-sum"), fig.cap="Convergence of squared error loss on the news article dataset for four algorithms: gradient descent (gd) and three basic stochastic gradient algorithms with a low learning rate, a high learning rate and a power law decay schedule.", fig.width=8, fig.height=4, out.width="100%"}
+```{r, dependson=c("news-gd", "sg-tracer-2", "sg-tracer-sum")}
+#| label: news-trace-plot
+#| echo: false
+#| fig-cap: >-
+#|   Convergence of squared error loss on the news article dataset for four
+#|   algorithms: gradient descent (gd) and three basic stochastic gradient
+#|   algorithms with a low learning rate, a high learning rate and a power law
+#|   decay schedule.
+#| fig-width: 8
+#| fig-height: 4
+#| out-width: "100%"
+
 dplyr::bind_rows(
-  low = sg_trace_low, 
-  high = sg_trace_high, 
+  low = sg_trace_low,
+  high = sg_trace_high,
   decay = sg_trace_decay,
-  gd = gd_trace[seq(1, 800, 20), ], 
+  gd = gd_trace[seq(1, 800, 20), ],
   .id = "Algorithm"
-) |> 
-  dplyr::filter(.time < 5) |> 
-autoplot(y = value - ls_news$H(lm_news$coefficients )) + 
+) |>
+  dplyr::filter(.time < 5) |>
+  autoplot(y = value - ls_news$H(lm_news$coefficients)) +
   ylab(expression(H(theta[n]) - H(theta[infinity]))) +
-  aes(color = Algorithm, shape = Algorithm) + 
+  aes(color = Algorithm, shape = Algorithm) +
   geom_line() +
-  scale_color_brewer(limits = c("low", "high", "decay", "gd", "mini", "moment", "adam", "adam_decay"), 
-                     breaks = c("low", "high", "decay", "gd"),
-                     type = "qual", palette = 2) +
-  scale_shape_manual(limits = c("low", "high", "decay", "gd", "mini", "moment", "adam", "adam_decay"), 
-                     breaks = c("low", "high", "decay", "gd"),
-                     values = c(0, 1, 2, 5, 15, 16, 17, 19))
+  scale_color_brewer(
+    limits = c(
+      "low",
+      "high",
+      "decay",
+      "gd",
+      "mini",
+      "moment",
+      "adam",
+      "adam_decay"
+    ),
+    breaks = c("low", "high", "decay", "gd"),
+    type = "qual",
+    palette = 2
+  ) +
+  scale_shape_manual(
+    limits = c(
+      "low",
+      "high",
+      "decay",
+      "gd",
+      "mini",
+      "moment",
+      "adam",
+      "adam_decay"
+    ),
+    breaks = c("low", "high", "decay", "gd"),
+    values = c(0, 1, 2, 5, 15, 16, 17, 19)
+  )
 ```
 
 For comparison purposes it is typically better to monitor convergence of
-optimization algorithms as a function of real time than iterations, but
-when comparing algorithms in terms of real time we are admittedly
-comparing their specific implementations. The R implementation of the
-stochastic gradient algorithm has some shortcomings that are not shared
-by the gradient descent algorithm. One epoch of the stochastic gradient
-algorithm should be about as computationally demanding as one iteration
-of gradient descent as both will compute the gradient in each data point
-exactly once and add them up. The vectorized batch gradient computation
-is fairly efficient in R, but the iterative looping over data in the
-stochastic gradient algorithm is not, and this inefficiency is
-compounded by the inefficiency of matrix slicing that results in data
-copying as the profiling revealed. Thus the comparisons in Figure
-\@ref(fig:news-trace-plot) are arguably not entirely fair to the
+optimization algorithms as a function of real time than iterations, but when
+comparing algorithms in terms of real time we are admittedly comparing their
+specific implementations. The R implementation of the stochastic gradient
+algorithm has some shortcomings that are not shared by the gradient descent
+algorithm. One epoch of the stochastic gradient algorithm should be about as
+computationally demanding as one iteration of gradient descent as both will
+compute the gradient in each data point exactly once and add them up. The
+vectorized batch gradient computation is fairly efficient in R, but the
+iterative looping over data in the stochastic gradient algorithm is not, and
+this inefficiency is compounded by the inefficiency of matrix slicing that
+results in data copying as the profiling revealed. Thus the comparisons in
+Figure \@ref(fig:news-trace-plot) are arguably not entirely fair to the
 stochastic gradient algorithm---only the specific R implementation.
 
-In the subsequent section we will see alternatives to the basic
-stochastic gradient algorithm, which will diminish the shortcomings of a
-pure R implementation somewhat. Another way to potentially circumvent some 
-shortcomings of the R implementation is to rewrite the algorithm using
-Rcpp. We will pursue Rcpp implementations in Section \@ref(sg-Rcpp), but
-we will first consider some beneficial modifications of the basic
-algorithm.
+In the subsequent section we will see alternatives to the basic stochastic
+gradient algorithm, which will diminish the shortcomings of a pure R
+implementation somewhat. Another way to potentially circumvent some shortcomings
+of the R implementation is to rewrite the algorithm using Rcpp. We will pursue
+Rcpp implementations in Section \@ref(sg-Rcpp), but we will first consider some
+beneficial modifications of the basic algorithm.
 
 ## Beyond basic stochastic gradient algorithms {#beyond}
 
-The gradient $\nabla_{\theta} L(y_i, x_i, \theta)$ for a single random data
-point is quickly computed, and though unbiased as an estimate of
-$\nabla_{\theta} H_N(\theta)$ it has a large variance. This affects the
-basic stochastic gradient algorithm negatively as the directions of each
-update can oscillate quite wildly from iteration to iteration. This
-section covers some techniques that yield a better trade-off between
-runtime and variability.
+The single-point gradient $\nabla_{\theta} L(y_i, x_i, \theta)$ is cheap to
+compute and unbiased as an estimate of $\nabla_{\theta} H_N(\theta)$, but it has
+a large variance. The resulting oscillation in update directions slows progress
+in iterations and eats into the per-iteration cost savings that motivated
+stochastic gradient in the first place. This section covers techniques that buy
+back some of those savings by trading per-iteration cost for variance reduction.
 
-The most obvious technique is to use more than one observation per
-computation of the gradient, which gives us *mini-batch* stochastic
-gradient algorithms. A second technique is to incorporate some memory
-about previous directions into the movements of the algorithms---in
-the same spirit as how the conjugate gradient algorithm uses the
-previous gradient to modify the descent direction.
+The most obvious technique is to use more than one observation per computation
+of the gradient, which gives us *mini-batch* stochastic gradient algorithms. A
+second technique is to incorporate some memory about previous directions into
+the movements of the algorithms, in the same spirit as how the conjugate
+gradient algorithm uses the previous gradient to modify the descent direction.
 
-The literature on deep learning has recently exploded with variations on
-the stochastic gradient algorithm. Performance is mostly studied
-empirically and applied in practice to the highly non-convex
-optimization problem of learning a neural network. A comprehensive
-coverage of all the different ideas will not be attempted, and only
-three of the most solidified variations will be treated. The use of
-mini-batches is ubiquitous, and momentum is a simple 
-illustration of an algorithm with memory. Finally, the Adam algorithm uses
-memory in combination with adaptive learning rates to achieve both speed
-and robustness.
+The literature on deep learning has recently exploded with variations on the
+stochastic gradient algorithm. Performance is mostly studied empirically and
+applied in practice to the highly non-convex optimization problem of learning a
+neural network. A comprehensive coverage of all the different ideas will not be
+attempted, and only three of the most solidified variations will be treated. The
+use of mini-batches is ubiquitous, and momentum is a simple illustration of an
+algorithm with memory. Finally, the Adam algorithm uses memory in combination
+with adaptive learning rates to achieve both speed and robustness.
 
 ### Mini-batches
 
-The three steps of the mini-batch stochastic gradient algorithm with
-mini-batch size $m$ are: given $\theta_{n}$
+The mini-batch stochastic gradient algorithm replaces the single-point gradient
+with an average over a subset $I \subseteq \{1, \ldots, N\}$ of $m$ indices.
 
--   sample $m$ indices, $I_n = \{i_1, \ldots, i_m\}$, from
-    $\{1, \ldots, N\}$
--   compute
-    $\rho_n = \frac{1}{m} \sum_{i\in I_n} \nabla_{\theta} L(y_i, x_i, \theta_{n})$
--   update the parameter $\theta_{n+1} = \theta_{n} - \gamma_n \rho_n.$
+```{algorithm, sg-mini-batch-alg}
+\begin{algorithm}
+  \caption{Mini-batch stochastic gradient descent}
+  \begin{algorithmic}
+    \Require learning rate $\gamma_n > 0$, mini-batch size $m$
+    \Repeat
+        \State sample $I \subseteq \{1, \ldots, N\}$ with $|I| = m$
+        \State $\theta \gets \theta - \dfrac{\gamma_n}{m} \sum_{i \in I} \nabla_{\theta} L(y_i, x_i, \theta)$
+    \Until{convergence}
+    \Return $\theta$
+  \end{algorithmic}
+\end{algorithm}
+```
 
 Of course, the mini-batch algorithm with $m = 1$ is the basic stochastic
-gradient algorithm. As for the basic algorithm, we implement the
-variation where we sample a *partition*
+gradient algorithm. As for the basic algorithm, we implement the variation where
+we sample a *partition*
 
 \[
   I_1 \cup \ldots \cup I_M \subseteq \{1, \ldots, N\}
 \]
 
-for $M = \lfloor N / m \rfloor$ and in one epoch loop through the
-mini-batches $I_1, \ldots, I_M$.
+for $M = \lfloor N / m \rfloor$ and in one epoch loop through the mini-batches
+$I_1, \ldots, I_M$.
 
-In the following sections we will develop a couple of modifications to
-the basic stochastic gradient algorithm, and we will therefore implement
-a more generic version of the algorithm. What is common to all the
-modifications is that they differ in the details of the epoch loop, thus
-we take out that loop as a separate function.
+In the following sections we will develop a couple of modifications to the basic
+stochastic gradient algorithm, and we will therefore implement a more generic
+version of the algorithm. What is common to all the modifications is that they
+differ in the details of the epoch loop, thus we take out that loop as a
+separate function.
 
-```{r sg-mini-batch}
+```{r}
+#| label: sg-mini-batch
+
 stoch_grad <- function(
-  par, 
-  N,                 # Sample size
-  gamma,             # Decay schedule or a fixed learning rate
-  epoch = batch,     # Epoch update function
-  ...,               # Other arguments passed to epoch updates
-  maxit = 100,       # Max epoch iterations
-  sampler = sample,  # Data resampler. Default is random permutation
+  par,
+  N, # Sample size
+  gamma, # Decay schedule or a fixed learning rate
+  epoch = batch, # Epoch update function
+  ..., # Other arguments passed to epoch updates
+  maxit = 100, # Max epoch iterations
+  sampler = sample, # Data resampler. Default is random permutation
   cb = NULL
 ) {
-  if (is.function(gamma)) gamma <- gamma(1:maxit) 
-  gamma <- rep_len(gamma, maxit) 
-  for(n in 1:maxit) {
-    if(!is.null(cb)) cb()
+  if (is.function(gamma)) {
+    gamma <- gamma(1:maxit)
+  }
+  gamma <- rep_len(gamma, maxit)
+  for (n in 1:maxit) {
+    if (!is.null(cb)) {
+      cb()
+    }
     samp <- sampler(N)
     par <- epoch(par, samp, gamma[n], ...)
   }
@@ -1207,184 +1476,627 @@ stoch_grad <- function(
 ```
 
 The implementation uses `batch()` as the default epoch update function, and we
-implement this function below. It uses the random permutation to
-generate the $M$ mini-batches, and it contains a loop through the
-mini-batches containing a call of `grad()` for the computation of the
-average gradient for each mini-batch in the loop. Note that the `grad`
-argument to `batch()` will be captured by and passed on from a call of
-`stoch_grad()` via the `...` argument.
+implement this function below. It uses the random permutation to generate the
+$M$ mini-batches, and it contains a loop through the mini-batches containing a
+call of `grad()` for the computation of the average gradient for each mini-batch
+in the loop. Note that the `grad` argument to `batch()` will be captured by and
+passed on from a call of `stoch_grad()` via the `...` argument.
 
-```{r batch}
+```{r}
+#| label: batch
+
 batch <- function(
-    par, 
-    samp,
-    gamma,  
-    grad,              # Function of parameter and observation index
-    m = 50,            # Mini-batch size
-    ...
-  ) {
-    M <- floor(length(samp) / m)
-    for(j in 0:(M - 1)) {
-      i <- samp[(j * m + 1):(j * m + m)]
-      par <- par - gamma * grad(par, i, ...)
-    }
-    par
+  par,
+  samp,
+  gamma,
+  grad, # Function of parameter and observation index
+  m = 50, # Mini-batch size
+  ...
+) {
+  M <- floor(length(samp) / m)
+  for (j in 0:(M - 1)) {
+    i <- samp[(j * m + 1):(j * m + m)]
+    par <- par - gamma * grad(par, i, ...)
+  }
+  par
 }
 ```
 
 The `grad()` function implemented in `ls_model()` in Section \@ref(news)
-anticipated that we need to compute gradients for mini-batches, and it
-can thus be used directly with the `batch()` function. 
+anticipated that we need to compute gradients for mini-batches, and it can thus
+be used directly with the `batch()` function.
 
-With increased flexibility of the algorithms comes more tuning
-parameters, and making a good choice of all of them becomes increasingly
-difficult. When introducing mini-batches we need to choose the
-mini-batch size in addition to the learning rate, and a good choice of
-learning rate or decay schedule will depend on the size of the
-mini-batch. To simplify matters, a mini-batch size of 1000 and a fixed
-learning rate are used in the subsequent applications. The learning rate
-will generally be chosen as large as possible without making the
-algorithms diverge, and with a mini-batch size of 1000 it is possible to
-run the algorithm with a learning rate of $\gamma = 0.05$.
+With increased flexibility of the algorithms comes more tuning parameters, and
+making a good choice of all of them becomes increasingly difficult. When
+introducing mini-batches we need to choose the mini-batch size in addition to
+the learning rate, and a good choice of learning rate or decay schedule will
+depend on the size of the mini-batch. To simplify matters, a mini-batch size of
+1000 and a fixed learning rate are used in the subsequent applications. The
+learning rate will generally be chosen as large as possible without making the
+algorithms diverge, and with a mini-batch size of 1000 it is possible to run the
+algorithm with a learning rate of $\gamma = 0.05$.
 
-```{r sg-mini-batch-run, echo = -c(1, 4), results='hide', dependson=c("sg-tracer", "batch", "sg-mini-batch", "ls-grad-update")}
+```{r, echo=-c(1, 4), dependson=c("sg-tracer", "batch", "sg-mini-batch", "ls-grad-update")}
+#| label: sg-mini-batch-run
+#| results: "hide"
+
 set.seed(20241110)
 sg_tracer$clear()
 stoch_grad(
-  par = ls_news$par0, 
-  N = ls_news$N, 
-  gamma = 5e-2, 
-  grad = ls_news$grad, 
-  m = 1000, 
-  maxit = 200, 
+  par = ls_news$par0,
+  N = ls_news$N,
+  gamma = 5e-2,
+  grad = ls_news$grad,
+  m = 1000,
+  maxit = 200,
   cb = sg_tracer$tracer
 )
 sg_trace_mini <- summary(sg_tracer)
 ```
 
-```{r news-trace-plot-2, echo=FALSE, dependson=c("sg-mini-batch-run", "news-gd", "sg-tracer-2"), fig.width=8, fig.height=4, out.width="100%", fig.cap="Convergence of squared error loss on the news article dataset for three algorithms: basic stochastic gradient with a power law decay schedule (decay), gradient descent (gd), and mini-batch stochastic gradient with a batch size of 1000 and a fixed learning rate (mini)."}
+```{r, dependson=c("sg-mini-batch-run", "news-gd", "sg-tracer-2")}
+#| label: news-trace-plot-2
+#| echo: false
+#| fig-width: 8
+#| fig-height: 4
+#| out-width: "100%"
+#| fig-cap: >-
+#|   Convergence of squared error loss on the news article dataset for three
+#|   algorithms: basic stochastic gradient with a power law decay schedule
+#|   (decay), gradient descent (gd), and mini-batch stochastic gradient with a
+#|   batch size of 1000 and a fixed learning rate (mini).
+
 dplyr::bind_rows(
-  mini = sg_trace_mini[seq(1, 200, 3), ], 
+  mini = sg_trace_mini[seq(1, 200, 3), ],
   decay = sg_trace_decay,
-  gd = gd_trace[seq(1, 800, 10), ], 
+  gd = gd_trace[seq(1, 800, 10), ],
   .id = "Algorithm"
-) |> 
-  dplyr::filter(.time < 2) |> 
-autoplot(y = value - ls_news$H(lm_news$coefficients )) + 
+) |>
+  dplyr::filter(.time < 2) |>
+  autoplot(y = value - ls_news$H(lm_news$coefficients)) +
   ylab(expression(H(theta[n]) - H(theta[infinity]))) +
-  aes(color = Algorithm, shape = Algorithm) + 
+  aes(color = Algorithm, shape = Algorithm) +
   geom_line() +
-  scale_color_brewer(limits = c("low", "high", "decay", "gd", "mini", "moment", "adam", "adam_decay"), 
-                     breaks = c("decay", "gd", "mini"), type = "qual", palette = 2) +
-  scale_shape_manual(limits = c("low", "high", "decay", "gd", "mini", "moment", "adam", "adam_decay"), 
-                     breaks = c("decay", "gd", "mini"),
-                     values = c(0, 1, 2, 5, 15, 16, 17, 19))
+  scale_color_brewer(
+    limits = c(
+      "low",
+      "high",
+      "decay",
+      "gd",
+      "mini",
+      "moment",
+      "adam",
+      "adam_decay"
+    ),
+    breaks = c("decay", "gd", "mini"),
+    type = "qual",
+    palette = 2
+  ) +
+  scale_shape_manual(
+    limits = c(
+      "low",
+      "high",
+      "decay",
+      "gd",
+      "mini",
+      "moment",
+      "adam",
+      "adam_decay"
+    ),
+    breaks = c("decay", "gd", "mini"),
+    values = c(0, 1, 2, 5, 15, 16, 17, 19)
+  )
 ```
 
-Figure \@ref(fig:news-trace-plot-2) shows that this implementation of
-the mini-batch stochastic gradient algorithm converges faster than the
-basic stochastic gradient algorithm with a power law decay schedule as
-well as the gradient descent algorithm. Eventually, it begins to
-fluctuate due to the fixed learning rate, but it quickly gets close to
-the minimum. We should not jump to conclusions from this assessment. It
-only really shows the improvement to the specific R implementation of
-using a mini-batch algorithm, and this implementation clearly benefits
-from the more vectorized computations with mini-batches of size 1000. We
-will return to this discussion in Section \@ref(Rcpp-grad-epoch).
+Figure \@ref(fig:news-trace-plot-2) shows that this implementation of the
+mini-batch stochastic gradient algorithm converges faster than the basic
+stochastic gradient algorithm with a power law decay schedule as well as the
+gradient descent algorithm. Eventually, it begins to fluctuate due to the fixed
+learning rate, but it quickly gets close to the minimum. We should not jump to
+conclusions from this assessment. It only really shows the improvement to the
+specific R implementation of using a mini-batch algorithm, and this
+implementation clearly benefits from the more vectorized computations with
+mini-batches of size 1000. We will return to this discussion in Section
+\@ref(Rcpp-grad-epoch).
 
 ### Momentum
 
-Mini-batches stabilize the gradients, and so does momentum. Both
-techniques can be used in combination, and the momentum update of a
-mini-batch stochastic gradient algorithm is as follows: Given
-$\theta_{n}$ and a batch $I_n \subseteq \{1, \ldots, N\}$ with
-$|I_n| = m$
+Mini-batches stabilize the gradients, and so does momentum. Both techniques can
+be used in combination, and the momentum update of a mini-batch stochastic
+gradient algorithm is as follows: Given $\theta_{n}$ and a batch
+$I_n \subseteq \{1, \ldots, N\}$ with $|I_n| = m$
 
--   compute
-    $g_n = \frac{1}{m} \sum_{i\in I_n} \nabla_{\theta} L(y_i, x_i, \theta_{n})$
--   compute $\rho_n = \beta \rho_{n-1} + (1-\beta) g_n$
--   update the parameter $\theta_{n+1} = \theta_{n} - \gamma_n \rho_n.$
+- compute
+  $g_n = \frac{1}{m} \sum_{i\in I_n} \nabla_{\theta} L(y_i, x_i, \theta_{n})$
+- compute $\rho_n = \beta \rho_{n-1} + (1-\beta) g_n$
+- update the parameter $\theta_{n+1} = \theta_{n} - \gamma_n \rho_n.$
 
 The memory of the algorithm is in the second step, where the direction,
-$\rho_{n}$, is updated using a convex combination of the previous
-direction, $\rho_{n-1}$, and the mini-batch gradient, $g_n$. Usually,
-the initial direction is chosen as $\rho_0 = 0$. The parameter
-$\beta \in [0,1)$ is a tuning parameter determining how long the memory
-is. A value like $\beta = 0.9$ or $\beta = 0.95$ is often recommended --
-otherwise the memory in the algorithm will be rather short, and the
-effect of using momentum will be small. A choice of $\beta = 0$
+$\rho_{n}$, is updated using a convex combination of the previous direction,
+$\rho_{n-1}$, and the mini-batch gradient, $g_n$. Usually, the initial direction
+is chosen as $\rho_0 = 0$. The parameter $\beta \in [0,1)$ is a tuning parameter
+determining how long the memory is. A value like $\beta = 0.9$ or $\beta = 0.95$
+is often recommended---otherwise the memory in the algorithm will be rather
+short, and the effect of using momentum will be small. A choice of $\beta = 0$
 corresponds to the mini-batch algorithm without memory.
 
-Contrary to the batch epoch function, the momentum epoch function needs
-to store the previous direction between updates. It is not immediately
-clear how to achieve this between two epochs using the generic `stoch_grad()`
-implementation, but by implementing momentum epochs using a function
-factory, we can easily use an enclosing environment of the epoch
-function for storage.
+Figure\ \@ref(fig:momentum-illustration) gives the geometric picture at
+$\theta_k$: the carryover $\beta(\theta_k - \theta_{k-1})$ (dashed) and the
+scaled gradient step $-\gamma(1-\beta)\nabla H(\theta_k)$ span a parallelogram,
+and the momentum update (orange) is its diagonal. Vanilla gradient descent
+(solid black) would instead take the unscaled step $-\gamma\nabla H(\theta_k)$
+in the same gradient direction, landing further out at GD's next iterate.
 
-```{r momentum}
+```{r}
+#| label: momentum-illustration
+#| echo: false
+#| fig-width: 6
+#| fig-height: 4
+#| warning: false
+#| fig-cap: >-
+#|   One momentum step on $H(\theta) = (\theta_1^2 + 9 \theta_2^2)/2$ with
+#|   $\gamma = 0.2$, $\beta = 0.5$ and $\theta_0 = (-2.5, 0.9)$. The carryover
+#|   $\beta(\theta_k - \theta_{k-1})$ (dashed) and the scaled gradient step
+#|   $-\gamma(1-\beta)\nabla H(\theta_k)$ (the open marker on the GD arrow) span
+#|   a parallelogram whose diagonal is the momentum update (orange). Vanilla
+#|   gradient descent takes the full step $-\gamma\nabla H(\theta_k)$ (solid
+#|   black) and lands at GD's $\theta_{k+1}$. The cross marks the minimum at the
+#|   origin.
+
+H_fun <- function(t1, t2) 0.5 * (t1^2 + 9 * t2^2)
+grad_H_2d <- function(theta) c(theta[1], 9 * theta[2])
+
+gamma_mom <- 0.2
+beta_mom <- 0.5
+theta_km1 <- c(-2.5, 0.9)
+theta_k <- theta_km1 - gamma_mom * grad_H_2d(theta_km1)
+
+g_k <- grad_H_2d(theta_k)
+gd_step <- -gamma_mom * g_k
+carry <- beta_mom * (theta_k - theta_km1)
+scaled_grad <- -gamma_mom * (1 - beta_mom) * g_k
+theta_kp1_gd <- theta_k + gd_step
+r_k <- theta_k + carry
+b_corner <- theta_k + scaled_grad
+theta_kp1_pol <- theta_k + carry + scaled_grad
+
+grid_mom <- expand.grid(
+  theta1 = seq(-3.3, 0.5, length.out = 120),
+  theta2 = seq(-1.8, 1.2, length.out = 100)
+)
+grid_mom$H <- H_fun(grid_mom$theta1, grid_mom$theta2)
+
+iter_df <- data.frame(
+  theta1 = c(theta_km1[1], theta_k[1]),
+  theta2 = c(theta_km1[2], theta_k[2])
+)
+
+ggplot(grid_mom, aes(theta1, theta2)) +
+  geom_contour(aes(z = H), color = "grey85", bins = 10) +
+  geom_path(data = iter_df) +
+  # Parallelogram closing sides (dotted)
+  geom_segment(
+    aes(
+      x = r_k[1],
+      y = r_k[2],
+      xend = theta_kp1_pol[1],
+      yend = theta_kp1_pol[2]
+    ),
+    linetype = "dotted",
+    color = "grey60"
+  ) +
+  geom_segment(
+    aes(
+      x = b_corner[1],
+      y = b_corner[2],
+      xend = theta_kp1_pol[1],
+      yend = theta_kp1_pol[2]
+    ),
+    linetype = "dotted",
+    color = "grey60"
+  ) +
+  # Momentum carryover (dashed grey, with arrowhead)
+  geom_segment(
+    aes(
+      x = theta_k[1],
+      y = theta_k[2],
+      xend = r_k[1],
+      yend = r_k[2]
+    ),
+    linetype = "dashed",
+    color = "grey40",
+    arrow = arrow(length = unit(0.12, "cm"), type = "closed")
+  ) +
+  # Momentum diagonal (solid orange)
+  geom_segment(
+    aes(
+      x = theta_k[1],
+      y = theta_k[2],
+      xend = theta_kp1_pol[1],
+      yend = theta_kp1_pol[2]
+    ),
+    color = "darkorange",
+    arrow = arrow(length = unit(0.15, "cm"), type = "closed")
+  ) +
+  annotate(
+    "point",
+    x = theta_kp1_pol[1],
+    y = theta_kp1_pol[2],
+    size = 1.5,
+    color = "darkorange"
+  ) +
+  geom_point(data = iter_df, size = 1.5) +
+  # Vanilla GD step (full length, solid black)
+  geom_segment(
+    aes(
+      x = theta_k[1],
+      y = theta_k[2],
+      xend = theta_kp1_gd[1],
+      yend = theta_kp1_gd[2]
+    ),
+    arrow = arrow(length = unit(0.15, "cm"), type = "closed")
+  ) +
+  annotate(
+    "point",
+    x = theta_kp1_gd[1],
+    y = theta_kp1_gd[2],
+    size = 1.5
+  ) +
+  # Parallelogram corner along the GD arrow (open marker)
+  annotate(
+    "point",
+    x = b_corner[1],
+    y = b_corner[2],
+    shape = 1,
+    size = 2.2,
+    stroke = 0.6,
+    color = "grey40"
+  ) +
+  # Labels
+  annotate(
+    "text",
+    x = theta_km1[1],
+    y = theta_km1[2],
+    label = "theta[k - 1]",
+    parse = TRUE,
+    hjust = 1.2
+  ) +
+  annotate(
+    "text",
+    x = theta_k[1],
+    y = theta_k[2],
+    label = "theta[k]",
+    parse = TRUE,
+    hjust = 1.2,
+    vjust = 1.2
+  ) +
+  annotate(
+    "text",
+    x = theta_kp1_gd[1],
+    y = theta_kp1_gd[2],
+    label = "GD",
+    hjust = -0.3,
+    vjust = -0.2
+  ) +
+  annotate(
+    "text",
+    x = theta_kp1_pol[1],
+    y = theta_kp1_pol[2],
+    label = "Momentum",
+    hjust = -0.2,
+    vjust = 0.5,
+    color = "darkorange"
+  ) +
+  annotate(
+    "text",
+    x = r_k[1],
+    y = r_k[2] - 0.08,
+    label = "theta[k] + beta * (theta[k] - theta[k - 1])",
+    parse = TRUE,
+    hjust = 0.5,
+    vjust = 1,
+    size = 3,
+    color = "grey30"
+  ) +
+  annotate(
+    "text",
+    x = b_corner[1] + 0.1,
+    y = b_corner[2],
+    label = "theta[k] - gamma * (1 - beta) * nabla * H(theta[k])",
+    parse = TRUE,
+    hjust = 0,
+    vjust = 0.5,
+    size = 3,
+    color = "grey30"
+  ) +
+  coord_equal(xlim = c(-3.1, 0.5), ylim = c(-1.8, 1.2), expand = FALSE) +
+  labs(x = expression(theta[1]), y = expression(theta[2]))
+```
+
+The mechanism is easiest to see for full-batch gradient descent on an
+anisotropic quadratic, where the gradient changes direction sharply across the
+steep axis at every step. Figure\ \@ref(fig:gd-momentum-quadratic) runs the
+algorithm on $H(\theta) = (\theta_1^2 + 9 \theta_2^2)/2$ from the same starting
+point with the same fixed step size, for three values of $\beta$. Without
+memory, the iterates oscillate back and forth across the narrow direction.
+Increasing $\beta$ averages out the sign-flipping component and the path
+straightens, at the price of a slower start because $\rho$ has to build up.
+
+```{r}
+#| label: gd-momentum-quadratic
+#| echo: false
+#| fig-width: 6
+#| fig-height: 3.5
+#| fig-cap: >-
+#|   Momentum on $H(\theta) = (\theta_1^2 + 9 \theta_2^2)/2$ from $\theta_0 =
+#|   (-2.5, 0.9)$ with fixed step size $\gamma = 0.2$ and $\beta \in \{0, 0.7,
+#|   0.95\}$, 40 iterations. The cross marks the minimum at the origin. Without
+#|   momentum the iterates zig-zag across the steep direction; momentum smooths
+#|   $\rho$ and dampens the oscillation.
+
+grad_quad <- function(theta) c(theta[1], 9 * theta[2])
+
+mom_quad_path <- function(theta0, gamma, beta_mom, n_steps) {
+  theta <- theta0
+  rho <- c(0, 0)
+  path <- matrix(0, n_steps + 1, 2)
+  path[1, ] <- theta
+
+  for (k in seq_len(n_steps)) {
+    rho <- beta_mom * rho + (1 - beta_mom) * grad_quad(theta)
+    theta <- theta - gamma * rho
+    path[k + 1, ] <- theta
+  }
+  data.frame(theta1 = path[, 1], theta2 = path[, 2])
+}
+
+paths_quad <- dplyr::bind_rows(
+  `0` = mom_quad_path(c(-2.5, 0.9), gamma = 0.2, beta_mom = 0, n_steps = 40),
+  `0.7` = mom_quad_path(
+    c(-2.5, 0.9),
+    gamma = 0.2,
+    beta_mom = 0.7,
+    n_steps = 40
+  ),
+  `0.95` = mom_quad_path(
+    c(-2.5, 0.9),
+    gamma = 0.2,
+    beta_mom = 0.95,
+    n_steps = 40
+  ),
+  .id = "beta"
+)
+
+grid_quad <- expand.grid(
+  theta1 = seq(-3, 1.5, length.out = 120),
+  theta2 = seq(-1.1, 1.1, length.out = 80)
+)
+grid_quad$H <- 0.5 * (grid_quad$theta1^2 + 9 * grid_quad$theta2^2)
+
+ggplot(grid_quad, aes(theta1, theta2)) +
+  geom_contour(aes(z = H), color = "grey85", bins = 10) +
+  geom_path(data = paths_quad, aes(color = beta)) +
+  geom_point(data = paths_quad, aes(color = beta), size = 0.6) +
+  annotate("point", x = 0, y = 0, shape = 4, size = 3, stroke = 1) +
+  coord_equal() +
+  scale_color_brewer(palette = "Set1") +
+  labs(
+    x = expression(theta[1]),
+    y = expression(theta[2]),
+    color = expression(beta)
+  )
+```
+
+Contrary to the batch epoch function, the momentum epoch function needs to store
+the previous direction between updates. It is not immediately clear how to
+achieve this between two epochs using the generic `stoch_grad()` implementation,
+but by implementing momentum epochs using a function factory, we can easily use
+an enclosing environment of the epoch function for storage.
+
+```{r}
+#| label: momentum
+
 momentum <- function() {
   rho <- 0
   function(
-    par, 
+    par,
     samp,
-    gamma,  
+    gamma,
     grad,
-    m = 50,             # Mini-batch size
-    beta = 0.95,        # Momentum memory 
+    m = 50, # Mini-batch size
+    beta = 0.95, # Momentum memory
     ...
   ) {
     M <- floor(length(samp) / m)
-    for(j in 0:(M - 1)) {
+
+    for (j in 0:(M - 1)) {
       i <- samp[(j * m + 1):(j * m + m)]
       # Using '<<-' assigns the value to rho in the enclosing environment
-      rho <<- beta * rho + (1 - beta) * grad(par, i, ...)  
+      rho <<- beta * rho + (1 - beta) * grad(par, i, ...)
       par <- par - gamma * rho
     }
+
     par
   }
 }
 ```
 
 When calling `stoch_grad()` below with `epoch = momentum()`, the evaluation of
-the function factory `momentum()` returns the momentum epoch function
-with is own local environment used to store $\rho$. With momentum, we
-can increase the learning rate to $\gamma = 7 \times 10^{-2}$.
+the function factory `momentum()` returns the momentum epoch function with is
+own local environment used to store $\rho$.
 
-```{r sg-7, results='hide', echo=-c(1, 4), dependson=c("sg-tracer", "momentum", "ls-grad-update")}
+Before turning to the news dataset, Figure\ \@ref(fig:sgd-momentum-traj)
+revisits the small Poisson regression of Example\ \@ref(exm:batch-pois-sg) and
+overlays a single-point momentum run on top of plain stochastic gradient
+descent, both starting from $(0, 0)$ with the same step size and the same
+sequence of sampled indices. The same single-point gradients drive both
+algorithms, but the momentum trajectory aggregates them through $\rho_n$ and the
+path becomes visibly smoother as a result.
+
+```{r, dependson="online-poisson-sg-SE"}
+#| label: sgd-momentum-traj
+#| echo: false
+#| fig-width: 7
+#| fig-height: 4
+#| out-width: "100%"
+#| fig-cap: >-
+#|   Per-step trajectories of stochastic gradient descent without (left) and
+#|   with momentum ($\beta = 0.9$, right) on the Poisson negative log-likelihood
+#|   with $N = 50$, $\gamma = 0.005$, over 5 epochs (250 single-point updates).
+#|   Both runs use the same starting point and the same sampling order, so the
+#|   only difference is the smoothing introduced by $\rho_n$. The cross marks
+#|   the maximum-likelihood estimate.
+
+library(patchwork)
+
+set.seed(28)
+N_p <- 50
+x_p <- runif(N_p, -1, 1)
+y_p <- rpois(N_p, mu(x_p, beta_true))
+grad_p <- function(par, i) (mu(x_p[i], par) - y_p[i]) * c(1, x_p[i])
+beta_hat_p <- coefficients(glm(y_p ~ x_p, family = poisson))
+
+set.seed(23)
+samp_order <- replicate(5, sample(N_p), simplify = FALSE)
+
+run_sg <- function(beta_mom, gamma) {
+  par <- c(0, 0)
+  rho <- c(0, 0)
+  n_iter <- 5 * N_p
+  path <- matrix(0, n_iter + 1, 2)
+  path[1, ] <- par
+  k <- 1
+
+  for (epoch in 1:5) {
+    for (i in samp_order[[epoch]]) {
+      rho <- beta_mom * rho + (1 - beta_mom) * grad_p(par, i)
+      par <- par - gamma * rho
+      k <- k + 1
+      path[k, ] <- par
+    }
+  }
+
+  data.frame(beta0 = path[, 1], beta1 = path[, 2])
+}
+
+sgd_path <- run_sg(0, 0.005)
+sgd_mom_path <- run_sg(0.9, 0.005)
+
+nll_p <- function(b0, b1) {
+  eta <- b0 + b1 * x_p
+  sum(exp(eta) - y_p * eta) / N_p
+}
+
+b0g <- seq(-0.2, 3.6, length.out = 80)
+b1g <- seq(-0.2, 3.6, length.out = 80)
+nll_grid_p <- expand.grid(beta0 = b0g, beta1 = b1g)
+nll_grid_p$z <- mapply(nll_p, nll_grid_p$beta0, nll_grid_p$beta1)
+
+xlab <- expression(beta[0])
+ylab <- expression(beta[1])
+
+make_panel <- function(path_data, subtitle, color) {
+  ggplot() +
+    geom_contour(
+      data = nll_grid_p,
+      aes(beta0, beta1, z = z),
+      color = "grey75",
+      bins = 18
+    ) +
+    geom_path(data = path_data, aes(beta0, beta1), color = color) +
+    geom_point(data = path_data, aes(beta0, beta1), color = color, size = 0.5) +
+    annotate(
+      "point",
+      x = beta_hat_p[1],
+      y = beta_hat_p[2],
+      shape = 4,
+      size = 3,
+      stroke = 1
+    ) +
+    labs(x = xlab, y = ylab, subtitle = subtitle)
+}
+
+make_panel(sgd_path, "SGD", "steelblue") +
+  make_panel(sgd_mom_path, "SGD + momentum", "dark orange") +
+  plot_layout(axes = "collect")
+```
+
+Returning to the news dataset, with momentum we can also increase the learning
+rate to $\gamma = 7 \times 10^{-2}$.
+
+```{r, echo=-c(1, 4), dependson=c("sg-tracer", "momentum", "ls-grad-update")}
+#| label: sg-7
+#| results: "hide"
+
 set.seed(20241110)
 sg_tracer$clear()
 stoch_grad(
-  par = ls_news$par0, 
-  N = ls_news$N, 
-  gamma = 7e-2, 
-  epoch = momentum(), 
+  par = ls_news$par0,
+  N = ls_news$N,
+  gamma = 7e-2,
+  epoch = momentum(),
   grad = ls_news$grad,
-  m = 1000, 
-  maxit = 150, 
+  m = 1000,
+  maxit = 150,
   cb = sg_tracer$tracer
 )
 sg_trace_moment <- summary(sg_tracer)
 ```
 
-```{r sg-fig-2, echo=FALSE, dependson=c("sg-mini-batch-run", "news-gd", "sg-tracer-2", "sg-7"), fig.height=4, fig.width=8, out.width="100%", fig.cap="Convergence of squared error loss on the news article dataset for four algorithms: gradient descent (gd), basic stochastic gradient with a power law decay schedule (decay), and mini-batch stochastic gradient with a batch size of 1000 and a fixed learning rate either without momentum (mini) or with momentum (moment)."}
+```{r, dependson=c("sg-mini-batch-run", "news-gd", "sg-tracer-2", "sg-7")}
+#| label: sg-fig-2
+#| echo: false
+#| fig-height: 4
+#| fig-width: 8
+#| out-width: "100%"
+#| fig-cap: >-
+#|   Convergence of squared error loss on the news article dataset for four
+#|   algorithms: gradient descent (gd), basic stochastic gradient with a power
+#|   law decay schedule (decay), and mini-batch stochastic gradient with a batch
+#|   size of 1000 and a fixed learning rate either without momentum (mini) or
+#|   with momentum (moment).
+
 dplyr::bind_rows(
-  mini = sg_trace_mini[seq(1, 150, 3), ], 
+  mini = sg_trace_mini[seq(1, 150, 3), ],
   decay = sg_trace_decay,
-  gd = gd_trace[seq(1, 800, 10), ], 
+  gd = gd_trace[seq(1, 800, 10), ],
   moment = sg_trace_moment[seq(1, 150, 3), ],
   .id = "Algorithm"
-) |> 
-  dplyr::filter(.time < 2) |> 
-autoplot(y = value - ls_news$H(lm_news$coefficients )) + 
+) |>
+  dplyr::filter(.time < 2) |>
+  autoplot(y = value - ls_news$H(lm_news$coefficients)) +
   ylab(expression(H(theta[n]) - H(theta[infinity]))) +
-  aes(color = Algorithm, shape = Algorithm) + 
-  geom_line() + 
-  scale_color_brewer(limits = c("low", "high", "decay", "gd", "mini", "moment", "adam", "adam_decay"), 
-                       breaks = c("decay", "gd", "mini", "moment"), type = "qual", palette = 2) +
-  scale_shape_manual(limits = c("low", "high", "decay", "gd", "mini", "moment", "adam", "adam_decay"), 
-                     breaks = c("decay", "gd", "mini", "moment"),
-                     values = c(0, 1, 2, 5, 15, 16, 17, 19))
+  aes(color = Algorithm, shape = Algorithm) +
+  geom_line() +
+  scale_color_brewer(
+    limits = c(
+      "low",
+      "high",
+      "decay",
+      "gd",
+      "mini",
+      "moment",
+      "adam",
+      "adam_decay"
+    ),
+    breaks = c("decay", "gd", "mini", "moment"),
+    type = "qual",
+    palette = 2
+  ) +
+  scale_shape_manual(
+    limits = c(
+      "low",
+      "high",
+      "decay",
+      "gd",
+      "mini",
+      "moment",
+      "adam",
+      "adam_decay"
+    ),
+    breaks = c("decay", "gd", "mini", "moment"),
+    values = c(0, 1, 2, 5, 15, 16, 17, 19)
+  )
 ```
 
 Figure \@ref(fig:sg-fig-2) shows that the momentum algorithm converges a little
@@ -1399,70 +2111,67 @@ illustrations.
 
 ### Adaptive learning rates
 
-One difficulty with optimization algorithms based only on gradients is
-that gradients are not invariant to reparametrizations. In fact, using
-gradients implicitly assumes that all parameters are on comparable
-scales. For our news article example, we standardized the model matrix
-to achieve this, but for many other optimization problems it is not so
-easy to choose a parametrization with all parameters on comparable
-scales. And even when we can reparametrize so that all parameters are on
-a common scale, this common scale can change from problem to problem
-making it impossible to recommend a good default choice of learning
-rate. One implication is that when the algorithms are 
-applied, a considerable amount of tuning is necessary.
+One difficulty with optimization algorithms based only on gradients is that
+gradients are not invariant to reparametrizations. In fact, using gradients
+implicitly assumes that all parameters are on comparable scales. For our news
+article example, we standardized the model matrix to achieve this, but for many
+other optimization problems it is not so easy to choose a parametrization with
+all parameters on comparable scales. And even when we can reparametrize so that
+all parameters are on a common scale, this common scale can change from problem
+to problem making it impossible to recommend a good default choice of learning
+rate. One implication is that when the algorithms are applied, a considerable
+amount of tuning is necessary.
 
-Algorithms that implement adaptive learning rates are alternatives to
-extensive tuning. They include schemes for adjusting the learning rate
-to the specific optimization problem. Adapting the learning rate is
-equivalent to scaling the gradient adaptively, and to achieve a form of
-automatic standardization of parameter scales, we will consider
-algorithms that adaptively scale each coordinate of the gradient
-separately.
+Algorithms that implement adaptive learning rates are alternatives to extensive
+tuning. They include schemes for adjusting the learning rate to the specific
+optimization problem. Adapting the learning rate is equivalent to scaling the
+gradient adaptively, and to achieve a form of automatic standardization of
+parameter scales, we will consider algorithms that adaptively scale each
+coordinate of the gradient separately.
 
-To gain some intuition on how to sensibly adapt the scales of the
-gradient, we will analyze the typical scale of the mini-batch gradient
-for the linear model. Introduce first the normalized squared column
-norms
+To gain some intuition on how to sensibly adapt the scales of the gradient, we
+will analyze the typical scale of the mini-batch gradient for the linear model.
+Introduce first the normalized squared column norms
 
 \[
   \zeta_j = \frac{1}{N} \sum_{i=1}^N x_{ij}^2 = \frac{1}{N} \| x_{\cdot j}\|^2_2,
-\]  
+\]
+\
 
-and note that with a standardized $X$, all the $\zeta_j$-s are equal.
-With $\hat{\beta}$ the least squares estimate we also have that
+and note that with a standardized $X$, all the $\zeta_j$-s are equal. With
+$\hat{\beta}$ the least squares estimate we also have that
 
 \[
   \frac{1}{N} \sum_{i=1}^N x_{ij} (y_i - \hat{\beta}{}^Tx_i) = 0
 \]
-  
-for $j = 1, \ldots, p$. Thus if we sample a random index, $J$, 
-from $\{1, \ldots, N\}$ it holds that 
-$\E(x_{J j} (y_{J} - \hat{\beta}{}^Tx_{J})) = 0$, 
-where the expectation is w.r.t. $J$. With
 
-\[ 
+for $j = 1, \ldots, p$. Thus if we sample a random index, $J$, from
+$\{1, \ldots, N\}$ it holds that
+$\E(x_{J j} (y_{J} - \hat{\beta}{}^Tx_{J})) = 0$, where the expectation is
+w.r.t. $J$. With
+
+\[
   \hat{\sigma}^2 = \frac{1}{N} \sum_{i=1}^N (y_i - \hat{\beta}{}^Tx_i)^2
 \]
 
 denoting the residual variance, we also have that
 
 \[
-\V(x_{J j} (y_{J} - \hat{\beta}{}^Tx_{J})) = 
-\E(x_{J j}^2 (y_{J} - \hat{\beta}{}^Tx_{J})^2) 
-\approx \zeta_j \hat{\sigma}^2.
+  \V(x_{J j} (y_{J} - \hat{\beta}{}^Tx_{J})) = 
+  \E(x_{J j}^2 (y_{J} - \hat{\beta}{}^Tx_{J})^2) 
+  \approx \zeta_j \hat{\sigma}^2.
 \]
 
 For the above approximation to hold, the squared residual,
-$(y_{J} - \hat{\beta}{}^Tx_{J})^2$, must be roughly independent
-of $x_{J}$, which is not guaranteed by the least squares fit alone,
-but holds approximately if data is from a population with homogeneous
-residual variance.
+$(y_{J} - \hat{\beta}{}^Tx_{J})^2$, must be roughly independent of $x_{J}$,
+which is not guaranteed by the least squares fit alone, but holds approximately
+if data is from a population with homogeneous residual variance.
 
-If $I \subseteq \{1,\ldots,N\}$ is a random subset of size $m$ sampled
-*with* replacement, the averaged gradient
+If $I \subseteq \{1,\ldots,N\}$ is a random subset of size $m$ sampled *with*
+replacement, the averaged gradient
 
 \[
-  g = - \frac{1}{m} \sum_{i \in I} x_{i} (y_i - \hat{\beta}{}^T x_i)
+  g = - \frac{1}{m} \sum_{i \in I} x_{i} (y_i - \hat{\beta}{}^\top x_i)
 \]
 
 is an average of $m$ i.i.d. random variables with mean 0, thus
@@ -1478,209 +2187,249 @@ product), this can also be written as
   \E(g \odot g) \approx  \zeta \frac{\hat{\sigma}^2}{m}.
 \]
 
-The computations suggest that by estimating $v = \E(g \odot g)$ for a
-mini-batch gradient evaluated in $\beta = \hat{\beta},$ we are in fact
-estimating $\zeta$ up to a scale factor. We extrapolate this insight to
-the general case and standardize the $j$-th coordinate of the descent
-direction by an estimate of $1 / \sqrt{v_j}$ to bring the coordinates on
-a (more) common scale. We will implement adaptive estimation of $v$
-using a similar update scheme as for momentum, where the estimate in
-iteration $n$ is updated as a convex combination of the current value of
-$g_n \odot g_n$ and the previous estimate of $v$.
+The computations suggest that by estimating $v = \E(g \odot g)$ for a mini-batch
+gradient evaluated in $\beta = \hat{\beta},$ we are in fact estimating $\zeta$
+up to a scale factor. We extrapolate this insight to the general case and
+standardize the $j$-th coordinate of the descent direction by an estimate of
+$1 / \sqrt{v_j}$ to bring the coordinates on a (more) common scale. We will
+implement adaptive estimation of $v$ using a similar update scheme as for
+momentum, where the estimate in iteration $n$ is updated as a convex combination
+of the current value of $g_n \odot g_n$ and the previous estimate of $v$.
 
-Given $\theta_{n}$ and a batch $I_n \subseteq \{1, \ldots, N\}$ with
-$|I_n| = m$ the update consists of the following steps
+Given $\theta_{n}$ and a batch $I_n \subseteq \{1, \ldots, N\}$ with $|I_n| = m$
+the update consists of the following steps
 
--   compute
-    $g_n = \frac{1}{m} \sum_{i\in I_n} \nabla_{\theta} L(y_i, x_i, \theta_{n})$
--   compute $\rho_n = \beta_1 \rho_{n-1} + (1-\beta_1) g_n$
--   compute $v_n = \beta_2 v_{n-1} + (1-\beta_2) g_n \odot g_n$
--   update the parameter
-    $\theta_{n+1} = \theta_{n} - \gamma_n \rho_n / (\sqrt{v_n} + 10^{-8}).$
+- compute
+  $g_n = \frac{1}{m} \sum_{i\in I_n} \nabla_{\theta} L(y_i, x_i, \theta_{n})$
+- compute $\rho_n = \beta_1 \rho_{n-1} + (1-\beta_1) g_n$
+- compute $v_n = \beta_2 v_{n-1} + (1-\beta_2) g_n \odot g_n$
+- update the parameter
+  $\theta_{n+1} = \theta_{n} - \gamma_n \rho_n / (\sqrt{v_n} + 10^{-8}).$
 
-The vectors $\rho_0$ and $v_0$ are usually initialized to be $0$. The
-tuning parameters $\beta_1, \beta_2 \in [0, 1)$ control the memory of
-the first and second moments, respectively. The $\sqrt{v_n}$ and the
-division in the last step are coordinate wise. The constant $10^{-8}$
-could, of course, be chosen differently, but is just a safeguard against
-division-by-zero.
+The vectors $\rho_0$ and $v_0$ are usually initialized to be $0$. The tuning
+parameters $\beta_1, \beta_2 \in [0, 1)$ control the memory of the first and
+second moments, respectively. The $\sqrt{v_n}$ and the division in the last step
+are coordinate wise. The constant $10^{-8}$ could, of course, be chosen
+differently, but is just a safeguard against division-by-zero.
 
-The algorithm above is known as *Adam* (adaptive moment estimation), and
-was introduced and analyzed by @kingma2014adam. They include so-called
+The algorithm above is known as *Adam* (adaptive moment estimation), and was
+introduced and analyzed by @kingma2014adam. They include so-called
 bias-correction steps that upscale $\rho_n$ and $v_n$ by the factors
-$1 / (1 - \beta_1^n)$ and $1 / (1 - \beta_2^n)$, respectively. These
-steps are not difficult to implement but are left out in the
-implementation below for simplicity. It is also possible to replace the
-$\sqrt{v_n}$ by other powers $v_n^q$. The choice of $q = 1$ instead of
-$q = 1/2$ makes the algorithm (more) invariant to scale changes. Again,
-for simplicity we will only implement the algorithm with $q = 1/2$.
+$1 / (1 - \beta_1^n)$ and $1 / (1 - \beta_2^n)$, respectively. These steps are
+not difficult to implement but are left out in the implementation below for
+simplicity. It is also possible to replace the $\sqrt{v_n}$ by other powers
+$v_n^q$. The choice of $q = 1$ instead of $q = 1/2$ makes the algorithm (more)
+invariant to scale changes. Again, for simplicity we will only implement the
+algorithm with $q = 1/2$.
 
-The `adam()` function below is a function factory just as `momentum()`,
-which returns a function doing the Adam epoch update loop with an
-enclosing environment used for storage of `rho` and `v`.
+The `adam()` function below is a function factory just as `momentum()`, which
+returns a function doing the Adam epoch update loop with an enclosing
+environment used for storage of `rho` and `v`.
 
-```{r Adam}
+```{r}
+#| label: Adam
+
 adam <- function() {
   rho <- v <- 0
   function(
-    par, 
+    par,
     samp,
-    gamma,   
+    gamma,
     grad,
-    m = 50,          # Mini-batch size
-    beta1 = 0.9,     # Momentum memory     
-    beta2 = 0.9,     # Second moment memory 
+    m = 50, # Mini-batch size
+    beta1 = 0.9, # Momentum memory
+    beta2 = 0.9, # Second moment memory
     ...
   ) {
     M <- floor(length(samp) / m)
-    for(j in 0:(M - 1)) {
+    for (j in 0:(M - 1)) {
       i <- samp[(j * m + 1):(j * m + m)]
-      gr <- grad(par, i, ...) 
-      rho <<- beta1 * rho + (1 - beta1) * gr 
-      v <<- beta2 * v + (1 - beta2) * gr^2 
-      par <- par - gamma * (rho / (sqrt(v) + 1e-8))  
+      gr <- grad(par, i, ...)
+      rho <<- beta1 * rho + (1 - beta1) * gr
+      v <<- beta2 * v + (1 - beta2) * gr^2
+      par <- par - gamma * (rho / (sqrt(v) + 1e-8))
     }
     par
   }
 }
 ```
 
-We run the stochastic gradient algorithm with Adam epochs and
-mini-batches of size 1000 with a fixed learning rate of $0.01$ and a
-power law decay schedule interpolating between a learning rate of $0.5$
-and $0.002$. The theoretical results by @kingma2014adam support a decay
-schedule proportional to $1/\sqrt{n}$, thus we take $a = 0.5$ below.
+We run the stochastic gradient algorithm with Adam epochs and mini-batches of
+size 1000 with a fixed learning rate of $0.01$ and a power law decay schedule
+interpolating between a learning rate of $0.5$ and $0.002$. The theoretical
+results by @kingma2014adam support a decay schedule proportional to
+$1/\sqrt{n}$, thus we take $a = 0.5$ below.
 
-```{r sg-8, results='hide', dependson=c("sg-tracer", "Adam", "ls-grad-update")}
+```{r, dependson=c("sg-tracer", "Adam", "ls-grad-update")}
+#| label: sg-8
+#| results: "hide"
+
 sg_tracer$clear()
 stoch_grad(
-  par = ls_news$par0, 
-  N = ls_news$N, 
-  gamma = 1e-2, 
-  epoch = adam(), 
+  par = ls_news$par0,
+  N = ls_news$N,
+  gamma = 1e-2,
+  epoch = adam(),
   grad = ls_news$grad,
-  m = 1000, 
-  maxit = 150, 
+  m = 1000,
+  maxit = 150,
   cb = sg_tracer$tracer
 )
 sg_trace_adam <- summary(sg_tracer)
 sg_tracer$clear()
 stoch_grad(
-  par = ls_news$par0, 
-  N =  ls_news$N, 
-  gamma = decay_scheduler(0.5, 0.5, gamma1 = 2e-3, n = 150), 
-  epoch = adam(), 
+  par = ls_news$par0,
+  N = ls_news$N,
+  gamma = decay_scheduler(0.5, 0.5, gamma1 = 2e-3, n = 150),
+  epoch = adam(),
   grad = ls_news$grad,
-  m = 1000, 
-  maxit = 150, 
+  m = 1000,
+  maxit = 150,
   cb = sg_tracer$tracer
 )
 sg_trace_adam_decay <- summary(sg_tracer)
 ```
 
-```{r sg-fig-3, echo=FALSE, dependson=c("sg-mini-batch-run", "news-gd", "sg-tracer-2", "sg-7", "sg-8"), fig.height=4, fig.width=8, out.width="100%", fig.cap="Convergence of squared error loss on the news article dataset for six algorithms: basic stochastic gradient with a power law decay schedule (decay), gradient descent (gd), mini-batch stochastic gradient with a batch size of 1000 and a fixed learning rate either without momentum (mini) or with momentum (moment), and the Adam algorithm either with a fixed learning rate (adam) or a power law decay schedule (adam\\_decay)."}
+```{r, dependson=c("sg-mini-batch-run", "news-gd", "sg-tracer-2", "sg-7", "sg-8")}
+#| label: sg-fig-3
+#| echo: false
+#| fig-height: 4
+#| fig-width: 8
+#| out-width: "100%"
+#| fig-cap: >-
+#|   Convergence of squared error loss on the news article dataset for six
+#|   algorithms: basic stochastic gradient with a power law decay schedule
+#|   (decay), gradient descent (gd), mini-batch stochastic gradient with a batch
+#|   size of 1000 and a fixed learning rate either without momentum (mini) or
+#|   with momentum (moment), and the Adam algorithm either with a fixed learning
+#|   rate (adam) or a power law decay schedule (adam\_decay).
+
 dplyr::bind_rows(
-  mini = sg_trace_mini[seq(1, 200, 3), ], 
+  mini = sg_trace_mini[seq(1, 200, 3), ],
   decay = sg_trace_decay,
-  gd = gd_trace[seq(1, 800, 10), ], 
+  gd = gd_trace[seq(1, 800, 10), ],
   moment = sg_trace_moment[seq(1, 200, 3), ],
   adam = sg_trace_adam[seq(1, 150, 2), ],
   adam_decay = sg_trace_adam_decay[seq(1, 150, 2), ],
   .id = "Algorithm"
-) |> 
-  dplyr::filter(.time < 2) |> 
-autoplot(y = value - ls_news$H(lm_news$coefficients )) + 
+) |>
+  dplyr::filter(.time < 2) |>
+  autoplot(y = value - ls_news$H(lm_news$coefficients)) +
   ylab(expression(H(theta[n]) - H(theta[infinity]))) +
-  aes(color = Algorithm, shape = Algorithm) + 
+  aes(color = Algorithm, shape = Algorithm) +
   geom_line() +
-  scale_color_brewer(limits = c("low", "high", "decay", "gd", "mini", "moment", "adam", "adam_decay"), 
-                       breaks = c("decay" ,"gd", "mini", "moment", "adam", "adam_decay"), type = "qual", palette = 2) +
-  scale_shape_manual(limits = c("low", "high", "decay", "gd", "mini", "moment", "adam", "adam_decay"), 
-                     breaks = c("decay", "gd", "mini", "moment", "adam", "adam_decay"),
-                     values = c(0, 1, 2, 5, 15, 16, 17, 19))
+  scale_color_brewer(
+    limits = c(
+      "low",
+      "high",
+      "decay",
+      "gd",
+      "mini",
+      "moment",
+      "adam",
+      "adam_decay"
+    ),
+    breaks = c("decay", "gd", "mini", "moment", "adam", "adam_decay"),
+    type = "qual",
+    palette = 2
+  ) +
+  scale_shape_manual(
+    limits = c(
+      "low",
+      "high",
+      "decay",
+      "gd",
+      "mini",
+      "moment",
+      "adam",
+      "adam_decay"
+    ),
+    breaks = c("decay", "gd", "mini", "moment", "adam", "adam_decay"),
+    values = c(0, 1, 2, 5, 15, 16, 17, 19)
+  )
 ```
 
-Figure \@ref(fig:sg-fig-3) shows that both runs of the Adam
-implementation converge faster initially than any of the other
-algorithms. Eventually they both level off when the error is around
-$10^{-3}$ and from this point on they fluctuate randomly. What is not
-shown is that Adam is also somewhat more robust to changes of the
-learning rate and rescaling of the parameters. Though Adam has more
-tuning parameters, it is easier to find good values of those parameters
+Figure \@ref(fig:sg-fig-3) shows that both runs of the Adam implementation
+converge faster initially than any of the other algorithms. Eventually they both
+level off when the error is around $10^{-3}$ and from this point on they
+fluctuate randomly. What is not shown is that Adam is also somewhat more robust
+to changes of the learning rate and rescaling of the parameters. Though Adam has
+more tuning parameters, it is easier to find good values of those parameters
 that will lead to fast convergence.
 
 ## Stochastic gradient algorithms with Rcpp {#sg-Rcpp}
 
-As pointed out toward the end of Section \@ref(news), the
-implementations of stochastic gradient algorithms in R suffer from some
-shortcomings. In this section we will explore how parts of the
-algorithms or entire algorithms can be moved to C++ via Rcpp.
+As pointed out toward the end of Section \@ref(news), the implementations of
+stochastic gradient algorithms in R suffer from some shortcomings. In this
+section we will explore how parts of the algorithms or entire algorithms can be
+moved to C++ via Rcpp.
 
 The modularity of the `stoch_grad()` implementation makes it easy to replace the
-implementation of either the gradient computation or the entire epoch
-loop by a C++ implementation, while retaining the overall control of the
-algorithm and the resampling in R. This is explored first and consists
-mostly of translating the numerical linear algebra of the gradient
-computations into C++ code. We can then easily test, compare and
-benchmark the implementations using the R implementation as a reference.
+implementation of either the gradient computation or the entire epoch loop by a
+C++ implementation, while retaining the overall control of the algorithm and the
+resampling in R. This is explored first and consists mostly of translating the
+numerical linear algebra of the gradient computations into C++ code. We can then
+easily test, compare and benchmark the implementations using the R
+implementation as a reference.
 
-In the second part of this section the entire mini-batch stochastic
-gradient algorithm is translated into C++. This has a couple of notable
-consequences. First, we need access to a sampler in C++ that can do the
-randomization. While there are various C++ interfaces to an equivalent
-of `sample()`, some considerations need to go into an appropriate
-choice. Second, we have to give up on tracing as otherwise implemented.
-Though it is possible to implement callback of an R function from a C++
-function, a tracer will not have the same access to the calling
-environment as in the R implementation. Thus for performance assessment
-we will rely on benchmarking of the entire algorithm.
+In the second part of this section the entire mini-batch stochastic gradient
+algorithm is translated into C++. This has a couple of notable consequences.
+First, we need access to a sampler in C++ that can do the randomization. While
+there are various C++ interfaces to an equivalent of `sample()`, some
+considerations need to go into an appropriate choice. Second, we have to give up
+on tracing as otherwise implemented. Though it is possible to implement callback
+of an R function from a C++ function, a tracer will not have the same access to
+the calling environment as in the R implementation. Thus for performance
+assessment we will rely on benchmarking of the entire algorithm.
 
-For the C++ implementations we need to give up on some of the
-abstractions that R provides, though we will benefit from Rcpp data
-types like `NumericVector` and `NumericMatrix`. In a final
-implementation we will use
-[RcppArmadillo](http://dirk.eddelbuettel.com/code/rcpp.armadillo.html)
-to regain an abstract approach to numerical linear algebra via the C++
-library [Armadillo](http://arma.sourceforge.net/).
+For the C++ implementations we need to give up on some of the abstractions that
+R provides, though we will benefit from Rcpp data types like `NumericVector` and
+`NumericMatrix`. In a final implementation we will use
+[RcppArmadillo](http://dirk.eddelbuettel.com/code/rcpp.armadillo.html) to regain
+an abstract approach to numerical linear algebra via the C++ library
+[Armadillo](http://arma.sourceforge.net/).
 
 ### Gradients and epochs in Rcpp {#Rcpp-grad-epoch}
 
-```{Rcpp compile-sg, ref.label=c("compile-sg", "grad-Rcpp", "epoch-Rcpp", "sg-Rcpp", "sg-Armadillo"), include=FALSE}
+```{Rcpp, ref.label=c("compile-sg", "grad-Rcpp", "epoch-Rcpp", "sg-Rcpp", "sg-Armadillo")}
+//| label: compile-sg
+//| include: false
+
 #include <RcppArmadillo.h>
 #include <dqrng.h>
 using namespace Rcpp;
 using namespace arma;
 ```
 
-We first implement the computation of the mini-batch gradient in Rcpp
-for the linear model, thus replacing the R implementation of the
-gradient in `ls_model()`. The implemented function takes the model
-matrix $X$ and the target variable $y$ as arguments in addition to the
-parameter vector and the subset of indices representing the mini-batch. The
-matrix-vector multiplications for computing predicted values, residuals
-and ultimately the gradient are replaced by two double for-loops.
+We first implement the computation of the mini-batch gradient in Rcpp for the
+linear model, thus replacing the R implementation of the gradient in
+`ls_model()`. The implemented function takes the model matrix $X$ and the target
+variable $y$ as arguments in addition to the parameter vector and the subset of
+indices representing the mini-batch. The matrix-vector multiplications for
+computing predicted values, residuals and ultimately the gradient are replaced
+by two double for-loops.
 
-```{Rcpp grad-Rcpp, eval=FALSE}
+```{Rcpp}
+//| label: grad-Rcpp
+//| eval: false
+
 // [[Rcpp::export]]
-NumericVector grad_cpp(
-    NumericVector beta, 
-    IntegerVector ii, 
-    NumericMatrix X, 
-    NumericVector y
-) {
+NumericVector
+grad_cpp(NumericVector beta, IntegerVector ii, NumericMatrix X, NumericVector y)
+{
   int m = ii.length(), p = beta.length();
   NumericVector grad(p), yhat(m);
   // Shift indices one down due to zero-indexing in C++
-  IntegerVector iii = clone(ii) - 1;  
-  
-  for(int i = 0; i < m; ++i) {
-    for(int j = 0; j < p; ++j) {
+  IntegerVector iii = clone(ii) - 1;
+
+  for (int i = 0; i < m; ++i) {
+    for (int j = 0; j < p; ++j) {
       yhat[i] += X(iii[i], j) * beta[j];
     }
   }
-  for(int i = 0; i < m; ++i) {
-    for(int j = 0; j < p; ++j) {
-      grad[j] += X(iii[i], j) * (yhat[i]- y[iii[i]]);
+  for (int i = 0; i < m; ++i) {
+    for (int j = 0; j < p; ++j) {
+      grad[j] += X(iii[i], j) * (yhat[i] - y[iii[i]]);
     }
   }
   return grad / m;
@@ -1690,25 +2439,29 @@ NumericVector grad_cpp(
 Note how `clone(ii)` is used to create a copy of the index vector `ii` before it
 is shifted by one. When R objects like vectors and matrices are passed as
 arguments to a C++ function, only a pointer to the data in the object is
-actually passed. A modification of the resulting Rcpp object within the body
-of the C++ function will be reflected in R---most likely as an unwanted side
+actually passed. A modification of the resulting Rcpp object within the body of
+the C++ function will be reflected in R---most likely as an unwanted side
 effect. To prevent this we can create a copy using `clone()` of all data in the
 object---a so-called deep copy.
 
 Since only a pointer to a matrix is passed when calling a C++ function, no
 notable cost is associated with passing the entire model matrix as argument. On
 the contrary, if we were to pass a subset of the model matrix to the C++
-function from R, data would inevitably be copied. And since the C++ implementation
-never creates a submatrix corresponding to the slicing, the implementation of 
-`grad_cpp()` avoids the data copying incurred by matrix slicing in R.
+function from R, data would inevitably be copied. And since the C++
+implementation never creates a submatrix corresponding to the slicing, the
+implementation of `grad_cpp()` avoids the data copying incurred by matrix
+slicing in R.
 
-We can test `grad_cpp()` by comparing it to `ls_news$grad()` for different choices
-of parameter vectors and indices. A simple way to achieve this is to run the
-mini-batch stochastic gradient algorithm with either implementation of the
+We can test `grad_cpp()` by comparing it to `ls_news$grad()` for different
+choices of parameter vectors and indices. A simple way to achieve this is to run
+the mini-batch stochastic gradient algorithm with either implementation of the
 gradient for one epoch and compare the results. Note that we make sure the
 algorithms use the same mini-batches by setting the seed.
 
-```{r test_grad_cpp, dependson=c("LS-model", "grad-Rcpp", "ls-grad-update", "LS-model", "sg-mini-batch", "batch"), eval=TRUE}
+```{r, dependson=c("LS-model", "grad-Rcpp", "ls-grad-update", "LS-model", "sg-mini-batch", "batch")}
+#| label: test_grad_cpp
+#| eval: true
+
 set.seed(10)
 par_R <- stoch_grad(
   par = ls_news$par0,
@@ -1720,63 +2473,68 @@ par_R <- stoch_grad(
 )
 set.seed(10)
 par_grad_cpp <- stoch_grad(
-  par = ls_news$par0, 
+  par = ls_news$par0,
   grad = grad_cpp,
   N = ls_news$N,
   gamma = 5e-2,
   m = 1000,
-  maxit = 1, 
+  maxit = 1,
   X = ls_news$X,
   y = ls_news$y
 )
 range(par_R - par_grad_cpp)
 ```
 
-The differences are all 0, thus the test suggests that `grad_cpp()`
-implements the same computation as `ls_news$grad()`.
+The differences are all 0, thus the test suggests that `grad_cpp()` implements
+the same computation as `ls_news$grad()`.
 
-We can also move the entire epoch loop to C++, thus replacing the
-`batch()` R function by the Rcpp function `batch_cpp()` below. This is
-achieved by implementing the outer batch loop in C++ and calling
-the `grad_cpp()` function from within. 
+We can also move the entire epoch loop to C++, thus replacing the `batch()` R
+function by the Rcpp function `batch_cpp()` below. This is achieved by
+implementing the outer batch loop in C++ and calling the `grad_cpp()` function
+from within.
 
-```{Rcpp epoch-Rcpp, eval=FALSE}
+```{Rcpp}
+//| label: epoch-Rcpp
+//| eval: false
+
 // [[Rcpp::export]]
-NumericVector batch_cpp(
-    NumericVector par, 
-    IntegerVector ii, 
-    double gamma, 
-    NumericMatrix X, 
-    NumericVector y, 
-    int m = 50
-) {
+NumericVector
+batch_cpp(NumericVector par,
+          IntegerVector ii,
+          double gamma,
+          NumericMatrix X,
+          NumericVector y,
+          int m = 50)
+{
   int M = floor(ii.length() / m);
   NumericVector grad(par.length()), beta = clone(par);
 
-  for(int j = 0; j < M; ++j) {
-      grad = grad_cpp(beta, ii[Range(j * m, (j + 1) * m - 1)], X, y);
-      beta = beta - gamma * grad;
+  for (int j = 0; j < M; ++j) {
+    grad = grad_cpp(beta, ii[Range(j * m, (j + 1) * m - 1)], X, y);
+    beta = beta - gamma * grad;
   }
   return beta;
 }
 ```
 
-We can test the implementation of `batch_cpp()` just as `grad_cpp()` by
-running the stochastic gradient algorithm for one epoch. We note that
-the `batch_cpp()` function should be passed to `stoch_grad()` as the `epoch`
-argument, and that no `grad` argument is required. The gradient
-computations are hard coded into the implementation of this epoch
-function.
+We can test the implementation of `batch_cpp()` just as `grad_cpp()` by running
+the stochastic gradient algorithm for one epoch. We note that the `batch_cpp()`
+function should be passed to `stoch_grad()` as the `epoch` argument, and that no
+`grad` argument is required. The gradient computations are hard coded into the
+implementation of this epoch function.
 
-```{r test_batch_cpp, dependson=c("LS-model", "epoch-Rcpp", "ls-grad-update", "LS-model", "sg-mini-batch", "batch"), eval=TRUE}
+```{r, dependson=c("LS-model", "epoch-Rcpp", "ls-grad-update", "LS-model", "sg-mini-batch", "batch")}
+#| label: test_batch_cpp
+#| eval: true
+
 set.seed(10)
 par_batch_cpp <- stoch_grad(
-  par = ls_news$par0, 
-  epoch = batch_cpp,   
+  par = ls_news$par0,
+  epoch = batch_cpp,
   N = ls_news$N,
   gamma = 5e-2,
   m = 1000,
-  maxit = 1, 
+  maxit = 1,
   X = ls_news$X,
   y = ls_news$y
 )
@@ -1784,330 +2542,376 @@ range(par_R - par_batch_cpp)
 ```
 
 We see that these differences are also zero, and the test suggests that
-`batch_cpp()` implements the same computation as `batch()` with either
-of the two implementations of the gradient.
+`batch_cpp()` implements the same computation as `batch()` with either of the
+two implementations of the gradient.
 
-To investigate the effect of the C++ implementation, the mini-batch
-stochastic gradient algorithm is run with the Rcpp implementations of
-either the gradient or the entire epoch using a mini-batch size of 1000
-and a constant learning rate $\gamma = 0.05$, which can be compared to
-the pure R implementation. 
+To investigate the effect of the C++ implementation, the mini-batch stochastic
+gradient algorithm is run with the Rcpp implementations of either the gradient
+or the entire epoch using a mini-batch size of 1000 and a constant learning rate
+$\gamma = 0.05$, which can be compared to the pure R implementation.
 
-```{r sg-6, results='hide', echo=FALSE, dependson=c("compile-sg", "sg")}
+```{r, dependson=c("compile-sg", "sg")}
+#| label: sg-6
+#| results: "hide"
+#| echo: false
+
 set.seed(20241110)
 sg_tracer$clear()
 stoch_grad(
-  par = ls_news$par0, 
-  N = ls_news$N, 
-  gamma = 5e-2, 
-  grad = grad_cpp, 
-  X = ls_news$X, 
-  y = ls_news$y, 
+  par = ls_news$par0,
+  N = ls_news$N,
+  gamma = 5e-2,
+  grad = grad_cpp,
+  X = ls_news$X,
+  y = ls_news$y,
   m = 1000,
-  maxit = 200, 
+  maxit = 200,
   cb = sg_tracer$tracer
 )
 sg_trace_Rcpp_grad <- summary(sg_tracer)
 #sg_tracer$clear()
 #stoch_grad(
-#  par = ls_news$par0, 
-#  N = ls_news$N, 
-#  gamma = 5e-5, 
-#  epoch = batch_cpp,   
-#  X = ls_news$X, 
-#  y = ls_news$y, 
-#  m = 1, 
-#  maxit = 200, 
+#  par = ls_news$par0,
+#  N = ls_news$N,
+#  gamma = 5e-5,
+#  epoch = batch_cpp,
+#  X = ls_news$X,
+#  y = ls_news$y,
+#  m = 1,
+#  maxit = 200,
 #  cb = sg_tracer$tracer
 #)
 #sg_trace_Rcpp_epoch <- summary(sg_tracer)
 set.seed(20241110)
 sg_tracer$clear()
 stoch_grad(
-  par = ls_news$par0, 
-  N = ls_news$N, 
-  gamma = 5e-2, 
-  epoch = batch_cpp,   
-  X = ls_news$X, 
-  y = ls_news$y, 
-  m = 1000, 
-  maxit = 200, 
+  par = ls_news$par0,
+  N = ls_news$N,
+  gamma = 5e-2,
+  epoch = batch_cpp,
+  X = ls_news$X,
+  y = ls_news$y,
+  m = 1000,
+  maxit = 200,
   cb = sg_tracer$tracer
 )
 sg_trace_Rcpp_epoch_mini <- summary(sg_tracer)
-
 ```
 
 (ref:Rcpp-fig) Convergence of squared error loss on the news article dataset for three algorithms: the R implementation of mini-batch stochastic gradient with a batch size of 1000 and a fixed learning rate (`mini`), the same mini-batch algorithm but with the gradient implemented in Rcpp (`Rcpp_grad_mini`) and with the entire epoch implemented in Rcpp (`Rcpp_epoch_mini`).
 
-```{r sg-fig-4, echo=FALSE, dependson=c("sg-basic", "sg-4", "sg-5", "sg-6", "sg-7", "sg-8"), fig.height=4, fig.width=8, out.width="100%", fig.cap='(ref:Rcpp-fig)'}
+```{r, dependson=c("sg-basic", "sg-4", "sg-5", "sg-6", "sg-7", "sg-8")}
+#| label: sg-fig-4
+#| echo: false
+#| fig-height: 4
+#| fig-width: 8
+#| out-width: "100%"
+#| fig-cap: "(ref:Rcpp-fig)"
+
 dplyr::bind_rows(
   Rcpp_grad_mini = sg_trace_Rcpp_grad[seq(1, 200, 3), ],
-#  Rcpp_epoch = sg_trace_Rcpp_epoch[seq(1, 200, 3), ],
+  #  Rcpp_epoch = sg_trace_Rcpp_epoch[seq(1, 200, 3), ],
   Rcpp_epoch_mini = sg_trace_Rcpp_epoch_mini[seq(1, 200, 3), ],
-  mini = sg_trace_mini[seq(1, 150, 2), ], 
-#  high = sg_trace_high,
+  mini = sg_trace_mini[seq(1, 150, 2), ],
+  #  high = sg_trace_high,
   .id = "Algorithm"
-) |> 
-  dplyr::filter(.time < 2) |> 
-autoplot(y = value - ls_news$H(lm_news$coefficients )) + 
+) |>
+  dplyr::filter(.time < 2) |>
+  autoplot(y = value - ls_news$H(lm_news$coefficients)) +
   ylab(expression(H(theta[n]) - H(theta[infinity]))) +
-  aes(color = Algorithm, shape = Algorithm) + 
+  aes(color = Algorithm, shape = Algorithm) +
   geom_line() +
-  scale_color_brewer(limits = c("Rcpp_grad_mini", "high", "Rcpp_epoch_mini", "Rcpp_epoch", "mini", "Rcpp4", "adam", "adam_decay"), 
-                     breaks = c("mini", "Rcpp_grad_mini", "Rcpp_epoch_mini"), type = "qual", palette = 2) +
-  scale_shape_manual(limits = c("Rcpp_grad_mini", "high", "Rcpp_epoch_mini", "Rcpp_epoch", "mini", "Rcpp4", "adam", "adam_decay"), 
-                     breaks = c("mini", "Rcpp_grad_mini", "Rcpp_epoch_mini"),
-                     values = c(0, 1, 2, 5, 15, 16, 17, 19))
+  scale_color_brewer(
+    limits = c(
+      "Rcpp_grad_mini",
+      "high",
+      "Rcpp_epoch_mini",
+      "Rcpp_epoch",
+      "mini",
+      "Rcpp4",
+      "adam",
+      "adam_decay"
+    ),
+    breaks = c("mini", "Rcpp_grad_mini", "Rcpp_epoch_mini"),
+    type = "qual",
+    palette = 2
+  ) +
+  scale_shape_manual(
+    limits = c(
+      "Rcpp_grad_mini",
+      "high",
+      "Rcpp_epoch_mini",
+      "Rcpp_epoch",
+      "mini",
+      "Rcpp4",
+      "adam",
+      "adam_decay"
+    ),
+    breaks = c("mini", "Rcpp_grad_mini", "Rcpp_epoch_mini"),
+    values = c(0, 1, 2, 5, 15, 16, 17, 19)
+  )
 ```
 
-Figure \@ref(fig:sg-fig-4) shows that there is virtually no differences 
-in the convergence of the C++ implementations and the pure R implementation.
-The relatively large mini-batch size of 1000 is one reason that the R 
-implementation, which relies on BLAS for the matrix operations, is not slower 
-than the C++ implementations. Exercise \@ref(exr:mini-batch-size) explores 
-the effect of the mini-batch size on the runtime of the algorithm
-in greater detail.
+Figure \@ref(fig:sg-fig-4) shows that there is virtually no differences in the
+convergence of the C++ implementations and the pure R implementation. The
+relatively large mini-batch size of 1000 is one reason that the R
+implementation, which relies on BLAS for the matrix operations, is not slower
+than the C++ implementations. Exercise \@ref(exr:mini-batch-size) explores the
+effect of the mini-batch size on the runtime of the algorithm in greater detail.
 
 ### Full Rcpp implementations {#full-Rcpp}
 
-In this section we convert the entire stochastic gradient algorithm for
-the linear model into a C++ function. Two considerations come up when
-doing so:
+In this section we convert the entire stochastic gradient algorithm for the
+linear model into a C++ function. Two considerations come up when doing so:
 
--   How do we sample with or without replacement in C++?
--   Is it possible in C++ to implement the gradient computations using
-    numerical linear algebra instead of two double for-loops?
+- How do we sample with or without replacement in C++?
+- Is it possible in C++ to implement the gradient computations using numerical
+  linear algebra instead of two double for-loops?
 
-We deal with the first question first, that is, how to sample from a
-finite set of size $d$ in C++ such as `sample()` does in R. Though it
-may seem like a rather trivial problem, it is not entirely trivial to
-implement sampling from a general distribution on a finite set of size
-$d$ that is both correct and efficient as a function of $d$. A
-non-exhaustive list of ways to sample from discrete sets using Rcpp is:
+We deal with the first question first, that is, how to sample from a finite set
+of size $d$ in C++ such as `sample()` does in R. Though it may seem like a
+rather trivial problem, it is not entirely trivial to implement sampling from a
+general distribution on a finite set of size $d$ that is both correct and
+efficient as a function of $d$. A non-exhaustive list of ways to sample from
+discrete sets using Rcpp is:
 
--   The R function `sample()` can be retrieved via
-    `Function sample("sample");` in Rcpp, which makes the function
-    callable from C++ code. There is, however, an overhead associated
-    with calling R functions from C++, which we prefer to avoid.
--   There is an [Rcpp
-    sugar](https://dirk.eddelbuettel.com/code/rcpp/html/sample_8h_source.html)
-    implementation of `sample()`. It generates different values than
-    the R function `sample()`.
--   There is an
-    [RcppArmadilloExtension](https://gallery.rcpp.org/articles/using-the-Rcpp-based-sample-implementation/)
-    implementation of `sample()`. See also the blog post [Sampling
-    Integers](https://barumpark.com/blog/2019/Sampling-Integers/). It
-    requires the R package RcppArmadillo, and it also generates
-    different values than the R function `sample()`.
--   There is the function `dqsample.int()` from the [dqrng
-    package](https://www.daqana.org/dqrng/) dealt with in Section
-    \@ref(rng-packages). It requires the R package dqrng and runs on a
-    stream of pseudo random numbers independent from R's base 
-    random number generator.
+- The R function `sample()` can be retrieved via `Function sample("sample");` in
+  Rcpp, which makes the function callable from C++ code. There is, however, an
+  overhead associated with calling R functions from C++, which we prefer to
+  avoid.
+- There is an [Rcpp
+  sugar](https://dirk.eddelbuettel.com/code/rcpp/html/sample_8h_source.html)
+  implementation of `sample()`. It generates different values than the R
+  function `sample()`.
+- There is an
+  [RcppArmadilloExtension](https://gallery.rcpp.org/articles/using-the-Rcpp-based-sample-implementation/)
+  implementation of `sample()`. See also the blog post [Sampling
+  Integers](https://barumpark.com/blog/2019/Sampling-Integers/). It requires the
+  R package RcppArmadillo, and it also generates different values than the R
+  function `sample()`.
+- There is the function `dqsample.int()` from the [dqrng
+  package](https://www.daqana.org/dqrng/) dealt with in Section
+  \@ref(rng-packages). It requires the R package dqrng and runs on a stream of
+  pseudo random numbers independent from R's base random number generator.
 
-The Rcpp sugar and the Rcpp Armadillo versions of `sample()` are touched
-on in the [Rcpp introduction
+The Rcpp sugar and the Rcpp Armadillo versions of `sample()` are touched on in
+the [Rcpp introduction
 vignette](https://cran.r-project.org/web/packages/Rcpp/vignettes/Rcpp-introduction.pdf),
-but they are not documented in detail. Both use R's stream of pseudo
-random numbers, but they nevertheless generate sequences that differ
-from each other and from `sample()`. To reproduce results in R, we would
-have to write an interface to those C++ functions if we were to use
-them. Since the dqrng package provides an interface to `dqsample.int()`
-from R as well as from C++, we will use that sampler in our
-implementations.
+but they are not documented in detail. Both use R's stream of pseudo random
+numbers, but they nevertheless generate sequences that differ from each other
+and from `sample()`. To reproduce results in R, we would have to write an
+interface to those C++ functions if we were to use them. Since the dqrng package
+provides an interface to `dqsample.int()` from R as well as from C++, we will
+use that sampler in our implementations.
 
 If we only want to generate random permutations, there are a couple of
 additional alternatives. There is `randperm()` from the [Armadillo
-library](http://arma.sourceforge.net/docs.html#randperm), and there is
-also `std::random_shuffle()` from the [C++ Standard
-Library](https://en.cppreference.com/w/cpp/algorithm/random_shuffle).
-The implementation of `std::random_shuffle()` is, however, not specified
-by the standard and can be compiler dependent. Both of these
-alternatives will also run on a stream of pseudo random numbers 
-independent from base R's random number generator, and they will not be 
-considered any further.
+library](http://arma.sourceforge.net/docs.html#randperm), and there is also
+`std::random_shuffle()` from the [C++ Standard
+Library](https://en.cppreference.com/w/cpp/algorithm/random_shuffle). The
+implementation of `std::random_shuffle()` is, however, not specified by the
+standard and can be compiler dependent. Both of these alternatives will also run
+on a stream of pseudo random numbers independent from base R's random number
+generator, and they will not be considered any further.
 
-The full Rcpp implementation of the stochastic gradient algorithm is 
-a simple outer loop over the epochs, and with each epoch consisting of 
-a call of `dqsample_int()` and then a call of `batch_cpp()`. Note that 
-to use our previous `batch_cpp()` implementation, the indices sampled need to 
-be 1-based, which is achieved by setting the offset argument of 
-`dqsample_int()` to 1.
+The full Rcpp implementation of the stochastic gradient algorithm is a simple
+outer loop over the epochs, and with each epoch consisting of a call of
+`dqsample_int()` and then a call of `batch_cpp()`. Note that to use our previous
+`batch_cpp()` implementation, the indices sampled need to be 1-based, which is
+achieved by setting the offset argument of `dqsample_int()` to 1.
 
-```{Rcpp sg-Rcpp, eval=FALSE}
+```{Rcpp}
+//| label: sg-Rcpp
+//| eval: false
+
 // [[Rcpp::depends(dqrng)]]
 // [[Rcpp::export]]
-NumericVector sg_cpp(
-    NumericVector par, 
-    int N, 
-    NumericVector gamma,
-    NumericMatrix X, 
-    NumericVector y,
-    int m = 50, 
-    int maxit = 100
-) {
+NumericVector
+sg_cpp(NumericVector par,
+       int N,
+       NumericVector gamma,
+       NumericMatrix X,
+       NumericVector y,
+       int m = 50,
+       int maxit = 100)
+{
   int p = par.length(), M = floor(N / m);
   NumericVector grad(p), yhat(N), beta = clone(par);
   IntegerVector ii;
-  
-  for(int l = 0; l < maxit; ++l) {
-    // dqsample_int samples from {0, 1, ..., N - 1} by default. Setting 
+
+  for (int l = 0; l < maxit; ++l) {
+    // dqsample_int samples from {0, 1, ..., N - 1} by default. Setting
     // the fifth argument (offset) to 1 gives values from {1, 2, ..., N}.
-    ii = dqrng::dqsample_int(N, N, false, R_NilValue, 1); 
+    ii = dqrng::dqsample_int(N, N, false, R_NilValue, 1);
     beta = batch_cpp(beta, ii, gamma[l], X, y, m);
   }
   return beta;
 }
 ```
 
-We test the implementation by comparing it to the pure R implementation,
-using `dqsample.int()` to sample the same permutations as in C++.
+We test the implementation by comparing it to the pure R implementation, using
+`dqsample.int()` to sample the same permutations as in C++.
 
-```{r test_full_Rcpp, dependson=c("sg-Rcpp", "grad-Rcpp", "ls-grad-update", "LS-model", "sg-mini-batch", "batch"), eval=TRUE}
-dqrng::dqset.seed(10) 
+```{r, dependson=c("sg-Rcpp", "grad-Rcpp", "ls-grad-update", "LS-model", "sg-mini-batch", "batch")}
+#| label: test_full_Rcpp
+#| eval: true
+
+dqrng::dqset.seed(10)
 par_R <- stoch_grad(
-  par = ls_news$par0, 
+  par = ls_news$par0,
   grad = ls_news$grad,
-  N = ls_news$N, 
-  gamma = 1e-3, 
+  N = ls_news$N,
+  gamma = 1e-3,
   maxit = 10,
   sampler = dqrng::dqsample.int
 )
-dqrng::dqset.seed(10) 
+dqrng::dqset.seed(10)
 par_sg_cpp <- sg_cpp(
-  par = ls_news$par0, 
+  par = ls_news$par0,
   N = ls_news$N,
   gamma = rep(1e-3, 10),
-  X = ls_news$X, 
+  X = ls_news$X,
   y = ls_news$y,
   maxit = 10
 )
 range(par_R - par_sg_cpp)
 ```
 
-The two main differences between `stoch_grad()` and `sg_cpp()`
-is that `sg_cpp()` is low level and problem specific, while `stoch_grad()`
-is high level and generic. It is definitely possible to write more generic C++
-code that would allow for different gradient computations for other models. 
-The `grad_cpp()` and `batch_cpp()` functions would then have to be reimplemented
-to support this. We will not pursue this any further. 
+The two main differences between `stoch_grad()` and `sg_cpp()` is that
+`sg_cpp()` is low level and problem specific, while `stoch_grad()` is high level
+and generic. It is definitely possible to write more generic C++ code that would
+allow for different gradient computations for other models. The `grad_cpp()` and
+`batch_cpp()` functions would then have to be reimplemented to support this. We
+will not pursue this any further.
 
-To achieve a more high level implementation, we can use the
-RcppArmadillo package, which provides an interface to numerical linear
-algebra from the C++ library [Armadillo](http://arma.sourceforge.net).
-In this way we can use a matrix-vector style implementation similar to
-the R implementation but without excessive data copying. It is, however,
-necessary to use various data types from the Armadillo library, e.g.
-matrices and column vectors, and it is also necessary to type cast the
-sequence of integers from `dqsample_int()` as a `uvec` data type.
+To achieve a more high level implementation, we can use the RcppArmadillo
+package, which provides an interface to numerical linear algebra from the C++
+library [Armadillo](http://arma.sourceforge.net). In this way we can use a
+matrix-vector style implementation similar to the R implementation but without
+excessive data copying. It is, however, necessary to use various data types from
+the Armadillo library, e.g. matrices and column vectors, and it is also
+necessary to type cast the sequence of integers from `dqsample_int()` as a
+`uvec` data type.
 
-```{Rcpp sg-Armadillo, eval=FALSE}
+```{Rcpp}
+//| label: sg-Armadillo
+//| eval: false
+
 // [[Rcpp::depends(RcppArmadillo)]]
 // [[Rcpp::export]]
-arma::colvec sg_arma(
-    NumericVector par, 
-    int N, 
-    NumericVector gamma,
-    const arma::mat& X, 
-    const arma::colvec& y, 
-    int m = 50, 
-    int maxit = 100
-) {
+arma::colvec
+sg_arma(NumericVector par,
+        int N,
+        NumericVector gamma,
+        const arma::mat& X,
+        const arma::colvec& y,
+        int m = 50,
+        int maxit = 100)
+{
   int p = par.length(), M = floor(N / m);
   arma::colvec grad(p), res(N), yhat(N), beta = clone(par);
   uvec ii, iii;
 
-  for(int l = 0; l < maxit; ++l) {
+  for (int l = 0; l < maxit; ++l) {
     ii = as<arma::uvec>(dqrng::dqsample_int(N, N));
-    for(int j = 0; j < M; ++j) {
+    for (int j = 0; j < M; ++j) {
       iii = ii.subvec(j * m, (j + 1) * m - 1);
       res = X.rows(iii) * beta - y(iii);
-      beta = beta - gamma[l] * (X.rows(iii).t() * res / m); 
+      beta = beta - gamma[l] * (X.rows(iii).t() * res / m);
     }
   }
   return beta;
 }
 ```
 
-The function returns a column vector, which R represents as a
-$p \times 1$ matrix, whereas all the other implementations return a
-vector. But besides this difference, a test will show that `sg_cpp()`
-computes the same updates as all other implementations when
-`dqsample_int()` is used.
+The function returns a column vector, which R represents as a $p \times 1$
+matrix, whereas all the other implementations return a vector. But besides this
+difference, a test will show that `sg_cpp()` computes the same updates as all
+other implementations when `dqsample_int()` is used.
 
-```{r test_Armadillo, dependson=c("sg-Armadillo", "grad-Rcpp", "ls-grad-update", "LS-model", "sg-mini-batch", "batch"), eval = FALSE, echo=FALSE}
-dqrng::dqset.seed(10) 
+```{r, dependson=c("sg-Armadillo", "grad-Rcpp", "ls-grad-update", "LS-model", "sg-mini-batch", "batch")}
+#| label: test_Armadillo
+#| eval: false
+#| echo: false
+
+dqrng::dqset.seed(10)
 par_sg_arma <- sg_arma(
-  par = ls_news$par0, 
+  par = ls_news$par0,
   N = ls_news$N,
   gamma = rep(1e-3, 10),
-  X = ls_news$X, 
+  X = ls_news$X,
   y = ls_news$y,
   maxit = 10
 )
 range(par_R - par_sg_arma)
 ```
 
-We benchmark and compare all five implementations of the mini-batch
-stochastic gradient algorithm by running them for 10 epoch iterations
-with a fixed learning rate of $\gamma = 10^{-4}$ and the default
-mini-batch size $m = 50$. 
+We benchmark and compare all five implementations of the mini-batch stochastic
+gradient algorithm by running them for 10 epochs with a fixed learning rate of
+$\gamma = 10^{-4}$ and the default mini-batch size $m = 50$.
 
-```{r mark-sg-batch, warning=FALSE, dependson=c("sg-Armadillo", "sg-Rcpp", "epoch-Rcpp", "grad-Rcpp", "ls-grad-update", "LS-model", "sg-mini-batch", "batch")}
+```{r, dependson=c("sg-Armadillo", "sg-Rcpp", "epoch-Rcpp", "grad-Rcpp", "ls-grad-update", "LS-model", "sg-mini-batch", "batch")}
+#| label: mark-sg-batch
+#| warning: false
+
 sg_bench <- function(sg = stoch_grad, ...) {
-    sg(
-      par = ls_news$par0,
-      N = ls_news$N,
-      gamma = rep(1e-4, 10),
-      X = ls_news$X, 
-      y = ls_news$y,
-      ...,
-      maxit = 10 
-    )
+  sg(
+    par = ls_news$par0,
+    N = ls_news$N,
+    gamma = rep(1e-4, 10),
+    X = ls_news$X,
+    y = ls_news$y,
+    ...,
+    maxit = 10
+  )
 }
 bench::mark(
   sg = sg_bench(grad = ls_news$grad),
   grad_cpp = sg_bench(grad = grad_cpp),
   batch_cpp = sg_bench(epoch = batch_cpp),
-  sg_cpp =  sg_bench(sg_cpp),
-  sg_arma = sg_bench(sg_arma), 
-  check = FALSE, iterations = 5
+  sg_cpp = sg_bench(sg_cpp),
+  sg_arma = sg_bench(sg_arma),
+  check = FALSE,
+  iterations = 5
 )
 ```
 
-The pure R implementation (`sg`) and the three different Rcpp-based implementations 
-(`grad_cpp`, `batch_cpp` and `sg_cpp`) have about the same runtime. The 
-pure R implementation uses by far the most memory though.
-The Armadillo based implementation is about twice as fast and also more memory efficient 
-than either of the other implementations. 
+The pure R implementation (`sg`) and the three different Rcpp-based
+implementations (`grad_cpp`, `batch_cpp` and `sg_cpp`) have about the same
+runtime. The pure R implementation uses by far the most memory though. The
+Armadillo based implementation is about twice as fast and also more memory
+efficient than either of the other implementations.
 
-We rerun all algorithms, but this time with the mini-batch size $m = 1$.
-Because `stoch_grad()` allocates a lot of memory, the default memory tracking of
-`mark()` will become prohibitively slow, thus memory tracking is
-disabled.
+We rerun all algorithms, but this time with the mini-batch size $m = 1$. Because
+`stoch_grad()` allocates a lot of memory, the default memory tracking of
+`mark()` will become prohibitively slow, thus memory tracking is disabled.
 
-```{r mark-sg-basic, warning=FALSE, dependson=c("sg-Armadillo", "sg-Rcpp", "epoch-Rcpp", "grad-Rcpp", "ls-grad-update", "LS-model", "sg-mini-batch", "batch")}
+```{r, dependson=c("sg-Armadillo", "sg-Rcpp", "epoch-Rcpp", "grad-Rcpp", "ls-grad-update", "LS-model", "sg-mini-batch", "batch")}
+#| label: mark-sg-basic
+#| warning: false
+
 bench::mark(
   sg = sg_bench(grad = ls_news$grad, m = 1),
   grad_cpp = sg_bench(grad = grad_cpp, m = 1),
   batch_cpp = sg_bench(epoch = batch_cpp, m = 1),
-  sg_cpp =  sg_bench(sg_cpp, m = 1),
-  sg_arma = sg_bench(sg_arma, m = 1), 
-  check = FALSE, memory = FALSE, iterations = 5
+  sg_cpp = sg_bench(sg_cpp, m = 1),
+  sg_arma = sg_bench(sg_arma, m = 1),
+  check = FALSE,
+  memory = FALSE,
+  iterations = 5
 )
 ```
 
-This reveals some bigger differences. When changing the mini-batch size 
-from 50 to 1, the runtime of `stoch_grad()` increases by roughly a factor 
-10. The runtimes of the other implementations also increase, but not as much,
-and the Armadillo based implementation is still the fastest, and now by a 
-factor 3-4 compared to the full Rcpp implementation. 
+This reveals some bigger differences. When changing the mini-batch size from 50
+to 1, the runtime of `stoch_grad()` increases by roughly a factor 10. The
+runtimes of the other implementations also increase, but not as much, and the
+Armadillo-based implementation is still the fastest, and now by a factor 3-4
+compared to the full Rcpp implementation.
 
-Beware that the above benchmark results and conclusions are for the 
-specific implementations on a machine with a specific configuration. 
-We should thus be cautious and not draw general conclusions from 
-these specific results, see also Section \@ref(perils).
+Be aware that the above benchmark results and conclusions are for the specific
+implementations on a machine with a specific configuration. We should thus be
+cautious and not draw general conclusions from these specific results, see also
+Section\ \@ref(perils).
 
 ## Exercises {#stochopt:ex}
 
@@ -2121,7 +2925,7 @@ Consider the loss
 for a model, $\mu(x, \theta)$, of the conditional mean, $\E(Y \mid X = x)$, of
 $Y$ given $X = x$. See also Example \@ref(exm:log-likelihood).
 
-Show that the function 
+Show that the function
 
 \[
   a \mapsto a - b \log(a)
@@ -2135,58 +2939,54 @@ Then show the lower bound on the risk
   H(\theta) = \E(L(Y, X, \theta)) \geq \E\Big( \E(Y \mid X)  - \E(Y \mid X) \log (\E(Y \mid X))\Big),
 \]
 
-and conclude that if $\E(Y \mid X = x) = \mu(x, \theta_0)$ for some
-$\theta_0$, then $\theta_0$ is a global minimizer of the risk.
+and conclude that if $\E(Y \mid X = x) = \mu(x, \theta_0)$ for some $\theta_0$,
+then $\theta_0$ is a global minimizer of the risk.
 :::
 
 ::: {#gauss-log-normal .exercise}
-Consider the same online setup as in Example \@ref(exm:online-pois-sg)
-but with
+Consider the same online setup as in Example \@ref(exm:online-pois-sg) but with
 
 \[
   Y_i \mid X_i = x_i \sim \mathcal{N}(e^{\beta_0 + \beta_1 x_i}, 5)
 \]
 
-instead. That is, the conditional mean value model is still log-linear,
-but the distribution is Gaussian instead of Poisson.
+instead. That is, the conditional mean value model is still log-linear, but the
+distribution is Gaussian instead of Poisson.
 
-Replicate the online learning simulation as in Example
-\@ref(exm:online-pois-sg) using the Poisson log-likelihood gradient and
-the squared error gradient. You may want to experiment with different
-learning rates. How does the change of the distribution affect the
-convergence of the algorithms?
+Replicate the online learning simulation as in Example \@ref(exm:online-pois-sg)
+using the Poisson log-likelihood gradient and the squared error gradient. You
+may want to experiment with different learning rates. How does the change of the
+distribution affect the convergence of the algorithms?
 :::
 
 ::: {#news-cond-number .exercise}
-Show that for the linear model and the squared error loss, the hessian
-of the objective function is 
+Show that for the linear model and the squared error loss, the hessian of the
+objective function is
 
 \[
-  D^2 H_N(\beta) = X^T X
+  D^2 H_N(\beta) = X^\top X
 \]
 
-where $X$ is the model matrix. Compute the eigenvalues of this matrix using the news data
-from Section \@ref(news) before and after standardization. What are the
-conditioning numbers of the matrices, and how do their values relate to
-convergence of gradient based methods? See also Section
-\@ref(grad-descent).
+where $X$ is the model matrix. Compute the eigenvalues of this matrix using the
+news data from Section \@ref(news) before and after standardization. What are
+the conditioning numbers of the matrices, and how do their values relate to
+convergence of gradient based methods? See also Section \@ref(grad-descent).
 :::
 
-
 ::: {#grad-transpose .exercise}
-Rewrite the function `ls_model()` so that it stores the transposed 
-model matrix instead of the model matrix, and so that the gradient 
-computations are done by slicing out columns of the transposed model matrix.
-Benchmark the new mini-batch gradient computations against the old ones for 
-different values of the mini-batch size $m$.
+Rewrite the function `ls_model()` so that it stores the transposed model matrix
+instead of the model matrix, and so that the gradient computations are done by
+slicing out columns of the transposed model matrix. Benchmark the new mini-batch
+gradient computations against the old ones for different values of the
+mini-batch size $m$.
 :::
 
 ::: {#mini-batch-size .exercise}
-Make sure that you have a working implementation of the mini-batch
-stochastic gradient algorithm for the news data from Section \@ref(news)
-with the `batch_cpp()` Rcpp implementation of the epoch updates. Set up
-an experiment where you run the algorithm over a grid of mini-batch
-sizes and learning rates. Run the algorithm until the absolute deviation
-from the minimum of the empirical squared error loss is less than 0.01
-and determine the optimal choice of the tuning parameters.
+Make sure that you have a working implementation of the mini-batch stochastic
+gradient algorithm for the news data from Section \@ref(news) with the
+`batch_cpp()` Rcpp implementation of the epoch updates. Set up an experiment
+where you run the algorithm over a grid of mini-batch sizes and learning rates.
+Run the algorithm until the absolute deviation from the minimum of the empirical
+squared error loss is less than 0.01 and determine the optimal choice of the
+tuning parameters.
 :::

--- a/32-R.Rmd
+++ b/32-R.Rmd
@@ -685,7 +685,7 @@ to the guide, curly braces should always be used when the function spans
 multiple lines, and `return()` should only be used for early returns---not when
 the function returns the last evaluated expression in the body. Whether we
 should break (complicated) expressions into simpler pieces, as in
-`gauss_step()`, is a judgment call, but see Section \@ref(performance) for how
+`gauss_step()`, is a judgment call, but see Section \@ref(measuring-performance) for how
 such a decision affects the results from line profiling.
 
 Larger pieces of software---such as an entire R package---should include a

--- a/CSwR.bib
+++ b/CSwR.bib
@@ -41,6 +41,18 @@
   pagetotal     = {381}
 }
 
+@book{Nash:2014,
+  title         = {Nonlinear Parameter Optimization Using {{R}} Tools},
+  author        = {Nash, John C.},
+  location      = {Chichester, West Sussex},
+  publisher     = {Wiley},
+  isbn          = {978-1-118-56928-3},
+  date          = {2014-05-27},
+  edition       = {1 edition},
+  langid        = {english},
+  pagetotal     = {304}
+}
+
 @article{Robbins:1951,
   title         = {A Stochastic Approximation Method},
   author        = {Robbins, Herbert and Monro, Sutton},
@@ -232,6 +244,14 @@
   year          = {2003},
   publisher     = {Cambridge University Press},
   series        = {Cambridge Series in Statistical and Probabilistic Mathematics}
+}
+
+@book{Boyd:2004,
+  title         = {Convex Optimization},
+  author        = {Boyd, Stephen and Vandenberghe, Lieven},
+  year          = {2004},
+  publisher     = {Cambridge University Press},
+  address       = {Cambridge, UK}
 }
 
 @article{Vinther:2006,

--- a/CSwR_extra.R
+++ b/CSwR_extra.R
@@ -7,3 +7,39 @@ benchTab <- function(x, ...) {
 
 # Set default ggplot2 theme
 ggplot2::theme_set(ggplot2::theme_bw())
+
+# Minimal theme for schematic/pedagogical plots: axis titles only,
+# no grid, no ticks, no panel border. Axis lines on by default.
+theme_schematic <- function(base_size = 11, base_family = "", axis_lines = TRUE) {
+  th <- ggplot2::theme_void(base_size = base_size, base_family = base_family) +
+    ggplot2::theme(
+      axis.title.x = ggplot2::element_text(margin = ggplot2::margin(t = 4)),
+      axis.title.y = ggplot2::element_text(angle = 90, margin = ggplot2::margin(r = 4)),
+      plot.background = ggplot2::element_rect(fill = NA, color = NA)
+    )
+  if (axis_lines) {
+    th <- th + ggplot2::theme(
+      axis.line = ggplot2::element_line(colour = "black", linewidth = 0.3)
+    )
+  }
+  th
+}
+
+# Knitr engine for pseudocode blocks.
+# Body is algorithmicx-flavoured LaTeX (\begin{algorithm} ... \begin{algorithmic} ...).
+# HTML output is rendered client-side by pseudocode.js;
+# LaTeX output uses the algorithm + algpseudocode packages.
+knitr::knit_engines$set(algorithm = function(options) {
+  code <- paste(options$code, collapse = "\n")
+  if (knitr::is_html_output()) {
+    paste0(
+      "```{=html}\n<pre class=\"pseudocode\">\n",
+      code,
+      "\n</pre>\n```"
+    )
+  } else if (knitr::is_latex_output()) {
+    paste0("```{=latex}\n", code, "\n```")
+  } else {
+    code
+  }
+})

--- a/Conventions.md
+++ b/Conventions.md
@@ -113,7 +113,8 @@ Uses roxygen2 for documentation.
 - $n$ and `n` denote iteration index/number or other integer variables/arguments
 - $i$, $j$, $k$, $l$ are data/parameter indices
 - $x$ and $X$ are (univariate) data variables: Chapters 1, 2, 5, 6, 7,
-- $y$ and $Y$ are (univariate) data variables, used when there is a need for $x$:
+- $y$ and $Y$ are (univariate) data variables, used when there is a need for
+  $x$:
   - Chapters 3 (bivariate data), 4 ($x$ is time)
   - Chapters 8 and 9 (regression on $x$)
   - Chapter 10 ($x$ is unobserved, $y = M(x)$ is observed; potentially
@@ -127,6 +128,7 @@ Uses roxygen2 for documentation.
 - Use \P, \E, \V, \cov for probability, expectation, variance and covariance.
   These are defined for pdf in latex/preamble.tex, and for HTML in
   mathjax_header.html
+- Use $\top$ for transpose.
 
 ### Terminology and grammar
 

--- a/TODO.md
+++ b/TODO.md
@@ -17,7 +17,7 @@
       - [x] One or two more in Rejection Sampling chapter
       - [ ] One or two more in MC chapter
       - [ ] Add exercises for Time Series Smoothing chapter
-      - [ ] Add exercises for Likelihood Optimization chapter
+      - [ ] Add exercises for Optimization and statistical estimation chapter
       - [ ] Add exercises for Numerical Optimization chapter
       - [ ] Add exercises for EM chapter
       - [ ] Add exercises for Stochastic EM chapter

--- a/latex/preamble.tex
+++ b/latex/preamble.tex
@@ -43,6 +43,9 @@
 
 \usepackage{amsthm}
 %\usepackage{amsmath}
+
+\usepackage{algorithm}
+\usepackage{algpseudocode}
 \makeatletter
 \def\thm@space@setup{%
   \thm@preskip=8pt plus 2pt minus 4pt

--- a/mathjax_header.html
+++ b/mathjax_header.html
@@ -6,3 +6,17 @@
 \(\newcommand{\cov}{\mathbf{Cov}}\)
 \(\newcommand{\P}{\mathbf{P}}\)
 </span>
+
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/pseudocode@2.4.1/build/pseudocode.min.css">
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/pseudocode@2.4.1/build/pseudocode.min.js"></script>
+<script>
+  window.addEventListener("load", function() {
+    if (typeof pseudocode !== "undefined") {
+      pseudocode.renderClass("pseudocode", { lineNumber: true });
+    } else {
+      console.error("pseudocode.js failed to load");
+    }
+  });
+</script>


### PR DESCRIPTION
This PR is a rewrite of the optimization part of the book. It uses a different approach, starting with basics of optimizatin, convexity, optimaity conditions, and also adds a part about constrained optimization to be able to tackle the Peppered moths example more meaningfully (without resorting to recoding the objective). I also let the Newton algorithm get its own section and take up more space, since I think it's very pedagogical on the computational side.

The edits mostly affect the old optimization and likelihood chapter and the numerical optimization chapter. It also has some slight impact on the EM chapter. 

It's still missing useful figures for many examples and especially the numerical optimization chapter needs a bit more work to become more pedagogical.